### PR TITLE
ci: upgrade codecov-action v4 → v5

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,12 +36,15 @@ jobs:
         shell: bash
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
-      - name: Upload coverage
-        uses: codecov/codecov-action@v4
+      - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
+        uses: codecov/codecov-action@v5
         with:
+          token: ${{ secrets.CODECOV_TOKEN }}
           files: ./coverage.txt
-          fail_ci_if_error: false
+          flags: unittests
+          name: codecov-naga
+          fail_ci_if_error: true
 
   lint:
     name: Lint

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,6 +36,10 @@ jobs:
         shell: bash
         run: go test -v -race -coverprofile=coverage.txt -covermode=atomic ./...
 
+      - name: Verify coverage file
+        if: matrix.os == 'ubuntu-latest'
+        run: ls -la coverage.txt && echo "$(wc -l < coverage.txt) lines"
+
       - name: Upload coverage to Codecov
         if: matrix.os == 'ubuntu-latest'
         uses: codecov/codecov-action@v5


### PR DESCRIPTION
## Summary

- Upgrade `codecov/codecov-action` from v4 to v5
- Enable `fail_ci_if_error: true` to surface upload failures in CI
- Use `files:` parameter (v5 syntax, replaces `file:`)

Coverage uploads were silently failing with v4 (exit code 1 masked by `fail_ci_if_error: false`), resulting in "unknown" badges on all repos.

## Test plan

- [ ] CI passes with v5 action
- [ ] Codecov upload step succeeds (not just "skipped")
- [ ] Coverage badge updates from "unknown" to actual percentage
