### PR TITLE
fix(spirv): fix OpLogicalAnd, var init, runtime arrays for compute shaders

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@
 - **MSL Backend** — Metal Shading Language output for macOS/iOS
 - **GLSL Backend** — OpenGL Shading Language for OpenGL 3.3+, ES 3.0+
 - **HLSL Backend** — High-Level Shading Language for DirectX 11/12
+- **Type Conversions** — Scalar constructors `f32(x)`, `u32(y)`, `i32(z)` with correct SPIR-V opcodes
 - **Warnings** — Unused variable detection with `_` prefix exception
 - **Validation** — Type checking and semantic validation
 - **CLI Tool** — `nagac` command-line compiler
@@ -240,7 +241,7 @@ naga/
 - Scalars: `f32`, `f64`, `i32`, `u32`, `bool`
 - Vectors: `vec2<T>`, `vec3<T>`, `vec4<T>`
 - Matrices: `mat2x2<f32>` ... `mat4x4<f32>`
-- Arrays: `array<T, N>`
+- Arrays: `array<T, N>`, `array<T>` (runtime-sized, storage buffers)
 - Structs: `struct { ... }`
 - Atomics: `atomic<u32>`, `atomic<i32>`
 - Textures: `texture_2d<f32>`, `texture_3d<f32>`, `texture_cube<f32>`

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,18 +19,18 @@
 
 ---
 
-## Current State: v0.11.0
+## Current State: v0.11.1
 
 ✅ **Production-ready** shader compiler (~19K LOC):
 - Full WGSL frontend (lexer, parser, IR)
 - 4 backend outputs (SPIR-V, MSL, GLSL, HLSL)
 - 90+ WGSL built-in functions (math, geometric, bit manipulation, packing)
-- Compute shaders (atomics, barriers, workgroups)
+- Compute shaders (atomics, barriers, workgroups, runtime-sized storage buffers)
 - Texture sampling and storage textures (50+ formats)
 - Local const declarations and switch statements
 - Correct SPIR-V structured control flow (`if/else`, `switch`, `loop`)
-- Type inference and validation
-- Development tools (nagac, spvdis)
+- Type inference, validation, and scalar type conversions
+- Development tools (nagac with SPIR-V 1.3, spvdis)
 
 ---
 
@@ -96,7 +96,8 @@
 
 | Version | Date | Highlights |
 |---------|------|------------|
-| **v0.11.0** | 2026-02 | SPIR-V if/else fix, 55 new built-in functions |
+| **v0.11.1** | 2026-02 | SPIR-V opcode fixes, compute shader improvements |
+| v0.11.0 | 2026-02 | SPIR-V if/else fix, 55 new built-in functions |
 | v0.10.0 | 2026-02 | Local const, switch statements, storage textures |
 | v0.9.0 | 2026-01 | Sampler types, swizzle, dev tools |
 | v0.8.x | 2026-01 | SPIR-V Intel fixes, MSL [[position]] fix |

--- a/cmd/nagac/main.go
+++ b/cmd/nagac/main.go
@@ -18,6 +18,7 @@ import (
 	"runtime/debug"
 
 	"github.com/gogpu/naga"
+	"github.com/gogpu/naga/spirv"
 )
 
 var (
@@ -64,8 +65,9 @@ func main() {
 
 	// Compile WGSL to SPIR-V
 	opts := naga.CompileOptions{
-		Debug:    *debugFlag,
-		Validate: *validate,
+		SPIRVVersion: spirv.Version1_3,
+		Debug:        *debugFlag,
+		Validate:     *validate,
 	}
 	spirvBytes, err := naga.CompileWithOptions(string(source), opts)
 	if err != nil {

--- a/spirv/spirv.go
+++ b/spirv/spirv.go
@@ -107,6 +107,7 @@ const (
 	OpTypeVector        OpCode = 23
 	OpTypeMatrix        OpCode = 24
 	OpTypeArray         OpCode = 28
+	OpTypeRuntimeArray  OpCode = 29
 	OpTypeStruct        OpCode = 30
 	OpTypePointer       OpCode = 32
 	OpTypeFunction      OpCode = 33
@@ -327,8 +328,8 @@ const (
 	OpFOrdEqual            OpCode = 180 // Float ordered equal
 	OpFOrdNotEqual         OpCode = 182 // Float ordered not equal
 	OpFOrdLessThan         OpCode = 184 // Float ordered less than
-	OpFOrdLessThanEqual    OpCode = 186 // Float ordered less than or equal
-	OpFOrdGreaterThan      OpCode = 188 // Float ordered greater than
+	OpFOrdGreaterThan      OpCode = 186 // Float ordered greater than
+	OpFOrdLessThanEqual    OpCode = 188 // Float ordered less than or equal
 	OpFOrdGreaterThanEqual OpCode = 190 // Float ordered greater than or equal
 	OpIEqual               OpCode = 170 // Integer equal
 	OpINotEqual            OpCode = 171 // Integer not equal
@@ -344,11 +345,13 @@ const (
 
 // Logical opcodes
 const (
-	OpLogicalNot OpCode = 168 // Logical not
-	OpLogicalAnd OpCode = 164 // Logical and
-	OpLogicalOr  OpCode = 166 // Logical or
-	OpSelect     OpCode = 169 // Select between values
-	OpNot        OpCode = 200 // Bitwise not
+	OpLogicalEqual    OpCode = 164 // Logical equal
+	OpLogicalNotEqual OpCode = 165 // Logical not equal
+	OpLogicalOr       OpCode = 166 // Logical or
+	OpLogicalAnd      OpCode = 167 // Logical and
+	OpLogicalNot      OpCode = 168 // Logical not
+	OpSelect          OpCode = 169 // Select between values
+	OpNot             OpCode = 200 // Bitwise not
 )
 
 // Composite opcodes
@@ -361,9 +364,9 @@ const (
 
 // Bitwise opcodes
 const (
-	OpShiftLeftLogical     OpCode = 194 // Shift left logical
-	OpShiftRightLogical    OpCode = 195 // Shift right logical
-	OpShiftRightArithmetic OpCode = 196 // Shift right arithmetic
+	OpShiftRightLogical    OpCode = 194 // Shift right logical
+	OpShiftRightArithmetic OpCode = 195 // Shift right arithmetic
+	OpShiftLeftLogical     OpCode = 196 // Shift left logical
 	OpBitwiseOr            OpCode = 197 // Bitwise OR
 	OpBitwiseXor           OpCode = 198 // Bitwise XOR
 	OpBitwiseAnd           OpCode = 199 // Bitwise AND
@@ -389,6 +392,15 @@ const (
 	OpDPdxCoarse   OpCode = 213 // Coarse derivative in X
 	OpDPdyCoarse   OpCode = 214 // Coarse derivative in Y
 	OpFwidthCoarse OpCode = 215 // Coarse fwidth
+)
+
+// Conversion opcodes
+const (
+	OpConvertFToU OpCode = 109 // Float to unsigned int
+	OpConvertFToS OpCode = 110 // Float to signed int
+	OpConvertSToF OpCode = 111 // Signed int to float
+	OpConvertUToF OpCode = 112 // Unsigned int to float
+	OpBitcast     OpCode = 124 // Bitcast between types of same width
 )
 
 // Extended instruction set opcodes

--- a/spirv/writer.go
+++ b/spirv/writer.go
@@ -313,6 +313,16 @@ func (b *ModuleBuilder) AddTypeArray(elementType uint32, length uint32) uint32 {
 	return id
 }
 
+// AddTypeRuntimeArray adds OpTypeRuntimeArray for storage buffer runtime-sized arrays.
+func (b *ModuleBuilder) AddTypeRuntimeArray(elementType uint32) uint32 {
+	id := b.AllocID()
+	builder := NewInstructionBuilder()
+	builder.AddWord(id)
+	builder.AddWord(elementType)
+	b.types = append(b.types, builder.Build(OpTypeRuntimeArray))
+	return id
+}
+
 // AddTypePointer adds OpTypePointer.
 func (b *ModuleBuilder) AddTypePointer(storageClass StorageClass, baseType uint32) uint32 {
 	id := b.AllocID()

--- a/wgsl/deduplication_test.go
+++ b/wgsl/deduplication_test.go
@@ -45,15 +45,15 @@ func TestTypeDeduplication(t *testing.T) {
 	typeCount := len(module.Types)
 
 	// Expected types:
-	// Built-ins: f32, f16, i32, u32, bool (5 types)
-	// Note: samplers are NOT pre-registered (only created on-demand when used)
+	// Built-ins: f32, i32, u32, bool (4 types)
+	// Note: f16 and samplers are NOT pre-registered (only created on-demand when used)
 	// User types:
 	// 1. vec4<f32> (vector) - deduplicated, should appear only once
 	// 2. Vertex (struct)
-	// Total: 7 unique types
+	// Total: 6 unique types
 
-	if typeCount != 7 {
-		t.Errorf("Expected 7 unique types, got %d", typeCount)
+	if typeCount != 6 {
+		t.Errorf("Expected 6 unique types, got %d", typeCount)
 		for i, typ := range module.Types {
 			t.Logf("Type %d: %s (%T)", i, typ.Name, typ.Inner)
 		}
@@ -102,16 +102,16 @@ func TestTypeDeduplicationMultipleStructs(t *testing.T) {
 	}
 
 	// Expected types:
-	// Built-ins: f32, f16, i32, u32, bool (5 types)
-	// Note: samplers are NOT pre-registered (only created on-demand when used)
+	// Built-ins: f32, i32, u32, bool (4 types)
+	// Note: f16 and samplers are NOT pre-registered (only created on-demand when used)
 	// User types:
 	// 1. vec4<f32> (vector) - used in both structs but deduplicated
 	// 2. A (struct)
 	// 3. B (struct)
-	// Total: 8 unique types
+	// Total: 7 unique types
 
-	if len(module.Types) != 8 {
-		t.Errorf("Expected 8 unique types, got %d", len(module.Types))
+	if len(module.Types) != 7 {
+		t.Errorf("Expected 7 unique types, got %d", len(module.Types))
 		for i, typ := range module.Types {
 			t.Logf("Type %d: %s (%T)", i, typ.Name, typ.Inner)
 		}


### PR DESCRIPTION
## Summary

Critical SPIR-V opcode corrections and compute shader fixes discovered during GPU SDF accelerator development in gogpu.

### SPIR-V Opcode Fixes
- **`OpLogicalAnd`**: was 164 (`OpLogicalEqual`), corrected to 167 — WGSL `&&` compiled to boolean equality instead of logical AND
- **Comparison opcodes**: `OpFOrdGreaterThan` (186) and `OpFOrdLessThanEqual` (188) were swapped
- **Shift opcodes**: `OpShiftLeftLogical`, `OpShiftRightLogical`, `OpShiftRightArithmetic` had rotated values

### Code Generation Fixes
- **Local variable initializers**: `var x: f32 = 0.0` now emits `OpStore` — previously `LocalVariable.Init` was ignored
- **Runtime-sized arrays**: `OpTypeRuntimeArray` for storage buffer `array<T>` (was returning error)
- **Type conversions**: `f32(x)`, `u32(y)` generate correct conversion opcodes instead of compose
- **Entry point interface**: only Input/Output variables per SPIR-V 1.3
- **Unsigned literals**: `1u` suffix correctly parsed as `u32`
- **`f16` pre-registration**: removed to avoid `OpCapability Float16` on non-supporting devices

### Impact
All 7 fixes were discovered through end-to-end GPU compute shader testing (SDF circle/rect rendering on Vulkan). Without these fixes, compute shaders produce incorrect visual output or fail validation.

## Test plan
- [x] `go test ./...` — all packages pass
- [x] `go build ./...` — clean build
- [x] Verified end-to-end: WGSL SDF shaders compile to valid SPIR-V, render correctly on Vulkan
- [ ] CI
