### PR TITLE
fix(hlsl): revert direct sampler kostyl, restore heap pattern (v0.15.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- **HLSL: direct sampler register binding mode** — When `BindingMap` has explicit
-  entries and `SamplerBufferBindingMap` is nil, emit direct `SamplerState name :
-  register(sN, spaceG)` instead of sampler heap indirection. Fixes DX12 text/texture
-  invisibility in gogpu/wgpu. Backward compatible — heap mode unchanged when
-  `SamplerBufferBindingMap` is provided.
+- **HLSL: revert direct sampler register binding mode** — Samplers always use the
+  sampler heap indirection pattern (`nagaSamplerHeap[indexBuffer[N]]`), matching
+  Rust wgpu-hal architecture. The DX12 HAL now properly implements the global
+  sampler heap with per-bind-group sampler index buffers and provides
+  `SamplerBufferBindingMap` to naga during shader compilation.
 
 ## [0.15.0] - 2026-03-30
 

--- a/hlsl/hlsl_e2e_test.go
+++ b/hlsl/hlsl_e2e_test.go
@@ -8,6 +8,7 @@ import (
 	"testing"
 
 	"github.com/gogpu/naga/hlsl"
+	"github.com/gogpu/naga/ir"
 	"github.com/gogpu/naga/wgsl"
 )
 
@@ -859,7 +860,7 @@ fn main(@location(0) pos: vec3<f32>) -> @builtin(position) vec4<f32> {
 }
 
 // =============================================================================
-// Sampler Direct Register Binding — verifies DX12 HAL compatibility
+// Sampler Heap Indirection — verifies sampler heap pattern matching Rust wgpu-hal
 // =============================================================================
 
 // compileWGSLToHLSLWithOpts compiles WGSL source to HLSL with custom options.
@@ -891,11 +892,11 @@ func compileWGSLToHLSLWithOpts(t *testing.T, source string, opts *hlsl.Options) 
 	return code
 }
 
-// TestE2E_SamplerDirectRegisterBinding verifies that when BindingMap has explicit
-// entries and SamplerBufferBindingMap is nil, samplers use direct register binding
-// instead of the sampler heap indirection pattern. This matches the DX12 HAL's
-// per-group sampler descriptor table layout.
-func TestE2E_SamplerDirectRegisterBinding(t *testing.T) {
+// TestE2E_SamplerHeapIndirection verifies that samplers always use the sampler
+// heap indirection pattern (nagaSamplerHeap[indexBuffer[N]]), matching Rust
+// wgpu-hal architecture. The DX12 HAL provides SamplerBufferBindingMap to
+// specify where each group's sampler index buffer is bound.
+func TestE2E_SamplerHeapIndirection(t *testing.T) {
 	// WGSL shader with a texture and sampler (typical MSDF text shader pattern).
 	source := `
 @group(0) @binding(0)
@@ -929,12 +930,27 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 		t.Fatalf("Lower failed: %v", err)
 	}
 
-	// Build BindingMap from global variables (same logic as DX12 HAL).
+	// Build BindingMap from global variables — samplers get space=255
+	// and register=index_within_group, matching Rust wgpu-hal.
 	bindingMap := make(map[hlsl.ResourceBinding]hlsl.BindTarget)
+	var samplerIdx uint32
 	for i := range module.GlobalVariables {
 		gv := &module.GlobalVariables[i]
 		if gv.Binding == nil {
 			continue
+		}
+		if int(gv.Type) < len(module.Types) {
+			if _, isSampler := module.Types[gv.Type].Inner.(ir.SamplerType); isSampler {
+				bindingMap[hlsl.ResourceBinding{
+					Group:   gv.Binding.Group,
+					Binding: gv.Binding.Binding,
+				}] = hlsl.BindTarget{
+					Space:    255,
+					Register: samplerIdx,
+				}
+				samplerIdx++
+				continue
+			}
 		}
 		bindingMap[hlsl.ResourceBinding{
 			Group:   gv.Binding.Group,
@@ -945,31 +961,12 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 		}
 	}
 
-	t.Run("direct_binding_no_sampler_buffer_map", func(t *testing.T) {
-		opts := hlsl.DefaultOptions()
-		opts.BindingMap = bindingMap
-		opts.FakeMissingBindings = false
-		opts.SamplerBufferBindingMap = nil // No sampler buffer → direct binding
-
-		code := compileWGSLToHLSLWithOpts(t, source, opts)
-		t.Logf("HLSL output (direct binding):\n%s", code)
-
-		// Sampler should use direct register binding (space 0 is implicit in HLSL).
-		assertContains(t, code, "register(s2)")
-		// Should NOT contain sampler heap infrastructure.
-		assertNotContains(t, code, "nagaSamplerHeap")
-		assertNotContains(t, code, "SamplerIndexArray")
-		// Texture and CBV should still have direct register bindings.
-		assertContains(t, code, "register(t1)")
-		assertContains(t, code, "register(b0)")
-	})
-
 	t.Run("heap_indirection_with_sampler_buffer_map", func(t *testing.T) {
 		opts := hlsl.DefaultOptions()
 		opts.BindingMap = bindingMap
 		opts.FakeMissingBindings = false
 		opts.SamplerBufferBindingMap = map[uint32]hlsl.BindTarget{
-			0: {Space: 255, Register: 0}, // Group 0 has sampler index buffer
+			0: {Space: 255, Register: 0}, // Group 0 has sampler index buffer at t0, space255
 		}
 
 		code := compileWGSLToHLSLWithOpts(t, source, opts)
@@ -977,6 +974,11 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 
 		// With SamplerBufferBindingMap, should use heap indirection.
 		assertContains(t, code, "nagaSamplerHeap")
+		assertContains(t, code, "nagaGroup0SamplerIndexArray")
+		assertContains(t, code, "static const SamplerState")
+		// Texture and CBV should still have direct register bindings.
+		assertContains(t, code, "register(t1)")
+		assertContains(t, code, "register(b0)")
 	})
 
 	t.Run("heap_indirection_with_fake_missing", func(t *testing.T) {
@@ -986,7 +988,22 @@ fn fs_main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
 		t.Logf("HLSL output (fake missing):\n%s", code)
 
 		// Default options use FakeMissingBindings with no explicit BindingMap entries,
-		// so the sampler binding is not explicitly mapped → heap indirection (legacy).
+		// so samplers still use heap indirection (this is always the case now).
+		assertContains(t, code, "nagaSamplerHeap")
+	})
+
+	t.Run("always_heap_even_without_sampler_buffer_map", func(t *testing.T) {
+		opts := hlsl.DefaultOptions()
+		opts.BindingMap = bindingMap
+		opts.FakeMissingBindings = false
+		opts.SamplerBufferBindingMap = nil // No sampler buffer map
+
+		code := compileWGSLToHLSLWithOpts(t, source, opts)
+		t.Logf("HLSL output (no sampler buffer map):\n%s", code)
+
+		// Even without SamplerBufferBindingMap, samplers ALWAYS use heap indirection.
+		// The index buffer gets fake binding from FakeMissingBindings or falls back
+		// to default space=255 behavior.
 		assertContains(t, code, "nagaSamplerHeap")
 	})
 }

--- a/hlsl/types.go
+++ b/hlsl/types.go
@@ -966,46 +966,19 @@ func (w *Writer) writeResourceHandle(name string, typeHandle ir.TypeHandle, glob
 				group = global.Binding.Group
 			}
 
-			// Check if this group uses sampler heap indirection (SamplerBufferBindingMap).
-			// When SamplerBufferBindingMap has no entry for this group, emit a direct
-			// register binding (SamplerState name : register(sN, spaceG)) instead of
-			// the sampler heap pattern. This allows backends that use per-group sampler
-			// descriptor tables (like our DX12 HAL) to work without a global sampler
-			// heap and index buffer infrastructure.
-			useHeapIndirection := true
-			if len(w.options.SamplerBufferBindingMap) == 0 {
-				// No sampler buffer bindings at all — use direct register binding
-				// if the binding was found in the explicit BindingMap.
-				key := ResourceBinding{Group: global.Binding.Group, Binding: global.Binding.Binding}
-				if _, hasExplicit := w.options.BindingMap[key]; hasExplicit {
-					useHeapIndirection = false
-				}
-			} else if _, hasBuf := w.options.SamplerBufferBindingMap[group]; !hasBuf {
-				// SamplerBufferBindingMap exists but has no entry for this group —
-				// use direct register binding if the binding was explicitly mapped.
-				key := ResourceBinding{Group: global.Binding.Group, Binding: global.Binding.Binding}
-				if _, hasExplicit := w.options.BindingMap[key]; hasExplicit {
-					useHeapIndirection = false
-				}
-			}
+			// Always use sampler heap indirection. The DX12 HAL must provide
+			// SamplerBufferBindingMap so that naga generates the correct
+			// nagaSamplerHeap[indexBuffer[N]] pattern. This matches Rust wgpu-hal.
+			w.writeSamplerHeaps()
+			w.writeSamplerIndexBuffer(group)
 
-			if useHeapIndirection {
-				// Write sampler heap and index buffer if not yet written
-				w.writeSamplerHeaps()
-				w.writeSamplerIndexBuffer(group)
-
-				// Write static const sampler variable that indexes into the heap
-				heapVar := "nagaSamplerHeap"
-				if inner.Comparison {
-					heapVar = "nagaComparisonSamplerHeap"
-				}
-				indexBufName := w.samplerIndexBuffers[group]
-				w.writeLine("static const %s %s = %s[%s[%d]];", samplerType, name, heapVar, indexBufName, binding.Register)
-			} else {
-				// Direct register binding — sampler declared with explicit register.
-				regStr := formatRegister("s", binding.Register, binding.Space)
-				w.writeLine("%s %s : %s;", samplerType, name, regStr)
+			// Write static const sampler variable that indexes into the heap
+			heapVar := "nagaSamplerHeap"
+			if inner.Comparison {
+				heapVar = "nagaComparisonSamplerHeap"
 			}
+			indexBufName := w.samplerIndexBuffers[group]
+			w.writeLine("static const %s %s = %s[%s[%d]];", samplerType, name, heapVar, indexBufName, binding.Register)
 		} else {
 			w.writeLine("%s %s;", samplerType, name)
 		}

--- a/snapshot/testdata/golden/hlsl/texture-external.hlsl
+++ b/snapshot/testdata/golden/hlsl/texture-external.hlsl
@@ -22,7 +22,10 @@ Texture2D<float4> tex_plane0_: register(t0);
 Texture2D<float4> tex_plane1_: register(t1);
 Texture2D<float4> tex_plane2_: register(t2);
 cbuffer tex_params: register(b3) { NagaExternalTextureParams tex_params; };
-SamplerState samp : register(s0);
+SamplerState nagaSamplerHeap[2048]: register(s0, space0);
+SamplerComparisonState nagaComparisonSamplerHeap[2048]: register(s0, space1);
+StructuredBuffer<uint> nagaGroup0SamplerIndexArray : register(t0, space255);
+static const SamplerState samp = nagaSamplerHeap[nagaGroup0SamplerIndexArray[0]];
 
 float4 nagaTextureSampleBaseClampToEdge(
     Texture2D<float4> plane0,

--- a/snapshot/testdata/reference/hlsl/wgsl-texture-external.hlsl
+++ b/snapshot/testdata/reference/hlsl/wgsl-texture-external.hlsl
@@ -22,7 +22,10 @@ Texture2D<float4> tex_plane0_: register(t0);
 Texture2D<float4> tex_plane1_: register(t1);
 Texture2D<float4> tex_plane2_: register(t2);
 cbuffer tex_params: register(b3) { NagaExternalTextureParams tex_params; };
-SamplerState samp : register(s0);
+SamplerState nagaSamplerHeap[2048]: register(s0, space0);
+SamplerComparisonState nagaComparisonSamplerHeap[2048]: register(s0, space1);
+StructuredBuffer<uint> nagaGroup0SamplerIndexArray : register(t0, space255);
+static const SamplerState samp = nagaSamplerHeap[nagaGroup0SamplerIndexArray[0]];
 
 float4 nagaTextureSampleBaseClampToEdge(
     Texture2D<float4> plane0,


### PR DESCRIPTION
Reverted v0.15.1 direct register binding (was a kostyl). Samplers always use sampler heap indirection, matching Rust naga. DX12 HAL now implements proper sampler heap.