### PR TITLE
fix(wgsl): add missing clamp built-in function

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.8.1] - 2025-12-29
+
+### Fixed
+
+#### WGSL Lowering
+- **clamp() built-in function** — Added missing `clamp` to math function map
+  - Root cause: `getMathFunction()` was missing `clamp` → `ir.MathClamp` mapping
+  - Caused "unknown function: clamp" error during shader compilation
+  - Affected any WGSL shader using `clamp(value, min, max)`
+
+### Added
+- **Comprehensive math function tests** — `TestMathFunctions` covering all 12 WGSL built-in math functions
+  - Tests: abs, min, max, clamp, sin, cos, tan, sqrt, length, normalize, dot, cross
+  - Verifies correct IR generation for each function
+
 ## [0.8.0] - 2025-12-28
 
 Code quality improvements and SPIR-V backend bug fixes.

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -135,6 +135,16 @@ Complete WGSL to SPIR-V compilation pipeline (~10K LOC).
 
 ---
 
+## Released: v0.8.1 ✅
+
+**Focus:** WGSL built-in function completeness
+
+### Completed
+- [x] **clamp() built-in** — Added missing `clamp` to WGSL math function map
+- [x] **Math function tests** — Comprehensive coverage for all 12 built-in math functions
+
+---
+
 ## Goal: v1.0.0
 
 **Focus:** Production ready

--- a/wgsl/lower.go
+++ b/wgsl/lower.go
@@ -1048,6 +1048,7 @@ func (l *Lowerer) getMathFunction(name string) (ir.MathFunction, bool) {
 		"abs":       ir.MathAbs,
 		"min":       ir.MathMin,
 		"max":       ir.MathMax,
+		"clamp":     ir.MathClamp,
 		"sin":       ir.MathSin,
 		"cos":       ir.MathCos,
 		"tan":       ir.MathTan,


### PR DESCRIPTION
## Summary

- Added missing `clamp` to WGSL math function map in `getMathFunction()`
- Root cause: `clamp` was missing from `mathFuncs` map, causing "unknown function: clamp" errors
- Added comprehensive `TestMathFunctions` covering all 12 WGSL built-in math functions

## Test Plan

- [x] `go test ./wgsl/...` - all tests pass including new `TestMathFunctions`
- [x] Pre-release script passes
- [x] All 12 math function subtests pass: abs, min, max, clamp, sin, cos, tan, sqrt, length, normalize, dot, cross

## Impact

This is a **bug fix** that was causing gg GPU compute shaders to fail compilation.