### PR TITLE
perf: allocation optimization — 4.9× fewer allocs for SPIR-V (v0.16.6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - **Lexer token preallocation** — Token slice estimate `len(source)/4` (was `/6`).
   Prevents slice regrowth for typical shaders.
 - **Overall: 594 → 569 allocs/op (-4.2%), ~23% faster median.**
+- **SPIR-V Backend reuse** — `Backend.Reset()` + `ModuleBuilder.Reset()` clear
+  all state without deallocating (Go 1.21+ `clear()` keeps map capacity).
+  `Compile()` calls `Reset()` internally. Small shaders: 4.9× fewer allocs
+  (68→14), 14× fewer bytes (17KB→1.2KB). Reuse benchmarks included.
 
 ## [0.16.4] - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (398 symbols scanned across 6 packages): `flattenBinding` (glsl), 
   `concretizeTypeInner` (ir/compact), `resolveLiteralTypeInner` (ir/process_overrides).
 
+### Performance
+
+- **TypeRegistry zero-alloc lookups** — Refactored `normalizeType()` to `appendTypeKey()`
+  using `keyBuf []byte` with inline `string(keyBuf)` map index (Go compiler optimization).
+  Eliminates heap string allocation per type lookup. large_pbr: -59 allocs/op.
+- **Lexer token preallocation** — Token slice estimate `len(source)/4` (was `/6`).
+  Prevents slice regrowth for typical shaders.
+- **Overall: 594 → 569 allocs/op (-4.2%), ~23% faster median.**
+
 ## [0.16.4] - 2026-04-04
 
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,13 +5,7 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [0.16.5] - 2026-04-05
-
-### Changed
-
-- **Dead code removal** — Removed 3 unused functions found by full codebase audit
-  (398 symbols scanned across 6 packages): `flattenBinding` (glsl), 
-  `concretizeTypeInner` (ir/compact), `resolveLiteralTypeInner` (ir/process_overrides).
+## [0.16.6] - 2026-04-05
 
 ### Performance
 
@@ -20,11 +14,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   Eliminates heap string allocation per type lookup. large_pbr: -59 allocs/op.
 - **Lexer token preallocation** — Token slice estimate `len(source)/4` (was `/6`).
   Prevents slice regrowth for typical shaders.
-- **Overall: 594 → 569 allocs/op (-4.2%), ~23% faster median.**
 - **SPIR-V Backend reuse** — `Backend.Reset()` + `ModuleBuilder.Reset()` clear
   all state without deallocating (Go 1.21+ `clear()` keeps map capacity).
   `Compile()` calls `Reset()` internally. Small shaders: 4.9× fewer allocs
   (68→14), 14× fewer bytes (17KB→1.2KB). Reuse benchmarks included.
+- **Lowerer/Parser pre-sizing** — Expression, statement, declaration slices
+  pre-allocated based on AST size estimates. TypeRegistry capacity hints.
+- **Overall: 594 → 562 allocs/op (-5.4%). SPIR-V reuse: 68 → 14 allocs (4.9×).**
+
+## [0.16.5] - 2026-04-05
+
+### Changed
+
+- **Dead code removal** — Removed 3 unused functions found by full codebase audit
+  (398 symbols scanned across 6 packages): `flattenBinding` (glsl), 
+  `concretizeTypeInner` (ir/compact), `resolveLiteralTypeInner` (ir/process_overrides).
 
 ## [0.16.4] - 2026-04-04
 

--- a/bench_test.go
+++ b/bench_test.go
@@ -579,3 +579,40 @@ func BenchmarkGenerateSPIRV(b *testing.B) {
 		})
 	}
 }
+
+// BenchmarkGenerateSPIRVReuse benchmarks SPIR-V code generation with a reused
+// Backend instance. The Backend.Reset() is called internally by Compile(),
+// eliminating map and slice re-allocation across iterations.
+func BenchmarkGenerateSPIRVReuse(b *testing.B) {
+	for _, sc := range shadersByComplexity {
+		b.Run(sc.name, func(b *testing.B) {
+			ast, err := Parse(sc.source)
+			if err != nil {
+				b.Fatalf("parse failed: %v", err)
+			}
+			module, err := Lower(ast)
+			if err != nil {
+				b.Fatalf("lower failed: %v", err)
+			}
+
+			opts := spirv.Options{
+				Version: spirv.Version1_3,
+				Debug:   false,
+			}
+			backend := spirv.NewBackend(opts)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(sc.source)))
+			b.ResetTimer()
+
+			var result []byte
+			for i := 0; i < b.N; i++ {
+				result, err = backend.Compile(module)
+				if err != nil {
+					b.Fatalf("spirv generate reuse failed: %v", err)
+				}
+			}
+			runtime.KeepAlive(result)
+		})
+	}
+}

--- a/ir/registry.go
+++ b/ir/registry.go
@@ -15,9 +15,18 @@ type TypeRegistry struct {
 
 // NewTypeRegistry creates a new type registry for deduplication.
 func NewTypeRegistry() *TypeRegistry {
+	return NewTypeRegistryWithCap(16)
+}
+
+// NewTypeRegistryWithCap creates a new type registry with pre-allocated capacity.
+// Use this when the expected number of types is known to avoid slice regrowth.
+func NewTypeRegistryWithCap(initialCap int) *TypeRegistry {
+	if initialCap < 16 {
+		initialCap = 16
+	}
 	return &TypeRegistry{
-		types:   make([]Type, 0, 16),
-		typeMap: make(map[string]TypeHandle, 16),
+		types:   make([]Type, 0, initialCap),
+		typeMap: make(map[string]TypeHandle, initialCap),
 		keyBuf:  make([]byte, 0, 64),
 	}
 }

--- a/ir/registry.go
+++ b/ir/registry.go
@@ -27,19 +27,18 @@ func NewTypeRegistry() *TypeRegistry {
 // Named struct types are never deduplicated with each other (different names
 // mean different types), matching Rust naga's Arena behavior.
 func (r *TypeRegistry) GetOrCreate(name string, inner TypeInner) TypeHandle {
-	key := r.normalizeType(inner)
-	// In Rust naga, UniqueArena deduplicates on the full Type{name, inner} pair.
-	// Type{name: None, inner: X} and Type{name: Some("A"), inner: X} are distinct.
-	// We replicate this by including the name in the dedup key for ALL named types,
-	// not just structs. Anonymous types (name="") still dedup on inner alone.
-	if name != "" {
-		key = "named:" + name + ":" + key
-	}
+	// Build the full key in keyBuf. normalizeType writes the type portion,
+	// and we prepend the name prefix if needed.
+	r.buildKey(name, inner)
 
-	// Check if type already exists
-	if handle, exists := r.typeMap[key]; exists {
+	// Use string(r.keyBuf) directly in the map index expression.
+	// Go compiler optimizes m[string(b)] to avoid heap allocation for lookups.
+	if handle, exists := r.typeMap[string(r.keyBuf)]; exists {
 		return handle
 	}
+
+	// Cache miss — allocate key string for storage in map.
+	key := string(r.keyBuf)
 
 	// Create new type
 	handle := TypeHandle(len(r.types))
@@ -52,6 +51,21 @@ func (r *TypeRegistry) GetOrCreate(name string, inner TypeInner) TypeHandle {
 	return handle
 }
 
+// buildKey writes the full dedup key into r.keyBuf.
+// In Rust naga, UniqueArena deduplicates on the full Type{name, inner} pair.
+// Type{name: None, inner: X} and Type{name: Some("A"), inner: X} are distinct.
+// We replicate this by including the name in the dedup key for ALL named types,
+// not just structs. Anonymous types (name="") still dedup on inner alone.
+func (r *TypeRegistry) buildKey(name string, inner TypeInner) {
+	r.keyBuf = r.keyBuf[:0]
+	if name != "" {
+		r.keyBuf = append(r.keyBuf, "named:"...)
+		r.keyBuf = append(r.keyBuf, name...)
+		r.keyBuf = append(r.keyBuf, ':')
+	}
+	r.appendTypeKey(inner)
+}
+
 // SetName renames an existing type in the registry and updates the dedup key.
 // Used when a type alias renames an anonymous type in-place (e.g., `alias rq = ray_query;`
 // renames the anonymous RayQuery entry to "rq").
@@ -62,18 +76,13 @@ func (r *TypeRegistry) SetName(handle TypeHandle, name string) {
 	oldName := r.types[handle].Name
 	r.types[handle].Name = name
 
-	// Update dedup key: remove old key, add new one
-	oldKey := r.normalizeType(r.types[handle].Inner)
-	if oldName != "" {
-		oldKey = "named:" + oldName + ":" + oldKey
-	}
-	delete(r.typeMap, oldKey)
+	// Remove old key
+	r.buildKey(oldName, r.types[handle].Inner)
+	delete(r.typeMap, string(r.keyBuf))
 
-	newKey := r.normalizeType(r.types[handle].Inner)
-	if name != "" {
-		newKey = "named:" + name + ":" + newKey
-	}
-	r.typeMap[newKey] = handle
+	// Add new key
+	r.buildKey(name, r.types[handle].Inner)
+	r.typeMap[string(r.keyBuf)] = handle
 }
 
 // Append adds a type without deduplication, always creating a new entry.
@@ -94,82 +103,122 @@ func (r *TypeRegistry) GetTypes() []Type {
 	return r.types
 }
 
-// normalizeType creates a unique key for a type based on its structure.
+// appendTypeKey appends a unique key for the type to r.keyBuf.
 // Two structurally identical types will produce the same key.
-// Uses a reusable byte buffer to avoid fmt.Sprintf allocations for common types.
-func (r *TypeRegistry) normalizeType(inner TypeInner) string {
-	b := r.keyBuf[:0]
-
+// All output goes to keyBuf to enable the Go map[string([]byte)] optimization
+// in callers, avoiding heap allocations for cache-hit lookups.
+func (r *TypeRegistry) appendTypeKey(inner TypeInner) {
 	switch t := inner.(type) {
 	case ScalarType:
-		b = append(b, "scalar:"...)
-		b = strconv.AppendInt(b, int64(t.Kind), 10)
-		b = append(b, ':')
-		b = strconv.AppendUint(b, uint64(t.Width), 10)
-		r.keyBuf = b
-		return string(b)
+		r.keyBuf = append(r.keyBuf, "scalar:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Kind), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Width), 10)
 
 	case VectorType:
-		// Recursive call clobbers keyBuf, so build with string concat.
-		scalarKey := r.normalizeType(t.Scalar)
-		return "vec:" + strconv.FormatUint(uint64(t.Size), 10) + ":" + scalarKey
+		r.keyBuf = append(r.keyBuf, "vec:"...)
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Size), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.appendTypeKey(t.Scalar)
 
 	case MatrixType:
-		scalarKey := r.normalizeType(t.Scalar)
-		return "mat:" + strconv.FormatUint(uint64(t.Columns), 10) + "x" + strconv.FormatUint(uint64(t.Rows), 10) + ":" + scalarKey
+		r.keyBuf = append(r.keyBuf, "mat:"...)
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Columns), 10)
+		r.keyBuf = append(r.keyBuf, 'x')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Rows), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.appendTypeKey(t.Scalar)
 
 	case ArrayType:
-		var sizeKey string
+		r.keyBuf = append(r.keyBuf, "array:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Base), 10)
+		r.keyBuf = append(r.keyBuf, ':')
 		if t.Size.Constant != nil {
-			sizeKey = strconv.FormatUint(uint64(*t.Size.Constant), 10)
+			r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(*t.Size.Constant), 10)
 		} else {
-			sizeKey = "runtime"
+			r.keyBuf = append(r.keyBuf, "runtime"...)
 		}
-		return "array:" + strconv.FormatInt(int64(t.Base), 10) + ":" + sizeKey + ":" + strconv.FormatUint(uint64(t.Stride), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Stride), 10)
 
 	case StructType:
-		// Structs use fmt.Sprintf since they're less frequent and more complex.
-		key := fmt.Sprintf("struct:%d:%d", len(t.Members), t.Span)
+		r.keyBuf = append(r.keyBuf, "struct:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(len(t.Members)), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Span), 10)
 		for _, member := range t.Members {
-			key += fmt.Sprintf(":m(%s,%d,%d)", member.Name, member.Type, member.Offset)
+			r.keyBuf = append(r.keyBuf, ":m("...)
+			r.keyBuf = append(r.keyBuf, member.Name...)
+			r.keyBuf = append(r.keyBuf, ',')
+			r.keyBuf = strconv.AppendInt(r.keyBuf, int64(member.Type), 10)
+			r.keyBuf = append(r.keyBuf, ',')
+			r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(member.Offset), 10)
+			r.keyBuf = append(r.keyBuf, ')')
 		}
-		return key
 
 	case PointerType:
-		return "ptr:" + strconv.FormatInt(int64(t.Base), 10) + ":" + strconv.FormatInt(int64(t.Space), 10)
+		r.keyBuf = append(r.keyBuf, "ptr:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Base), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Space), 10)
 
 	case SamplerType:
+		r.keyBuf = append(r.keyBuf, "sampler:"...)
 		if t.Comparison {
-			return "sampler:true"
+			r.keyBuf = append(r.keyBuf, "true"...)
+		} else {
+			r.keyBuf = append(r.keyBuf, "false"...)
 		}
-		return "sampler:false"
 
 	case ImageType:
-		return fmt.Sprintf("image:%d:%v:%d:%v:%d:%d:%d", t.Dim, t.Arrayed, t.Class, t.Multisampled, t.StorageFormat, t.StorageAccess, t.SampledKind)
+		r.keyBuf = append(r.keyBuf, "image:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Dim), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		if t.Arrayed {
+			r.keyBuf = append(r.keyBuf, "true"...)
+		} else {
+			r.keyBuf = append(r.keyBuf, "false"...)
+		}
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Class), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		if t.Multisampled {
+			r.keyBuf = append(r.keyBuf, "true"...)
+		} else {
+			r.keyBuf = append(r.keyBuf, "false"...)
+		}
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.StorageFormat), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.StorageAccess), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.SampledKind), 10)
 
 	case AtomicType:
-		b = append(b, "atomic:"...)
-		b = strconv.AppendInt(b, int64(t.Scalar.Kind), 10)
-		b = append(b, ':')
-		b = strconv.AppendUint(b, uint64(t.Scalar.Width), 10)
-		r.keyBuf = b
-		return string(b)
+		r.keyBuf = append(r.keyBuf, "atomic:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Scalar.Kind), 10)
+		r.keyBuf = append(r.keyBuf, ':')
+		r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(t.Scalar.Width), 10)
 
 	case AccelerationStructureType:
-		return "acceleration_structure"
+		r.keyBuf = append(r.keyBuf, "acceleration_structure"...)
 
 	case RayQueryType:
-		return "ray_query"
+		r.keyBuf = append(r.keyBuf, "ray_query"...)
 
 	case BindingArrayType:
-		sizeKey := "unbounded"
+		r.keyBuf = append(r.keyBuf, "binding_array:"...)
+		r.keyBuf = strconv.AppendInt(r.keyBuf, int64(t.Base), 10)
+		r.keyBuf = append(r.keyBuf, ':')
 		if t.Size != nil {
-			sizeKey = strconv.FormatUint(uint64(*t.Size), 10)
+			r.keyBuf = strconv.AppendUint(r.keyBuf, uint64(*t.Size), 10)
+		} else {
+			r.keyBuf = append(r.keyBuf, "unbounded"...)
 		}
-		return "binding_array:" + strconv.FormatInt(int64(t.Base), 10) + ":" + sizeKey
 
 	default:
-		return fmt.Sprintf("unknown:%T", inner)
+		r.keyBuf = append(r.keyBuf, "unknown:"...)
+		r.keyBuf = fmt.Appendf(r.keyBuf, "%T", inner)
 	}
 }
 

--- a/spirv/backend.go
+++ b/spirv/backend.go
@@ -197,6 +197,53 @@ func NewBackend(options Options) *Backend {
 	}
 }
 
+// Reset clears all state in the Backend without deallocating.
+// This allows reuse of the same Backend instance across compilations,
+// avoiding repeated allocation of maps and slices. After Reset, the
+// Backend is in the same logical state as a freshly created one.
+//
+// Reset is called automatically at the start of Compile, so callers
+// do not need to call it explicitly.
+func (b *Backend) Reset() {
+	b.module = nil
+
+	// Clear maps — Go 1.21+ clear() keeps capacity, removes all entries
+	clear(b.typeIDs)
+	clear(b.constantIDs)
+	clear(b.globalIDs)
+	clear(b.functionIDs)
+	clear(b.entryInputVars)
+	clear(b.entryOutputVars)
+	clear(b.entryPointFuncIDs)
+	clear(b.sampledImageTypeIDs)
+	clear(b.imageTypeIDs)
+	clear(b.scalarTypeIDs)
+	clear(b.pointerTypeIDs)
+	clear(b.vectorTypeIDs)
+	clear(b.matrixTypeIDs)
+	clear(b.usedCapabilities)
+	clear(b.usedExtensions)
+	clear(b.funcTypeIDs)
+	clear(b.wrappedStorageVars)
+	clear(b.blockDecoratedTypes)
+	clear(b.layoutFreeTypeIDs)
+	clear(b.forcePointSizeVars)
+	clear(b.workgroupInitVars)
+	clear(b.wrappedFuncIDs)
+	clear(b.f16PolyfillVars)
+	clear(b.sampleMaskVars)
+	clear(b.rayQueryFuncIDs)
+	clear(b.uniformStructTypes)
+
+	// Reset scalar IDs
+	b.glslExtID = 0
+	b.voidTypeID = 0
+	b.samplerTypeID = 0
+
+	// Reset instruction builder scratch space
+	b.ib.words = b.ib.words[:0]
+}
+
 // needsF16Polyfill checks if a type is f16-related and needs polyfill
 // (converting to f32) for Input/Output variables when StorageInputOutput16
 // is not available.
@@ -245,12 +292,23 @@ func (b *Backend) newIB() *InstructionBuilder {
 }
 
 // Compile translates an IR module to SPIR-V binary.
+// The Backend is automatically reset before each compilation, so
+// a single Backend instance can be reused across multiple Compile calls.
 func (b *Backend) Compile(module *ir.Module) ([]byte, error) {
+	// Reset all per-compilation state (maps cleared, slices truncated).
+	b.Reset()
 	b.module = module
-	b.builder = NewModuleBuilder(b.options.Version)
+
+	// Reuse or create the ModuleBuilder.
+	if b.builder != nil {
+		b.builder.Reset(b.options.Version)
+	} else {
+		b.builder = NewModuleBuilder(b.options.Version)
+	}
+
 	// Initialize shared instruction builder with module builder's arena for zero-alloc builds.
 	b.ib = InstructionBuilder{
-		words: make([]uint32, 0, 16),
+		words: b.ib.words[:0], // reuse existing scratch buffer
 		arena: &b.builder.arena,
 	}
 

--- a/spirv/backend_test.go
+++ b/spirv/backend_test.go
@@ -1343,3 +1343,170 @@ func TestF16PolyfillConvertsIO(t *testing.T) {
 		t.Error("f16 polyfill produced empty/invalid SPIR-V")
 	}
 }
+
+// TestBackendReuse verifies that reusing a Backend instance across multiple
+// compilations produces identical output to using a fresh Backend each time.
+// This is the correctness gate for the Reset() optimization.
+func TestBackendReuse(t *testing.T) {
+	// Two different modules to compile sequentially with the same backend.
+	module1 := buildVertexModule()
+	module2 := buildFragModule()
+
+	opts := DefaultOptions()
+
+	// --- Fresh backends (reference) ---
+	fresh1 := NewBackend(opts)
+	out1Fresh, err := fresh1.Compile(module1)
+	if err != nil {
+		t.Fatalf("fresh compile module1: %v", err)
+	}
+
+	fresh2 := NewBackend(opts)
+	out2Fresh, err := fresh2.Compile(module2)
+	if err != nil {
+		t.Fatalf("fresh compile module2: %v", err)
+	}
+
+	// --- Reused backend ---
+	reused := NewBackend(opts)
+
+	// First compilation
+	out1Reused, err := reused.Compile(module1)
+	if err != nil {
+		t.Fatalf("reused compile module1: %v", err)
+	}
+
+	// Second compilation (different module, same backend)
+	out2Reused, err := reused.Compile(module2)
+	if err != nil {
+		t.Fatalf("reused compile module2: %v", err)
+	}
+
+	// Verify: reused output must be identical to fresh output
+	if len(out1Fresh) != len(out1Reused) {
+		t.Fatalf("module1: fresh len=%d, reused len=%d", len(out1Fresh), len(out1Reused))
+	}
+	for i := range out1Fresh {
+		if out1Fresh[i] != out1Reused[i] {
+			t.Errorf("module1: byte %d differs: fresh=0x%02x reused=0x%02x", i, out1Fresh[i], out1Reused[i])
+			break
+		}
+	}
+
+	if len(out2Fresh) != len(out2Reused) {
+		t.Fatalf("module2: fresh len=%d, reused len=%d", len(out2Fresh), len(out2Reused))
+	}
+	for i := range out2Fresh {
+		if out2Fresh[i] != out2Reused[i] {
+			t.Errorf("module2: byte %d differs: fresh=0x%02x reused=0x%02x", i, out2Fresh[i], out2Reused[i])
+			break
+		}
+	}
+
+	// Third compilation: re-compile module1 again to verify no leftover state from module2.
+	out1Again, err := reused.Compile(module1)
+	if err != nil {
+		t.Fatalf("reused compile module1 again: %v", err)
+	}
+	if len(out1Fresh) != len(out1Again) {
+		t.Fatalf("module1 again: fresh len=%d, reused len=%d", len(out1Fresh), len(out1Again))
+	}
+	for i := range out1Fresh {
+		if out1Fresh[i] != out1Again[i] {
+			t.Errorf("module1 again: byte %d differs: fresh=0x%02x reused=0x%02x", i, out1Fresh[i], out1Again[i])
+			break
+		}
+	}
+}
+
+// buildVertexModule builds a minimal vertex shader IR module for reuse testing.
+func buildVertexModule() *ir.Module {
+	vertexIndexBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinVertexIndex})
+	positionBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	return &ir.Module{
+		Types: []ir.Type{
+			{Name: "u32", Inner: ir.ScalarType{Kind: ir.ScalarUint, Width: 4}},  // 0
+			{Name: "f32", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, // 1
+			{Name: "vec4f", Inner: ir.VectorType{ // 2
+				Size:   ir.Vec4,
+				Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+			}},
+		},
+		Constants: []ir.Constant{
+			{Name: "zero", Type: 1, Value: ir.ScalarValue{Kind: ir.ScalarFloat, Bits: 0}},                 // 0
+			{Name: "one", Type: 1, Value: ir.ScalarValue{Kind: ir.ScalarFloat, Bits: 0x3f800000}},         // 1
+			{Name: "pos", Type: 2, Value: ir.CompositeValue{Components: []ir.ConstantHandle{0, 0, 0, 1}}}, // 2
+		},
+		GlobalVariables: []ir.GlobalVariable{},
+		Functions:       []ir.Function{},
+		EntryPoints: []ir.EntryPoint{
+			{
+				Name:  "vs_main",
+				Stage: ir.StageVertex,
+				Function: ir.Function{
+					Name: "vs_main",
+					Arguments: []ir.FunctionArgument{
+						{Name: "idx", Type: 0, Binding: &vertexIndexBinding},
+					},
+					Result: &ir.FunctionResult{
+						Type: 2, Binding: &positionBinding,
+					},
+					LocalVars: []ir.LocalVariable{},
+					Expressions: []ir.Expression{
+						{Kind: ir.ExprConstant{Constant: 2}},
+					},
+					NamedExpressions: map[ir.ExpressionHandle]string{},
+					Body: []ir.Statement{
+						{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+						{Kind: ir.StmtReturn{Value: ptrExprHandle(0)}},
+					},
+				},
+			},
+		},
+	}
+}
+
+// buildFragModule builds a minimal fragment shader IR module for reuse testing.
+func buildFragModule() *ir.Module {
+	locationBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	return &ir.Module{
+		Types: []ir.Type{
+			{Name: "f32", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, // 0
+			{Name: "vec4f", Inner: ir.VectorType{ // 1
+				Size:   ir.Vec4,
+				Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+			}},
+		},
+		Constants: []ir.Constant{
+			{Name: "one", Type: 0, Value: ir.ScalarValue{Kind: ir.ScalarFloat, Bits: 0x3f800000}},           // 0
+			{Name: "zero", Type: 0, Value: ir.ScalarValue{Kind: ir.ScalarFloat, Bits: 0}},                   // 1
+			{Name: "color", Type: 1, Value: ir.CompositeValue{Components: []ir.ConstantHandle{0, 1, 1, 0}}}, // 2
+		},
+		GlobalVariables: []ir.GlobalVariable{},
+		Functions:       []ir.Function{},
+		EntryPoints: []ir.EntryPoint{
+			{
+				Name:  "fs_main",
+				Stage: ir.StageFragment,
+				Function: ir.Function{
+					Name:      "fs_main",
+					Arguments: []ir.FunctionArgument{},
+					Result: &ir.FunctionResult{
+						Type: 1, Binding: &locationBinding,
+					},
+					LocalVars: []ir.LocalVariable{},
+					Expressions: []ir.Expression{
+						{Kind: ir.ExprConstant{Constant: 2}},
+					},
+					NamedExpressions: map[ir.ExpressionHandle]string{},
+					Body: []ir.Statement{
+						{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+						{Kind: ir.StmtReturn{Value: ptrExprHandle(0)}},
+					},
+				},
+			},
+		},
+	}
+}

--- a/spirv/bench_test.go
+++ b/spirv/bench_test.go
@@ -156,6 +156,37 @@ func BenchmarkSPIRVEmit(b *testing.B) {
 	}
 }
 
+// BenchmarkSPIRVEmitReuse benchmarks SPIR-V code generation with a reused
+// Backend instance. Compile() calls Reset() internally, so the same Backend
+// can be used across iterations without allocating new maps/slices.
+func BenchmarkSPIRVEmitReuse(b *testing.B) {
+	for _, bc := range spirvBenchShaders {
+		b.Run(bc.name, func(b *testing.B) {
+			module := parseToIR(b, bc.source)
+			opts := Options{
+				Version: Version1_3,
+				Debug:   false,
+			}
+
+			backend := NewBackend(opts)
+
+			b.ReportAllocs()
+			b.SetBytes(int64(len(bc.source)))
+			b.ResetTimer()
+
+			var result []byte
+			for i := 0; i < b.N; i++ {
+				var err error
+				result, err = backend.Compile(module)
+				if err != nil {
+					b.Fatalf("spirv emit reuse failed: %v", err)
+				}
+			}
+			runtime.KeepAlive(result)
+		})
+	}
+}
+
 // BenchmarkSPIRVEmitWithDebug benchmarks SPIR-V code generation with debug
 // info (OpName instructions) to measure the overhead of debug output.
 func BenchmarkSPIRVEmitWithDebug(b *testing.B) {

--- a/spirv/writer.go
+++ b/spirv/writer.go
@@ -202,6 +202,41 @@ func NewModuleBuilder(version Version) *ModuleBuilder {
 	return mb
 }
 
+// Reset clears all state in the ModuleBuilder without deallocating.
+// This allows reuse of the builder across compilations, avoiding
+// repeated allocation of instruction slices and the word arena.
+func (b *ModuleBuilder) Reset(version Version) {
+	b.version = version
+	b.generator = GeneratorID
+	b.bound = 0
+	b.schema = 0
+
+	// Reset instruction slices — keep backing arrays, set length to 0
+	b.capabilities = b.capabilities[:0]
+	b.extensions = b.extensions[:0]
+	b.extInstImports = b.extInstImports[:0]
+	b.memoryModel = nil
+	b.entryPoints = b.entryPoints[:0]
+	b.executionModes = b.executionModes[:0]
+	b.debugStrings = b.debugStrings[:0]
+	b.debugNames = b.debugNames[:0]
+	b.annotations = b.annotations[:0]
+	b.types = b.types[:0]
+	b.globalVars = b.globalVars[:0]
+	b.functions = b.functions[:0]
+	b.funcSink = nil
+
+	// Reset ID allocation
+	b.nextID = 1
+
+	// Reset word arena position — keep the backing buffer
+	b.arena.pos = 0
+
+	// Reset instruction builder scratch space — keep capacity
+	b.ib.words = b.ib.words[:0]
+	// arena pointer stays valid (points to b.arena)
+}
+
 // RequireVersion bumps the module's SPIR-V version to at least minVersion.
 // If the current version is already >= minVersion, this is a no-op.
 func (b *ModuleBuilder) RequireVersion(minVersion Version) {

--- a/wgsl/lexer.go
+++ b/wgsl/lexer.go
@@ -17,8 +17,10 @@ type Lexer struct {
 
 // NewLexer creates a new lexer for the given source.
 func NewLexer(source string) *Lexer {
-	// Estimate ~1 token per 6 characters of source.
-	estTokens := len(source) / 6
+	// Estimate ~1 token per 4 characters of source.
+	// WGSL averages ~4 chars/token (operators, keywords, punctuation).
+	// Slight overallocation is cheap — it's one slice, and avoids regrowth.
+	estTokens := len(source) / 4
 	if estTokens < 16 {
 		estTokens = 16
 	}

--- a/wgsl/lower.go
+++ b/wgsl/lower.go
@@ -135,18 +135,49 @@ func LowerWithSource(ast *Module, source string) (*ir.Module, error) {
 
 // LowerWithWarnings converts a WGSL AST module to Naga IR, returning warnings.
 func LowerWithWarnings(ast *Module, source string) (*LowerResult, error) {
+	// Pre-size module-level slices based on AST declaration counts.
+	// This avoids repeated slice growth during lowering.
+	nFuncs := len(ast.Functions)
+	nStructs := len(ast.Structs)
+	nGlobals := len(ast.GlobalVars)
+	nConsts := len(ast.Constants)
+	nOverrides := len(ast.Overrides)
+	// Types: builtins (~15) + struct types + param/return types.
+	estTypes := 16 // default matches NewTypeRegistry
+	if nStructs > 1 || nFuncs > 2 || nGlobals > 2 {
+		estTypes = nStructs*2 + nFuncs + nGlobals + 16
+	}
+	// Global expressions: roughly 1 per constant/override + 1 per global var init.
+	estGlobalExprs := nConsts + nOverrides + nGlobals + 4
+
+	// Build module with pre-sized slices. Only pre-allocate slices that
+	// have enough expected items to benefit from avoiding regrowth.
+	// For small counts (0-2), nil slice append is fine — Go allocates
+	// on first append with no regrowth for single-element slices.
+	mod := &ir.Module{}
+	if nConsts > 2 {
+		mod.Constants = make([]ir.Constant, 0, nConsts)
+	}
+	if nGlobals > 2 {
+		mod.GlobalVariables = make([]ir.GlobalVariable, 0, nGlobals)
+		mod.GlobalExpressions = make([]ir.Expression, 0, estGlobalExprs)
+	}
+	if nOverrides > 2 {
+		mod.Overrides = make([]ir.Override, 0, nOverrides)
+	}
+
 	l := &Lowerer{
-		module:            &ir.Module{},
+		module:            mod,
 		source:            source,
-		registry:          ir.NewTypeRegistry(),
+		registry:          ir.NewTypeRegistryWithCap(estTypes),
 		types:             make(map[string]ir.TypeHandle, 16),
-		globals:           make(map[string]ir.GlobalVariableHandle, 8),
+		globals:           make(map[string]ir.GlobalVariableHandle, max(nGlobals, 8)),
 		locals:            make(map[string]ir.ExpressionHandle, 16),
-		moduleConstants:   make(map[string]ir.ConstantHandle, 16),
-		moduleOverrides:   make(map[string]ir.OverrideHandle, 8),
+		moduleConstants:   make(map[string]ir.ConstantHandle, max(nConsts, 16)),
+		moduleOverrides:   make(map[string]ir.OverrideHandle, max(nOverrides, 8)),
 		inlineConstants:   make(map[string]ir.LiteralValue, 32),
 		abstractConstants: make(map[string]*abstractConstInfo, 4),
-		functions:         make(map[string]ir.FunctionHandle, len(ast.Functions)),
+		functions:         make(map[string]ir.FunctionHandle, nFuncs),
 		entryPointFuncs:   make(map[string]bool, 4),
 		localDecls:        make(map[string]Span, 16),
 		usedLocals:        make(map[string]bool, 16),
@@ -3671,11 +3702,14 @@ func (l *Lowerer) lowerFunction(f *FunctionDecl) error {
 	l.currentExprIdx = 0
 
 	// Estimate sizes based on function complexity.
+	// Each AST statement typically produces ~3 IR expressions (binary ops, loads, etc.).
+	// Parameters each produce 1 expression. Globals referenced add ~1 each.
 	var bodySize int
 	if f.Body != nil {
-		bodySize = len(f.Body.Statements)
+		bodySize = countStatementsDeep(f.Body)
 	}
-	estExprs := bodySize * 3 // rough: ~3 expressions per statement
+	nParams := len(f.Params)
+	estExprs := bodySize*3 + nParams + len(l.globals) + 4
 	if estExprs < 8 {
 		estExprs = 8
 	}
@@ -3687,10 +3721,17 @@ func (l *Lowerer) lowerFunction(f *FunctionDecl) error {
 		Expressions:      make([]ir.Expression, 0, estExprs),
 		ExpressionTypes:  make([]ir.TypeResolution, 0, estExprs),
 		Body:             make([]ir.Statement, 0, bodySize),
-		NamedExpressions: make(map[ir.ExpressionHandle]string),
+		NamedExpressions: make(map[ir.ExpressionHandle]string, nParams+4),
 	}
 	l.currentFunc = fn
-	l.nonConstExprs = make(map[ir.ExpressionHandle]bool)
+	// Reuse nonConstExprs map — clear instead of reallocating.
+	if l.nonConstExprs == nil {
+		l.nonConstExprs = make(map[ir.ExpressionHandle]bool, 8)
+	} else {
+		for k := range l.nonConstExprs {
+			delete(l.nonConstExprs, k)
+		}
+	}
 
 	// Lower parameters
 	for i, p := range f.Params {
@@ -9589,6 +9630,38 @@ func (l *Lowerer) interruptEmitter(expr ir.Expression) ir.ExpressionHandle {
 	}
 
 	return handle
+}
+
+// countStatementsDeep returns a rough count of statements in a block,
+// recursively counting sub-blocks. Used to estimate IR expression count
+// for slice pre-allocation.
+func countStatementsDeep(block *BlockStmt) int {
+	if block == nil {
+		return 0
+	}
+	count := len(block.Statements)
+	for _, s := range block.Statements {
+		switch stmt := s.(type) {
+		case *IfStmt:
+			count += countStatementsDeep(stmt.Body)
+			if elseBlock, ok := stmt.Else.(*BlockStmt); ok {
+				count += countStatementsDeep(elseBlock)
+			}
+		case *ForStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *WhileStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *LoopStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *SwitchStmt:
+			for _, c := range stmt.Cases {
+				count += countStatementsDeep(c.Body)
+			}
+		case *BlockStmt:
+			count += countStatementsDeep(stmt)
+		}
+	}
+	return count
 }
 
 // ensureBlockReturns ensures every control flow path in a block ends with a Return.

--- a/wgsl/parser.go
+++ b/wgsl/parser.go
@@ -31,7 +31,17 @@ func NewParser(tokens []Token) *Parser {
 
 // Parse parses the tokens and returns a Module AST.
 func (p *Parser) Parse() (*Module, error) {
+	// Estimate declaration counts from token count for pre-allocation.
+	// Only pre-allocate for shaders with enough tokens to benefit from
+	// avoiding slice regrowth. Small shaders (< ~100 tokens) are fine
+	// with nil slice append growth.
+	nTokens := len(p.tokens)
 	module := &Module{}
+	if nTokens > 100 {
+		estDecls := nTokens/20 + 1
+		module.Declarations = make([]Decl, 0, estDecls)
+		module.Functions = make([]*FunctionDecl, 0, estDecls/3+1)
+	}
 
 	for !p.isAtEnd() {
 		// Skip optional semicolons between declarations (e.g., struct Foo { ... };)


### PR DESCRIPTION
## Summary

Three allocation optimizations reducing GC pressure across the shader compilation pipeline.

### OPT-001a: TypeRegistry zero-alloc lookups + Lexer prealloc
- `normalizeType()` → `appendTypeKey()` with inline `string(keyBuf)` map index (Go compiler optimization)
- Lexer token slice estimate `len(source)/4`
- **594 → 569 allocs/op (-4.2%)**

### OPT-001b: SPIR-V Backend.Reset() reuse
- `Backend.Reset()` clears 24 maps with `clear()` (keeps capacity)
- `ModuleBuilder.Reset()` resets word arena + ID counter
- `Compile()` calls `Reset()` internally
- **Small fragment: 68 → 14 allocs (4.9×), 17KB → 1.2KB (14×)**
- `TestBackendReuse` verifies byte-exact match vs fresh backend

### OPT-001c partial: Lowerer/Parser pre-sizing
- Expression slices pre-allocated from AST size estimates
- Declaration slices pre-sized from token count
- TypeRegistry capacity hints
- **-6 allocs/op** (modest — interface boxing is the real bottleneck)

## Test plan
- [x] `go build ./...` + all unit tests pass
- [x] `TestRustReference` — no regressions
- [x] `TestSpirvValBinary` — 164/164 (100%)
- [x] `TestBackendReuse` — byte-exact reuse verification
- [x] `golangci-lint` — 0 issues
- [ ] CI