### PR TITLE
docs: update gogpu version to v0.4.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ naga/
 
 | Project | Description | Status |
 |---------|-------------|--------|
-| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Pure Go graphics framework | v0.3.0 |
+| [gogpu/gogpu](https://github.com/gogpu/gogpu) | Pure Go graphics framework | **v0.4.0** |
 | [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU types and HAL | **v0.5.0** |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics with GPU backend, scene graph, SIMD | **v0.9.2** |
 | [go-webgpu/webgpu](https://github.com/go-webgpu/webgpu) | WebGPU FFI bindings | Stable |


### PR DESCRIPTION
Update ecosystem table to reflect gogpu v0.4.0 release (Linux Wayland platform).