### PR TITLE
feat(dxil): DXIL backend — direct DXIL generation from naga IR (experimental)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,21 +7,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.0] - 2026-04-06
+
 ### Added
 
-- **DXIL backend (experimental)** — Direct DXIL generation from naga IR for DX12
-  Shader Model 6.0. Eliminates FXC/DXC dependency entirely. Pure Go, zero external
-  dependencies. 190 tests, ~12.5K LOC. Public API: `dxil.Compile()`, `dxil.DefaultOptions()`.
-  - Phase 0: LLVM 3.7 bitcode writer, module builder, DXBC container, BYPASS hash
-  - Phase 1a: naga IR → DXIL lowering (type mapping, scalarized vectors, I/O via dx.op)
-  - Phase 1b: multi-arg math (min/max/clamp/dot/cross/mix/fma/smoothstep), type casts
-    (10 LLVM cast opcodes), control flow (basic blocks with br/br_cond, loops with
-    back edges, break/continue), local variables (alloca+load+store), swizzle,
-    derivatives (dx.op.derivCoarseX/Y, derivFineX/Y), relational (isNaN, isInf),
-    error hardening (unsupported features return errors, not silent skip)
-  - Phase 1c: resource bindings (dx.op.createHandle for CBV/SRV/Sampler), texture
-    sampling (dx.op.sample), I/O signatures (ISG1/OSG1), pipeline state validation
-    (PSV0), semantic mapping (SV_Position, TEXCOORD, SV_Target), dx.resources metadata
+- **DXIL backend (experimental)** — First Pure Go DXIL generator. Direct DXIL
+  generation from naga IR for DX12 Shader Model 6.0. Eliminates FXC/DXC compiler
+  dependency entirely. Zero CGO, zero external dependencies.
+  **Verified: 2400+ frames at 60 FPS on D3D12 (Intel Iris Xe).**
+  Rust naga has not implemented this (open issue since 2020).
+  190 tests, ~12.5K LOC. Public API: `dxil.Compile()`, `dxil.DefaultOptions()`.
+  - LLVM 3.7 bitcode writer with VBR encoding, nested blocks, abbreviation records
+  - DXBC container with DXIL, ISG1, OSG1, PSV0, SFI0, HASH parts
+  - BYPASS hash (Agility SDK 1.615+, January 2025) — no dxil.dll signing needed
+  - Full expression lowering: literals, binary/unary ops, compose, access, splat,
+    select, load/store, swizzle, derivatives, relational, type casts (10 LLVM
+    cast opcodes), math intrinsics (30+ functions including min/max/clamp/dot/
+    cross/mix/fma/smoothstep/pow/length/distance/normalize)
+  - Control flow: LLVM basic blocks with br/br_cond, loops with back edges,
+    break/continue via loop context stack, BreakIf support
+  - Local variables: alloca + load + store with proper bitcode serialization
+  - Resource bindings: dx.op.createHandle(57) for CBV/SRV/Sampler,
+    dx.op.sample(60) for texture sampling, dx.resources metadata
+  - I/O signatures: ISG1/OSG1 with semantic mapping (SV_Position, TEXCOORD,
+    SV_Target, SV_VertexID, SV_InstanceID, SV_IsFrontFace, SV_Depth)
+  - Pipeline state validation: PSV0 with runtime info, shader stage, wave lanes
+  - Vector scalarization: DXIL has no native vectors — vec4 = 4 separate values,
+    per-component tracking via exprComponents map
+  - dx.op intrinsic system: overload-typed function declarations, lazy caching
+  - Value ID remapping: emitter local IDs → serializer global numbering via finalize()
+  - Error hardening: unsupported features return errors (not silent skip)
 
 ## [0.16.6] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,11 +9,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **DXIL backend Phase 0** — LLVM 3.7 bitcode writer + DXBC container PoC.
-  Pure Go, zero external dependencies. Bit-level bitcode writer (VBR, blocks,
-  records), module builder (types, functions, metadata), full serialization,
-  DXBC container assembly with BYPASS hash. 47 tests, 2959 LOC.
-  Public API: `dxil.Compile()`, `dxil.DefaultOptions()` (stub).
+- **DXIL backend Phase 0+1** — Direct DXIL generation from naga IR. Pure Go,
+  zero external dependencies. Phase 0: LLVM 3.7 bitcode writer, module builder,
+  DXBC container, BYPASS hash (47 tests). Phase 1: naga IR → DXIL lowering for
+  vertex + fragment shaders — type mapping (scalarized vectors), entry point I/O
+  (dx.op.loadInput/storeOutput), expression lowering, statement lowering.
+  82 tests, 6357 LOC. All output validated via `dxc.exe -dumpbin`.
+  Public API: `dxil.Compile()`, `dxil.DefaultOptions()`.
   All implementation in `dxil/internal/` from day one.
 
 ## [0.16.6] - 2026-04-05

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,14 +9,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
-- **DXIL backend Phase 0+1** — Direct DXIL generation from naga IR. Pure Go,
-  zero external dependencies. Phase 0: LLVM 3.7 bitcode writer, module builder,
-  DXBC container, BYPASS hash (47 tests). Phase 1: naga IR → DXIL lowering for
-  vertex + fragment shaders — type mapping (scalarized vectors), entry point I/O
-  (dx.op.loadInput/storeOutput), expression lowering, statement lowering.
-  82 tests, 6357 LOC. All output validated via `dxc.exe -dumpbin`.
-  Public API: `dxil.Compile()`, `dxil.DefaultOptions()`.
-  All implementation in `dxil/internal/` from day one.
+- **DXIL backend (experimental)** — Direct DXIL generation from naga IR for DX12
+  Shader Model 6.0. Eliminates FXC/DXC dependency entirely. Pure Go, zero external
+  dependencies. 190 tests, ~12.5K LOC. Public API: `dxil.Compile()`, `dxil.DefaultOptions()`.
+  - Phase 0: LLVM 3.7 bitcode writer, module builder, DXBC container, BYPASS hash
+  - Phase 1a: naga IR → DXIL lowering (type mapping, scalarized vectors, I/O via dx.op)
+  - Phase 1b: multi-arg math (min/max/clamp/dot/cross/mix/fma/smoothstep), type casts
+    (10 LLVM cast opcodes), control flow (basic blocks with br/br_cond, loops with
+    back edges, break/continue), local variables (alloca+load+store), swizzle,
+    derivatives (dx.op.derivCoarseX/Y, derivFineX/Y), relational (isNaN, isInf),
+    error hardening (unsupported features return errors, not silent skip)
+  - Phase 1c: resource bindings (dx.op.createHandle for CBV/SRV/Sampler), texture
+    sampling (dx.op.sample), I/O signatures (ISG1/OSG1), pipeline state validation
+    (PSV0), semantic mapping (SV_Position, TEXCOORD, SV_Target), dx.resources metadata
 
 ## [0.16.6] - 2026-04-05
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   all state without deallocating (Go 1.21+ `clear()` keeps map capacity).
   `Compile()` calls `Reset()` internally. Small shaders: 4.9× fewer allocs
   (68→14), 14× fewer bytes (17KB→1.2KB). Reuse benchmarks included.
+- **Lowerer/Parser pre-sizing** — Expression, statement, declaration slices
+  pre-allocated based on AST size estimates. TypeRegistry capacity hints.
+  Modest improvement (-6 allocs/op) — interface boxing remains the main bottleneck.
 
 ## [0.16.4] - 2026-04-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,17 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+### Added
+
+- **DXIL backend Phase 0** — LLVM 3.7 bitcode writer + DXBC container PoC.
+  Pure Go, zero external dependencies. Bit-level bitcode writer (VBR, blocks,
+  records), module builder (types, functions, metadata), full serialization,
+  DXBC container assembly with BYPASS hash. 47 tests, 2959 LOC.
+  Public API: `dxil.Compile()`, `dxil.DefaultOptions()` (stub).
+  All implementation in `dxil/internal/` from day one.
+
 ## [0.16.6] - 2026-04-05
 
 ### Performance

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 | **Outputs** | SPIR-V, MSL, GLSL, HLSL, DXIL (experimental) |
 | **Compute** | Storage buffers, workgroups, atomics, barriers, subgroup operations |
 | **Ray Tracing** | Ray query types, acceleration structures, 7 ray query builtins |
-| **Compatibility** | **144/144 (100%)** reference shaders compile. Five-layer exact match: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 58/58** — complete Rust naga parity on all backends |
+| **Compatibility** | **144/144 (100%)** reference shaders compile. Five-layer exact match: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 72/72** — complete Rust naga parity on all backends |
 | **Build** | Zero CGO, single binary |
 
 ---
@@ -47,7 +47,7 @@
 
 - **Pure Go** — No CGO, no external dependencies
 - **WGSL Frontend** — Full lexer and parser (120+ tokens), 48 short type aliases (`vec3f`, `mat4x4f`, etc.), abstract constructors (`vec3(1,2,3)`)
-- **Rust Naga Compatibility** — **144/144 (100%)** reference shaders compile. Five-layer exact match: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 58/58** — complete Rust naga parity on all backends. 164 snapshot tests with 994 golden outputs
+- **Rust Naga Compatibility** — **144/144 (100%)** reference shaders compile. Five-layer exact match: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 72/72** — complete Rust naga parity on all backends. 164 snapshot tests with 994 golden outputs
 - **IR** — Complete intermediate representation (expressions, statements, types)
 - **Compute Shaders** — Storage buffers, workgroup memory, `@workgroup_size`
 - **Atomic Operations** — atomicAdd, atomicSub, atomicMin, atomicMax, atomicCompareExchangeWeak
@@ -166,8 +166,11 @@ mslCode, _, _ := msl.Compile(module, msl.DefaultOptions())
 // Generate GLSL (OpenGL)
 glslCode, _, _ := glsl.Compile(module, glsl.DefaultOptions())
 
-// Generate HLSL (DirectX)
+// Generate HLSL (DirectX 11/12)
 hlslCode, _, _ := hlsl.Compile(module, hlsl.DefaultOptions())
+
+// Generate DXIL (DirectX 12, SM 6.0 — experimental)
+dxilBytes, _ := dxil.Compile(module, dxil.DefaultOptions())
 ```
 
 ### Individual Stages
@@ -331,7 +334,7 @@ See [ROADMAP.md](ROADMAP.md) for detailed development plans.
 
 ### Rust Naga Compatibility
 
-naga is tested against **all 144 reference WGSL shaders** from the [Rust naga](https://github.com/gfx-rs/naga) test suite — **100% compatibility** across all five layers: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 58/58** exact output match. Total: 164 test shaders with 994 golden outputs.
+naga is tested against **all 144 reference WGSL shaders** from the [Rust naga](https://github.com/gfx-rs/naga) test suite — **100% compatibility** across all five layers: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 72/72** exact output match. Total: 164 test shaders with 994 golden outputs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <p align="center">
   <strong>Pure Go Shader Compiler</strong><br>
-  WGSL to SPIR-V, MSL, GLSL, and HLSL. Zero CGO.
+  WGSL to SPIR-V, MSL, GLSL, HLSL, and DXIL. Zero CGO.
 </p>
 
 <p align="center">
@@ -35,7 +35,7 @@
 | Category | Capabilities |
 |----------|--------------|
 | **Input** | Full WGSL parser (120+ tokens), 48 short type aliases (`vec3f`, `mat4x4f`...), abstract constructors |
-| **Outputs** | SPIR-V, MSL, GLSL, HLSL |
+| **Outputs** | SPIR-V, MSL, GLSL, HLSL, DXIL (experimental) |
 | **Compute** | Storage buffers, workgroups, atomics, barriers, subgroup operations |
 | **Ray Tracing** | Ray query types, acceleration structures, 7 ray query builtins |
 | **Compatibility** | **144/144 (100%)** reference shaders compile. Five-layer exact match: **IR 144/144**, **SPIR-V 87/87**, **MSL 91/91**, **GLSL 68/68**, **HLSL 58/58** — complete Rust naga parity on all backends |
@@ -62,6 +62,7 @@
 - **MSL Backend** — Metal Shading Language output for macOS/iOS (**91/91 exact Rust naga parity**), vertex pulling transform, external textures, override pipeline constants
 - **GLSL Backend** — OpenGL Shading Language for OpenGL 3.3+, ES 3.0+ (**68/68 exact Rust naga parity**), dead code elimination, ProcessOverrides, image bounds checking
 - **HLSL Backend** — High-Level Shading Language for DirectX 11/12 (**58/58 exact Rust naga parity**)
+- **DXIL Backend** (experimental) — Direct DXIL generation from naga IR. LLVM 3.7 bitcode with dx.op intrinsics, DXBC container with BYPASS hash. Vertex + fragment shaders, SM 6.0. Eliminates FXC/DXC dependency. `dxil.Compile()` API. ~12K LOC, 190 tests.
 - **Type Conversions** — Scalar constructors `f32(x)`, `u32(y)`, `i32(z)` with correct SPIR-V opcodes
 - **Bitcast** — `bitcast<T>(expr)` for reinterpreting bit patterns between types
 - **Warnings** — Unused variable detection with `_` prefix exception

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,17 +19,18 @@
 
 ---
 
-## Current State: v0.16.6 (2026-04-05)
+## Current State: v0.17.0 (2026-04-06)
 
-✅ **Production-ready** shader compiler (~90K LOC) with **complete Rust naga parity**
-and **100% SPIR-V binary validation**:
+✅ **Production-ready** shader compiler (~102K LOC) with **complete Rust naga parity**,
+**100% SPIR-V binary validation**, and **experimental DXIL backend**:
 
 ### What We Have
 
 - **Full WGSL frontend** — Lexer (120+ tokens), parser, AST → IR lowerer
-- **4 backend outputs** — SPIR-V, MSL, GLSL, HLSL — all at 100% Rust naga golden parity
+- **5 backend outputs** — SPIR-V, MSL, GLSL, HLSL — all at 100% Rust naga golden parity. DXIL (experimental) — first Pure Go DXIL generator
 - **164/164 SPIR-V binary validation** — every shader compiles and passes spirv-val (100%)
-- **Five-layer exact match** — IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 58/58
+- **Five-layer exact match** — IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 72/72
+- **DXIL backend** — Direct DXIL generation (SM 6.0), verified 2400+ frames at 60 FPS on D3D12. Eliminates FXC/DXC dependency. ~12.5K LOC, 190 tests. Rust naga has not implemented this (open issue since 2020)
 - **100+ WGSL built-in functions** — math, geometric, bit manipulation, packing, derivatives
 - **Compute shaders** — atomics (int32/int64/float32), barriers, workgroups, runtime-sized arrays
 - **Ray tracing** — ray query types, acceleration structures, 7 ray query builtins

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -19,7 +19,7 @@
 
 ---
 
-## Current State: v0.16.1 (2026-04-04)
+## Current State: v0.16.6 (2026-04-05)
 
 ✅ **Production-ready** shader compiler (~90K LOC) with **complete Rust naga parity**
 and **100% SPIR-V binary validation**:
@@ -62,10 +62,10 @@ and **100% SPIR-V binary validation**:
 
 | Task | Priority | Effort | Description |
 |------|----------|--------|-------------|
-| **DXIL-000: Bitcode writer** | P1 | 8 | ✅ Done. LLVM 3.7 bitcode writer, module builder, DXBC container, BYPASS hash. 47 tests. |
-| **DXIL-001: MVP vertex+fragment** | P1 | 13 | naga IR → DXIL for basic rendering (`dxil/internal/emit/`) |
-| **DXIL-002: Compute shaders** | P2 | 5 | UAV, atomics, barriers for GPU compute |
-| **DXIL-003: SM 6.x features** | P3 | ongoing | Wave intrinsics, f16, mesh shaders, dynamic resources |
+| **DXIL Phase 0: Bitcode writer** | P1 | 8 | ✅ Done. LLVM 3.7 bitcode writer, module builder, DXBC container, BYPASS hash. |
+| **DXIL Phase 1: Vertex+fragment** | P1 | 21 | ✅ Done. Full IR → DXIL lowering: math, casts, control flow, locals, resources, signatures. 190 tests, ~12.5K LOC. |
+| **DXIL Phase 2: Compute shaders** | P2 | 5 | UAV, atomics, barriers, thread ID intrinsics |
+| **DXIL Phase 3: SM 6.x features** | P3 | ongoing | Wave intrinsics, f16, mesh shaders, dynamic resources |
 
 ### v1.0.0 — Stable Release
 
@@ -78,7 +78,7 @@ and **100% SPIR-V binary validation**:
 | Subgroup operations | ✅ Done | Ballot, shuffle, broadcast, quad |
 | Mesh shaders | ✅ Done | MeshEXT/TaskEXT |
 | Internal packages | Planned | ARCH-001: `internal/` for all backends |
-| DXIL backend | Planned | Direct DXIL, no FXC dependency |
+| DXIL backend | ✅ Phase 1 done | Direct DXIL, no FXC dependency (~12.5K LOC, 190 tests) |
 | API stability guarantee | Planned | Semantic versioning contract |
 | Test coverage 80%+ | Planned | awesome-go requirement, after ARCH-001 |
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -62,7 +62,7 @@ and **100% SPIR-V binary validation**:
 
 | Task | Priority | Effort | Description |
 |------|----------|--------|-------------|
-| **DXIL-000: Bitcode writer** | P1 | 8 | LLVM 3.7 bitcode writer in pure Go (`dxil/internal/bitcode/`) |
+| **DXIL-000: Bitcode writer** | P1 | 8 | ✅ Done. LLVM 3.7 bitcode writer, module builder, DXBC container, BYPASS hash. 47 tests. |
 | **DXIL-001: MVP vertex+fragment** | P1 | 13 | naga IR → DXIL for basic rendering (`dxil/internal/emit/`) |
 | **DXIL-002: Compute shaders** | P2 | 5 | UAV, atomics, barriers for GPU compute |
 | **DXIL-003: SM 6.x features** | P3 | ongoing | Wave intrinsics, f16, mesh shaders, dynamic resources |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -8,7 +8,7 @@ naga is a shader compiler written entirely in Go. It compiles WGSL (WebGPU Shadi
 to multiple backend formats (SPIR-V, MSL, GLSL, HLSL) without requiring CGO or external
 dependencies.
 
-**Core principle: one IR, four backends.**
+**Core principle: one IR, five backends.**
 
 ```
                      ┌──────────────────┐
@@ -46,20 +46,20 @@ dependencies.
                      │    Validator     │  ir/validate.go
                      └────────┬─────────┘
                               │
-           ┌──────────┬───────┴───────┬──────────┐
-           │          │               │          │
-    ┌──────▼──────┐ ┌─▼───┐      ┌────▼───┐ ┌────▼───┐
-    │   SPIR-V    │ │ MSL │      │  GLSL  │ │  HLSL  │
-    │  (binary)   │ │     │      │        │ │        │
-    └──────┬──────┘ └──┬──┘      └────┬───┘ └────┬───┘
-           │           │              │          │
-        Vulkan      Metal          OpenGL     DirectX
+           ┌──────────┬───────┴───────┬──────────┬─────────┐
+           │          │               │          │         │
+    ┌──────▼──────┐ ┌─▼───┐      ┌────▼───┐ ┌────▼───┐ ┌───▼────┐
+    │   SPIR-V    │ │ MSL │      │  GLSL  │ │  HLSL  │ │  DXIL  │
+    │  (binary)   │ │     │      │        │ │  (text)│ │(binary)│
+    └──────┬──────┘ └──┬──┘      └────┬───┘ └────┬───┘ └───┬────┘
+           │           │              │          │         │
+        Vulkan      Metal          OpenGL    DX11/12    DX12 (SM6)
 ```
 
 ## Package Structure
 
 ```
-naga/                              ~90K LOC total
+naga/                              ~102K LOC total
 ├── naga.go                        # Public API: Compile, Parse, Lower, Validate, GenerateSPIRV
 ├── wgsl/                          # WGSL frontend (~19.5K LOC)
 │   ├── token.go                   # 120+ token types (incl. f16, i64, u64, f64)
@@ -112,12 +112,13 @@ naga/                              ~90K LOC total
 │   ├── functions.go               # Entry points with semantics
 │   └── keywords.go                # HLSL reserved words
 │
-├── dxil/                          # DXIL backend (Phase 0 — bitcode PoC, ~3K LOC)
+├── dxil/                          # DXIL backend (experimental, ~12.5K LOC)
 │   ├── dxil.go                    # Public API: Compile, Options (2 symbols only)
 │   └── internal/                  # ALL implementation internal
 │       ├── bitcode/               # LLVM 3.7 bit-level writer (VBR, blocks, records)
 │       ├── module/                # In-memory DXIL module + bitcode serialization
-│       └── container/             # DXBC container assembly + BYPASS hash
+│       ├── container/             # DXBC container (DXIL, ISG1, OSG1, PSV0, SFI0, HASH)
+│       └── emit/                  # naga IR → DXIL lowering (expressions, statements, I/O, resources)
 │
 └── cmd/
     ├── nagac/                     # CLI compiler

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,6 +112,13 @@ naga/                              ~90K LOC total
 │   ├── functions.go               # Entry points with semantics
 │   └── keywords.go                # HLSL reserved words
 │
+├── dxil/                          # DXIL backend (Phase 0 — bitcode PoC, ~3K LOC)
+│   ├── dxil.go                    # Public API: Compile, Options (2 symbols only)
+│   └── internal/                  # ALL implementation internal
+│       ├── bitcode/               # LLVM 3.7 bit-level writer (VBR, blocks, records)
+│       ├── module/                # In-memory DXIL module + bitcode serialization
+│       └── container/             # DXBC container assembly + BYPASS hash
+│
 └── cmd/
     ├── nagac/                     # CLI compiler
     ├── spvdis/                    # SPIR-V disassembler

--- a/dxil/dxil.go
+++ b/dxil/dxil.go
@@ -10,8 +10,8 @@
 // details (bitcode writer, module builder, container assembly) are in
 // internal sub-packages.
 //
-// Current status: Phase 0 — bitcode writer and container PoC.
-// The Compile function is not yet implemented; it will be added in Phase 1.
+// Current status: Phase 1 — vertex + fragment shader lowering (SM 6.0).
+// The Compile function translates naga IR entry points to DXIL bytecode.
 //
 // Reference implementations:
 //   - Mesa's src/microsoft/compiler/ (C, MIT license)
@@ -22,6 +22,9 @@ package dxil
 import (
 	"fmt"
 
+	"github.com/gogpu/naga/dxil/internal/container"
+	"github.com/gogpu/naga/dxil/internal/emit"
+	"github.com/gogpu/naga/dxil/internal/module"
 	"github.com/gogpu/naga/ir"
 )
 
@@ -67,8 +70,67 @@ func DefaultOptions() Options {
 // Compile translates a naga IR module to DXIL bytecode wrapped in
 // a DXBC container.
 //
-// This function is not yet implemented (Phase 0). It will be available
-// in Phase 1 when the naga IR to DXIL lowering is complete.
-func Compile(_ *ir.Module, _ Options) ([]byte, error) {
-	return nil, fmt.Errorf("dxil: backend not yet implemented (Phase 0)")
+// The compilation pipeline:
+//  1. Emit: naga IR -> DXIL module (types, expressions, statements)
+//  2. Serialize: DXIL module -> LLVM 3.7 bitcode
+//  3. Container: wrap bitcode in DXBC with program header and hash
+//
+// The result is a valid DXBC container that can be loaded by D3D12
+// or inspected with dxc.exe -dumpbin.
+func Compile(irModule *ir.Module, opts Options) ([]byte, error) {
+	if irModule == nil {
+		return nil, fmt.Errorf("dxil: nil IR module")
+	}
+	if len(irModule.EntryPoints) == 0 {
+		return nil, fmt.Errorf("dxil: module has no entry points")
+	}
+
+	// Step 1: Emit naga IR -> DXIL module.
+	emitOpts := emit.EmitOptions{
+		ShaderModelMajor: opts.ShaderModel.Major,
+		ShaderModelMinor: opts.ShaderModel.Minor,
+	}
+	mod, err := emit.Emit(irModule, emitOpts)
+	if err != nil {
+		return nil, fmt.Errorf("dxil: emit: %w", err)
+	}
+
+	// Step 2: Serialize DXIL module -> LLVM 3.7 bitcode.
+	bitcodeData := module.Serialize(mod)
+	if len(bitcodeData) == 0 {
+		return nil, fmt.Errorf("dxil: serialization produced empty bitcode")
+	}
+
+	// Step 3: Wrap in DXBC container.
+	ep := &irModule.EntryPoints[0]
+	shaderKind := stageToContainerKind(ep.Stage)
+
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(shaderKind, 1, opts.ShaderModel.Minor, bitcodeData)
+	c.AddHashPart()
+
+	containerData := c.Bytes()
+
+	// Apply BYPASS hash if requested.
+	if opts.UseBypassHash {
+		container.SetBypassHash(containerData)
+	}
+
+	return containerData, nil
+}
+
+// stageToContainerKind maps naga ShaderStage to the DXIL shader kind
+// value used in the DXBC container program header.
+func stageToContainerKind(stage ir.ShaderStage) uint32 {
+	switch stage {
+	case ir.StageVertex:
+		return uint32(module.VertexShader)
+	case ir.StageFragment:
+		return uint32(module.PixelShader)
+	case ir.StageCompute:
+		return uint32(module.ComputeShader)
+	default:
+		return uint32(module.VertexShader)
+	}
 }

--- a/dxil/dxil.go
+++ b/dxil/dxil.go
@@ -108,6 +108,17 @@ func Compile(irModule *ir.Module, opts Options) ([]byte, error) {
 	c := container.New()
 	c.AddFeaturesPart(0)
 	c.AddDXILPart(shaderKind, 1, opts.ShaderModel.Minor, bitcodeData)
+
+	// Step 4: Add I/O signatures and pipeline state.
+	isFragment := ep.Stage == ir.StageFragment
+	inputSig, outputSig := buildSignatures(irModule, ep, isFragment)
+	if len(inputSig) > 0 {
+		c.AddInputSignature(inputSig)
+	}
+	if len(outputSig) > 0 {
+		c.AddOutputSignature(outputSig)
+	}
+	c.AddPSV0(buildPSV(ep, isFragment, len(inputSig), len(outputSig)))
 	c.AddHashPart()
 
 	containerData := c.Bytes()
@@ -118,6 +129,88 @@ func Compile(irModule *ir.Module, opts Options) ([]byte, error) {
 	}
 
 	return containerData, nil
+}
+
+// buildSignatures extracts input/output signature elements from an entry point.
+func buildSignatures(irMod *ir.Module, ep *ir.EntryPoint, isFragment bool) ([]container.SignatureElement, []container.SignatureElement) {
+	var inputs, outputs []container.SignatureElement
+	register := uint32(0)
+
+	// Inputs from function arguments.
+	for _, arg := range ep.Function.Arguments {
+		if arg.Binding == nil {
+			continue
+		}
+		elems := bindingToSignatureElements(irMod, *arg.Binding, arg.Type, register, false, isFragment)
+		inputs = append(inputs, elems...)
+		register += uint32(len(elems)) //nolint:gosec // bounded by argument count
+	}
+
+	// Outputs from function result.
+	if ep.Function.Result != nil {
+		resultType := irMod.Types[ep.Function.Result.Type]
+		if st, ok := resultType.Inner.(ir.StructType); ok {
+			// Struct result: each member is a separate output.
+			outReg := uint32(0)
+			for _, member := range st.Members {
+				if member.Binding == nil {
+					continue
+				}
+				elems := bindingToSignatureElements(irMod, *member.Binding, member.Type, outReg, true, isFragment)
+				outputs = append(outputs, elems...)
+				outReg += uint32(len(elems)) //nolint:gosec // bounded by struct members
+			}
+		} else if ep.Function.Result.Binding != nil {
+			// Scalar/vector result with binding.
+			outputs = bindingToSignatureElements(irMod, *ep.Function.Result.Binding, ep.Function.Result.Type, 0, true, isFragment)
+		}
+	}
+
+	return inputs, outputs
+}
+
+// bindingToSignatureElements converts a naga binding to signature elements.
+func bindingToSignatureElements(_ *ir.Module, binding ir.Binding, typeHandle ir.TypeHandle, register uint32, isOutput, isFragment bool) []container.SignatureElement {
+	var sem container.SemanticMapping
+	if isOutput {
+		sem = container.MapBindingToSemantic(binding, true, isFragment)
+	} else {
+		sem = container.MapBindingToSemantic(binding, false, isFragment)
+	}
+
+	// Default: float32, xyzw mask for vec4.
+	elem := container.SignatureElement{
+		SemanticName:  sem.SemanticName,
+		SemanticIndex: sem.SemanticIndex,
+		SystemValue:   sem.SystemValue,
+		CompType:      container.CompTypeFloat32,
+		Register:      register,
+		Mask:          0x0F, // xyzw
+		RWMask:        0x0F,
+	}
+	_ = typeHandle // TODO: refine mask/compType from actual type
+
+	return []container.SignatureElement{elem}
+}
+
+// buildPSV creates pipeline state validation info for an entry point.
+func buildPSV(ep *ir.EntryPoint, isFragment bool, inputCount, outputCount int) container.PSVInfo {
+	info := container.PSVInfo{
+		ShaderStage:       container.PSVVertex,
+		MinWaveLaneCount:  0,
+		MaxWaveLaneCount:  0xFFFFFFFF,
+		SigInputElements:  uint8(inputCount),  //nolint:gosec // bounded by entry point args
+		SigOutputElements: uint8(outputCount), //nolint:gosec // bounded by entry point results
+	}
+	if isFragment {
+		info.ShaderStage = container.PSVPixel
+	} else {
+		// Vertex shader: check if SV_Position is in outputs.
+		if ep.Function.Result != nil {
+			info.OutputPositionPresent = true
+		}
+	}
+	return info
 }
 
 // stageToContainerKind maps naga ShaderStage to the DXIL shader kind

--- a/dxil/dxil.go
+++ b/dxil/dxil.go
@@ -1,0 +1,74 @@
+// Package dxil implements a DXIL (DirectX Intermediate Language) backend
+// for the naga shader compiler.
+//
+// DXIL is LLVM 3.7 bitcode with DirectX-specific metadata and dx.op
+// intrinsic calls, wrapped in a DXBC container. This backend generates
+// DXIL directly from naga IR, eliminating the need for external HLSL
+// compilers (FXC/DXC).
+//
+// This package provides the public API surface. All implementation
+// details (bitcode writer, module builder, container assembly) are in
+// internal sub-packages.
+//
+// Current status: Phase 0 — bitcode writer and container PoC.
+// The Compile function is not yet implemented; it will be added in Phase 1.
+//
+// Reference implementations:
+//   - Mesa's src/microsoft/compiler/ (C, MIT license)
+//   - LLVM 3.7 Bitcode Format: https://releases.llvm.org/3.7.1/docs/BitCodeFormat.html
+//   - INF-0004 Validator Hashing: https://github.com/microsoft/hlsl-specs
+package dxil
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/ir"
+)
+
+// ShaderModel represents a DXIL shader model version.
+type ShaderModel struct {
+	Major uint32
+	Minor uint32
+}
+
+// Predefined shader model versions.
+var (
+	SM6_0 = ShaderModel{6, 0}
+	SM6_1 = ShaderModel{6, 1}
+	SM6_2 = ShaderModel{6, 2}
+	SM6_3 = ShaderModel{6, 3}
+	SM6_4 = ShaderModel{6, 4}
+	SM6_5 = ShaderModel{6, 5}
+	SM6_6 = ShaderModel{6, 6}
+	SM6_7 = ShaderModel{6, 7}
+	SM6_8 = ShaderModel{6, 8}
+	SM6_9 = ShaderModel{6, 9}
+)
+
+// Options configures DXIL compilation.
+type Options struct {
+	// ShaderModel is the target shader model version.
+	ShaderModel ShaderModel
+
+	// UseBypassHash uses the BYPASS sentinel hash instead of the
+	// retail validator hash. Requires AgilitySDK 1.615+ (January 2025).
+	// Default: true.
+	UseBypassHash bool
+}
+
+// DefaultOptions returns the default DXIL compilation options.
+func DefaultOptions() Options {
+	return Options{
+		ShaderModel:   SM6_0,
+		UseBypassHash: true,
+	}
+}
+
+// Compile translates a naga IR module to DXIL bytecode wrapped in
+// a DXBC container.
+//
+// This function is not yet implemented (Phase 0). It will be available
+// in Phase 1 when the naga IR to DXIL lowering is complete.
+func Compile(_ *ir.Module, _ Options) ([]byte, error) {
+	return nil, fmt.Errorf("dxil: backend not yet implemented (Phase 0)")
+}

--- a/dxil/dxil_integration_test.go
+++ b/dxil/dxil_integration_test.go
@@ -1,0 +1,611 @@
+package dxil
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogpu/naga/dxil/internal/container"
+	"github.com/gogpu/naga/dxil/internal/emit"
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
+// TestCompile_EmptyVertex tests the simplest possible vertex shader:
+// @vertex fn main() {}
+func TestCompile_EmptyVertex(t *testing.T) {
+	irMod := &ir.Module{
+		Types: []ir.Type{},
+	}
+
+	fn := ir.Function{
+		Name: "main",
+	}
+
+	irMod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	data, err := Compile(irMod, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	if len(data) < 32 {
+		t.Fatalf("output too small: %d bytes", len(data))
+	}
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != container.FourCCDXBC {
+		t.Errorf("container magic: got 0x%08X, want DXBC", magic)
+	}
+
+	// Write for DXC validation.
+	writeToTmp(t, data, "test_empty_vs.dxil")
+}
+
+// TestDXC_ManualModuleWithConstants builds a module by hand with constants
+// to verify DXC accepts our constant encoding.
+func TestDXC_ManualModuleWithConstants(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	funcTy := mod.GetFunctionType(voidTy, nil)
+
+	mainFn := mod.AddFunction("main", funcTy, false)
+	bb := mainFn.AddBasicBlock("entry")
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Add a constant that won't be referenced by the function body.
+	mod.AddIntConst(i32Ty, 42)
+
+	// Metadata.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_manual_constants.dxil")
+}
+
+// TestDXC_ManualModuleWithDeclOnly builds a module with a dx.op function
+// declaration but no call, to verify function declaration encoding.
+func TestDXC_ManualModuleWithDeclOnly(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	f32Ty := mod.GetFloatType(32)
+	i8Ty := mod.GetIntType(8)
+
+	mainFuncTy := mod.GetFunctionType(voidTy, nil)
+	loadInputFuncTy := mod.GetFunctionType(f32Ty, []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, i32Ty})
+
+	// Note: in DXIL, function declarations come before definitions.
+	mod.AddFunction("dx.op.loadInput.f32", loadInputFuncTy, true)
+	mainFn := mod.AddFunction("main", mainFuncTy, false)
+
+	bb := mainFn.AddBasicBlock("entry")
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_manual_decl_only.dxil")
+}
+
+// TestDXC_ManualModuleWithDeclAndCall builds a module with a dx.op function
+// declaration and a call to it, to isolate the call encoding.
+func TestDXC_ManualModuleWithDeclAndCall(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	f32Ty := mod.GetFloatType(32)
+	i8Ty := mod.GetIntType(8)
+
+	// Function types.
+	mainFuncTy := mod.GetFunctionType(voidTy, nil) // void()
+
+	// dx.op.loadInput.f32: float(i32, i32, i32, i8, i32)
+	loadInputFuncTy := mod.GetFunctionType(f32Ty, []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, i32Ty})
+
+	// Add functions. DXC expects declarations BEFORE definitions.
+	loadInputFn := mod.AddFunction("dx.op.loadInput.f32", loadInputFuncTy, true)
+	mainFn := mod.AddFunction("main", mainFuncTy, false)
+
+	// Constants for the call.
+	_ = mod.AddIntConst(i32Ty, 4) // opcodeConst: OpLoadInput = 4
+	_ = mod.AddIntConst(i32Ty, 0) // inputIDConst: input 0
+	_ = mod.AddIntConst(i32Ty, 0) // rowConst: row 0 (dedup'd with inputID)
+	_ = mod.AddIntConst(i32Ty, 0) // colConst: col 0 (dedup'd)
+	mod.Constants = append(mod.Constants, &module.Constant{ConstType: i32Ty, IsUndef: true})
+
+	// Build main function body: just a loadInput call + ret void.
+	bb := mainFn.AddBasicBlock("entry")
+
+	// The call instruction operands use global value IDs.
+	// Global: loadInputFn(0), mainFn(1), opcodeConst(2), inputIDConst(3),
+	//         rowConst(4), colConst(5), undefConst(6)
+	// Function body starts at value ID 7.
+	callInstr := &module.Instruction{
+		Kind:       module.InstrCall,
+		HasValue:   true,
+		ResultType: f32Ty,
+		CalledFunc: loadInputFn,
+		Operands:   []int{2, 3, 4, 5, 6}, // opcodeConst, inputID, row, col, undef
+		ValueID:    7,                    // first value in function body
+	}
+	bb.AddInstruction(callInstr)
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_manual_call.dxil")
+}
+
+// TestDXC_MinimalCall tests the absolute simplest call instruction:
+// declare void @foo()
+// define void @main() { call void @foo(); ret void }
+func TestDXC_MinimalCall(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	voidFuncTy := mod.GetFunctionType(voidTy, nil)
+
+	fooFn := mod.AddFunction("foo", voidFuncTy, true)
+	mainFn := mod.AddFunction("main", voidFuncTy, false)
+
+	bb := mainFn.AddBasicBlock("entry")
+
+	// Call foo(). fooFn has ValueID=0, mainFn has ValueID=1.
+	// No constants, so globalValueCount = 0 (globalvars) + 2 (functions) + 0 (constants before metadata).
+	// But wait, metadata creates constants too.
+	callInstr := &module.Instruction{
+		Kind:       module.InstrCall,
+		HasValue:   false,
+		ResultType: voidTy,
+		CalledFunc: fooFn,
+		Operands:   nil, // no args
+	}
+	bb.AddInstruction(callInstr)
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata (creates constants).
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_minimal_call.dxil")
+}
+
+// TestDXC_CallWithOneArg tests a call with one i32 argument.
+func TestDXC_CallWithOneArg(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	// bar takes one i32 argument.
+	barFuncTy := mod.GetFunctionType(voidTy, []*module.Type{i32Ty})
+	mainFuncTy := mod.GetFunctionType(voidTy, nil)
+
+	barFn := mod.AddFunction("bar", barFuncTy, true)
+	mainFn := mod.AddFunction("main", mainFuncTy, false)
+
+	// Constants.
+	_ = mod.AddIntConst(i32Ty, 42) // argConst, gets ValueID=2 after assignIDs
+
+	bb := mainFn.AddBasicBlock("entry")
+
+	// Values: barFn(0), mainFn(1), argConst(2)
+	// Metadata consts added below: const0(3), const1(4), const6(5)
+	// globalValueCount = 2 + 4 = 6 (after metadata consts added)
+	// Actually: globalValueCount = len(globalVars) + len(functions) + len(constants)
+	// At serialization time: 0 gv + 2 fn + N consts
+
+	// Call bar(42). currentValueID at first instr = globalValueCount.
+	callInstr := &module.Instruction{
+		Kind:       module.InstrCall,
+		HasValue:   false,
+		ResultType: voidTy,
+		CalledFunc: barFn,
+		Operands:   []int{2}, // argConst value ID = 2
+	}
+	bb.AddInstruction(callInstr)
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_call_one_arg.dxil")
+}
+
+// TestDXC_CallWithFiveArgs tests a dx.op.loadInput-style call with 5 args.
+func TestDXC_CallWithFiveArgs(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	f32Ty := mod.GetFloatType(32)
+	i8Ty := mod.GetIntType(8)
+	mainFuncTy := mod.GetFunctionType(voidTy, nil)
+	loadInputFuncTy := mod.GetFunctionType(f32Ty, []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, i32Ty})
+
+	loadInputFn := mod.AddFunction("dx.op.loadInput.f32", loadInputFuncTy, true)
+	mainFn := mod.AddFunction("main", mainFuncTy, false)
+
+	// Constants: 5 of them.
+	_ = mod.AddIntConst(i32Ty, 4)                                                            // [0] opcode = LoadInput
+	_ = mod.AddIntConst(i32Ty, 0)                                                            // [1] inputID
+	_ = mod.AddIntConst(i32Ty, 0)                                                            // [2] row
+	mod.Constants = append(mod.Constants, &module.Constant{ConstType: i8Ty, IntValue: 0})    // [3] col (i8)
+	mod.Constants = append(mod.Constants, &module.Constant{ConstType: i32Ty, IsUndef: true}) // [4] vertexID (undef)
+
+	bb := mainFn.AddBasicBlock("entry")
+
+	// ValueIDs after assignIDs: loadInputFn(0), mainFn(1), consts(2,3,4,5,6)
+	// globalValueCount = 2 + 5 + metadata_consts
+
+	// Metadata constants:
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	// Now total constants = 5 + 3 = 8. GlobalValueCount = 2 + 8 = 10.
+	// Call instruction at currentValueID = 10.
+	callInstr := &module.Instruction{
+		Kind:       module.InstrCall,
+		HasValue:   true,
+		ResultType: f32Ty,
+		CalledFunc: loadInputFn,
+		Operands:   []int{2, 3, 4, 5, 6}, // opcode, inputID, row, col, undef
+		ValueID:    10,
+	}
+	bb.AddInstruction(callInstr)
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata.
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_call_five_args.dxil")
+}
+
+// TestDebug_PassthroughEmitterIDs inspects value IDs after emission
+// to verify correctness.
+func TestDebug_PassthroughEmitterIDs(t *testing.T) {
+	vec4f32Handle := ir.TypeHandle(0)
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	resultBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	retHandle := ir.ExpressionHandle(0)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "pos", Type: vec4f32Handle, Binding: &posBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+	irMod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	data, err := Compile(irMod, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	// Dump the DXIL module internals after emission.
+	// Re-create the module for inspection.
+	emitOpts := emit.EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0}
+	mod, err := emit.Emit(irMod, emitOpts)
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	t.Logf("Functions (%d):", len(mod.Functions))
+	for i, fn := range mod.Functions {
+		t.Logf("  [%d] %s (decl=%v, valueID=%d, typeID=%d)", i, fn.Name, fn.IsDeclaration, fn.ValueID, fn.FuncType.ID)
+	}
+
+	t.Logf("Constants (%d):", len(mod.Constants))
+	for i, c := range mod.Constants {
+		if c.IsUndef {
+			t.Logf("  [%d] undef (type=%v, valueID=%d)", i, c.ConstType.Kind, c.ValueID)
+		} else if c.ConstType.Kind == module.TypeFloat {
+			t.Logf("  [%d] float %f (valueID=%d)", i, c.FloatValue, c.ValueID)
+		} else {
+			t.Logf("  [%d] int %d (valueID=%d)", i, c.IntValue, c.ValueID)
+		}
+	}
+
+	globalCount := len(mod.GlobalVars) + len(mod.Functions) + len(mod.Constants)
+	t.Logf("globalValueCount=%d", globalCount)
+
+	var mainFn *module.Function
+	for _, fn := range mod.Functions {
+		if fn.Name == "main" {
+			mainFn = fn
+			break
+		}
+	}
+	if mainFn != nil {
+		for _, bb := range mainFn.BasicBlocks {
+			for i, instr := range bb.Instructions {
+				t.Logf("  instr[%d]: kind=%d, hasValue=%v, valueID=%d, operands=%v, callee=%v",
+					i, instr.Kind, instr.HasValue, instr.ValueID, instr.Operands,
+					func() string {
+						if instr.CalledFunc != nil {
+							return instr.CalledFunc.Name
+						}
+						return "<nil>"
+					}())
+			}
+		}
+	}
+
+	_ = data // already verified
+}
+
+// TestDXC_StoreOutputShader tests a minimal fragment shader that only
+// calls storeOutput — matching DXC's own output pattern.
+func TestDXC_StoreOutputShader(t *testing.T) {
+	mod := module.NewModule(module.PixelShader)
+
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	f32Ty := mod.GetFloatType(32)
+	i8Ty := mod.GetIntType(8)
+
+	mainFuncTy := mod.GetFunctionType(voidTy, nil)
+	// storeOutput: void(i32 opcode, i32 outputID, i32 row, i8 col, float value)
+	storeOutFuncTy := mod.GetFunctionType(voidTy, []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, f32Ty})
+
+	storeOutFn := mod.AddFunction("dx.op.storeOutput.f32", storeOutFuncTy, true)
+	mainFn := mod.AddFunction("main", mainFuncTy, false)
+
+	// Constants (in order they'll be referenced).
+	_ = mod.AddIntConst(i32Ty, 5) // constOpcode: StoreOutput opcode = 5
+	_ = mod.AddIntConst(i32Ty, 0) // constZeroI32: outputID=0, row=0
+	_ = mod.AddIntConst(i8Ty, 0)  // constZeroI8: col=0
+	_ = mod.AddIntConst(i8Ty, 1)  // constOneI8: col=1
+	_ = mod.AddIntConst(i8Ty, 2)  // constTwoI8: col=2
+	_ = mod.AddIntConst(i8Ty, 3)  // constThreeI8: col=3
+
+	// Float constants for the output color.
+	constOneF32 := &module.Constant{ConstType: f32Ty, FloatValue: 1.0}
+	constZeroF32 := &module.Constant{ConstType: f32Ty, FloatValue: 0.0}
+	mod.Constants = append(mod.Constants, constOneF32, constZeroF32)
+
+	// Metadata constants.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	// Value IDs (after assignIDs):
+	// storeOutFn=0, mainFn=1
+	// constOpcode=2, constZeroI32=3, constZeroI8=4, constOneI8=5,
+	// constTwoI8=6, constThreeI8=7, constOneF32=8, constZeroF32=9,
+	// const0=10, const1=11, const6=12
+	// globalValueCount=13
+
+	bb := mainFn.AddBasicBlock("entry")
+
+	// call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 0, float 1.0)
+	bb.AddInstruction(&module.Instruction{
+		Kind: module.InstrCall, HasValue: false, ResultType: voidTy,
+		CalledFunc: storeOutFn,
+		Operands:   []int{2, 3, 3, 4, 8}, // opcode, 0, 0, col0, 1.0
+	})
+	// call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 1, float 0.0)
+	bb.AddInstruction(&module.Instruction{
+		Kind: module.InstrCall, HasValue: false, ResultType: voidTy,
+		CalledFunc: storeOutFn,
+		Operands:   []int{2, 3, 3, 5, 9}, // opcode, 0, 0, col1, 0.0
+	})
+	// call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 2, float 0.0)
+	bb.AddInstruction(&module.Instruction{
+		Kind: module.InstrCall, HasValue: false, ResultType: voidTy,
+		CalledFunc: storeOutFn,
+		Operands:   []int{2, 3, 3, 6, 9}, // opcode, 0, 0, col2, 0.0
+	})
+	// call void @dx.op.storeOutput.f32(i32 5, i32 0, i32 0, i8 3, float 1.0)
+	bb.AddInstruction(&module.Instruction{
+		Kind: module.InstrCall, HasValue: false, ResultType: voidTy,
+		CalledFunc: storeOutFn,
+		Operands:   []int{2, 3, 3, 7, 8}, // opcode, 0, 0, col3, 1.0
+	})
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Metadata.
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+	mdPS := mod.AddMetadataString("ps")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdSM := mod.AddMetadataTuple([]*module.MetadataNode{mdPS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+	mdMainName := mod.AddMetadataString("main")
+	mdEntry := mod.AddMetadataTuple([]*module.MetadataNode{nil, mdMainName, nil, nil, nil})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	bc := module.Serialize(mod)
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(uint32(module.PixelShader), 1, 0, bc)
+	c.AddHashPart()
+	data := c.Bytes()
+	container.SetBypassHash(data)
+
+	writeToTmp(t, data, "test_storeoutput_ps.dxil")
+}
+
+func writeToTmp(t *testing.T, data []byte, name string) {
+	t.Helper()
+	tmpDir := filepath.Join("..", "tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Logf("warning: could not create tmp dir: %v", err)
+		return
+	}
+	outPath := filepath.Join(tmpDir, name)
+	if err := os.WriteFile(outPath, data, 0o644); err != nil {
+		t.Logf("warning: could not write: %v", err)
+	} else {
+		t.Logf("wrote %d bytes to %s", len(data), outPath)
+	}
+}

--- a/dxil/dxil_test.go
+++ b/dxil/dxil_test.go
@@ -8,12 +8,21 @@ import (
 
 	"github.com/gogpu/naga/dxil/internal/container"
 	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
 )
 
-func TestCompile_NotImplemented(t *testing.T) {
+func TestCompile_NilModule(t *testing.T) {
 	_, err := Compile(nil, DefaultOptions())
 	if err == nil {
-		t.Fatal("expected error from unimplemented Compile")
+		t.Fatal("expected error for nil module")
+	}
+}
+
+func TestCompile_NoEntryPoints(t *testing.T) {
+	irMod := &ir.Module{}
+	_, err := Compile(irMod, DefaultOptions())
+	if err == nil {
+		t.Fatal("expected error for module with no entry points")
 	}
 }
 
@@ -194,4 +203,162 @@ func TestBypassHash(t *testing.T) {
 			t.Errorf("byte %d: got 0x%02X, want 0x01", i, data[i])
 		}
 	}
+}
+
+// TestCompile_PassthroughVertex tests the full compilation pipeline
+// for a passthrough vertex shader.
+func TestCompile_PassthroughVertex(t *testing.T) {
+	vec4f32Handle := ir.TypeHandle(0)
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	resultBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	retHandle := ir.ExpressionHandle(0)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "pos", Type: vec4f32Handle, Binding: &posBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	irMod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	data, err := Compile(irMod, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	// Verify DXBC container structure.
+	if len(data) < 32 {
+		t.Fatalf("output too small: %d bytes", len(data))
+	}
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != container.FourCCDXBC {
+		t.Errorf("container magic: got 0x%08X, want DXBC", magic)
+	}
+
+	fileSize := binary.LittleEndian.Uint32(data[24:28])
+	if fileSize != uint32(len(data)) {
+		t.Errorf("file size: header=%d, actual=%d", fileSize, len(data))
+	}
+
+	// Verify BYPASS hash.
+	for i := 4; i < 20; i++ {
+		if data[i] != 0x01 {
+			t.Errorf("bypass hash byte %d: got 0x%02X, want 0x01", i, data[i])
+			break
+		}
+	}
+
+	// Write to tmp/ for manual DXC validation.
+	tmpDir := filepath.Join("..", "tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Logf("warning: could not create tmp dir: %v", err)
+	} else {
+		outPath := filepath.Join(tmpDir, "test_passthrough_vs.dxil")
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			t.Logf("warning: could not write test file: %v", err)
+		} else {
+			t.Logf("wrote %d bytes to %s", len(data), outPath)
+		}
+	}
+
+	t.Logf("passthrough vertex shader compiled: %d bytes", len(data))
+}
+
+// TestCompile_SimpleFragment tests compilation of a minimal fragment shader.
+func TestCompile_SimpleFragment(t *testing.T) {
+	vec4f32Handle := ir.TypeHandle(0)
+	f32Handle := ir.TypeHandle(1)
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{0, 1, 2, 3}}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	irMod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	data, err := Compile(irMod, DefaultOptions())
+	if err != nil {
+		t.Fatalf("Compile failed: %v", err)
+	}
+
+	if len(data) < 32 {
+		t.Fatalf("output too small: %d bytes", len(data))
+	}
+
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != container.FourCCDXBC {
+		t.Errorf("container magic: got 0x%08X, want DXBC", magic)
+	}
+
+	// Write to tmp/ for manual DXC validation.
+	tmpDir := filepath.Join("..", "tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Logf("warning: could not create tmp dir: %v", err)
+	} else {
+		outPath := filepath.Join(tmpDir, "test_simple_ps.dxil")
+		if err := os.WriteFile(outPath, data, 0o644); err != nil {
+			t.Logf("warning: could not write test file: %v", err)
+		} else {
+			t.Logf("wrote %d bytes to %s", len(data), outPath)
+		}
+	}
+
+	t.Logf("simple fragment shader compiled: %d bytes", len(data))
 }

--- a/dxil/dxil_test.go
+++ b/dxil/dxil_test.go
@@ -1,0 +1,197 @@
+package dxil
+
+import (
+	"encoding/binary"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gogpu/naga/dxil/internal/container"
+	"github.com/gogpu/naga/dxil/internal/module"
+)
+
+func TestCompile_NotImplemented(t *testing.T) {
+	_, err := Compile(nil, DefaultOptions())
+	if err == nil {
+		t.Fatal("expected error from unimplemented Compile")
+	}
+}
+
+func TestDefaultOptions(t *testing.T) {
+	opts := DefaultOptions()
+	if opts.ShaderModel != SM6_0 {
+		t.Errorf("default shader model: got %v, want SM6_0", opts.ShaderModel)
+	}
+	if !opts.UseBypassHash {
+		t.Error("expected UseBypassHash=true by default")
+	}
+}
+
+func TestMinimalDXILModule(t *testing.T) {
+	// Build a minimal DXIL module:
+	// - target triple "dxil-ms-dx"
+	// - one empty vertex shader function @main of type void()
+	// - dx.version = {1, 0}
+	// - dx.shaderModel = {vs, 6, 0}
+	// - dx.entryPoints = {{@main, "main", null, null, null}}
+
+	mod := module.NewModule(module.VertexShader)
+
+	// Create types.
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	funcTy := mod.GetFunctionType(voidTy, nil) // void()
+
+	// Add main function with an empty body that just returns void.
+	mainFn := mod.AddFunction("main", funcTy, false)
+	bb := mainFn.AddBasicBlock("entry")
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Add constants for metadata values.
+	const0 := mod.AddIntConst(i32Ty, 0)
+	const1 := mod.AddIntConst(i32Ty, 1)
+	const6 := mod.AddIntConst(i32Ty, 6)
+
+	// Build metadata:
+	// !dx.version = !{!N} where !N = !{i32 1, i32 0}
+	mdVer1 := mod.AddMetadataValue(i32Ty, const1)
+	mdVer0 := mod.AddMetadataValue(i32Ty, const0)
+	mdVersionTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVer1, mdVer0})
+	mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersionTuple})
+
+	// !dx.shaderModel = !{!M} where !M = !{!"vs", i32 6, i32 0}
+	mdVS := mod.AddMetadataString("vs")
+	mdSM6 := mod.AddMetadataValue(i32Ty, const6)
+	mdSM0 := mod.AddMetadataValue(i32Ty, const0)
+	mdShaderModelTuple := mod.AddMetadataTuple([]*module.MetadataNode{mdVS, mdSM6, mdSM0})
+	mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdShaderModelTuple})
+
+	// !dx.entryPoints = !{!E} where !E = !{void()* @main, !"main", null, null, null}
+	mdMainName := mod.AddMetadataString("main")
+	mdEntryTuple := mod.AddMetadataTuple([]*module.MetadataNode{
+		nil,        // function reference (simplified for Phase 0)
+		mdMainName, // entry point name
+		nil,        // signatures (null)
+		nil,        // resources (null)
+		nil,        // properties (null)
+	})
+	mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntryTuple})
+
+	// Serialize to bitcode.
+	bitcodeData := module.Serialize(mod)
+	if len(bitcodeData) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+
+	// Verify bitcode magic.
+	if bitcodeData[0] != 'B' || bitcodeData[1] != 'C' ||
+		bitcodeData[2] != 0xC0 || bitcodeData[3] != 0xDE {
+		t.Errorf("invalid bitcode magic: %02X %02X %02X %02X",
+			bitcodeData[0], bitcodeData[1], bitcodeData[2], bitcodeData[3])
+	}
+
+	// Verify 32-bit alignment.
+	if len(bitcodeData)%4 != 0 {
+		t.Errorf("bitcode not 32-bit aligned: %d bytes", len(bitcodeData))
+	}
+
+	// Wrap in DXBC container.
+	c := container.New()
+	c.AddFeaturesPart(0) // no special features
+	c.AddDXILPart(uint32(module.VertexShader), 1, 0, bitcodeData)
+	c.AddHashPart()
+	containerData := c.Bytes()
+
+	// Verify DXBC header.
+	if len(containerData) < 28 {
+		t.Fatalf("container too small: %d bytes", len(containerData))
+	}
+	magic := binary.LittleEndian.Uint32(containerData[0:4])
+	if magic != container.FourCCDXBC {
+		t.Errorf("container magic: got 0x%08X, want 0x%08X (DXBC)", magic, container.FourCCDXBC)
+	}
+
+	// Verify file size field (offset 24 in DXBC header).
+	fileSize := binary.LittleEndian.Uint32(containerData[24:28])
+	if fileSize != uint32(len(containerData)) {
+		t.Errorf("file size: got %d, want %d", fileSize, len(containerData))
+	}
+
+	// Apply BYPASS hash.
+	container.SetBypassHash(containerData)
+
+	// Verify BYPASS hash was written.
+	for i := 4; i < 20; i++ {
+		if containerData[i] != 0x01 {
+			t.Errorf("bypass hash byte %d: got 0x%02X, want 0x01", i, containerData[i])
+		}
+	}
+
+	// Write to tmp/ for manual validation with D3D12.
+	tmpDir := filepath.Join("..", "tmp")
+	if err := os.MkdirAll(tmpDir, 0o755); err != nil {
+		t.Logf("warning: could not create tmp dir: %v", err)
+	} else {
+		outPath := filepath.Join(tmpDir, "test_minimal.dxil")
+		if err := os.WriteFile(outPath, containerData, 0o644); err != nil {
+			t.Logf("warning: could not write test file: %v", err)
+		} else {
+			t.Logf("wrote %d bytes to %s", len(containerData), outPath)
+		}
+	}
+
+	t.Logf("bitcode size: %d bytes", len(bitcodeData))
+	t.Logf("container size: %d bytes", len(containerData))
+}
+
+func TestContainerStructure(t *testing.T) {
+	c := container.New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(1, 1, 0, []byte{0x42, 0x43, 0xC0, 0xDE, 0, 0, 0, 0}) // minimal bitcode
+	c.AddHashPart()
+	data := c.Bytes()
+
+	// Header checks.
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != container.FourCCDXBC {
+		t.Fatalf("wrong magic: 0x%08X", magic)
+	}
+
+	fileSize := binary.LittleEndian.Uint32(data[24:28])
+	if fileSize != uint32(len(data)) {
+		t.Errorf("file size mismatch: header says %d, actual %d", fileSize, len(data))
+	}
+
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 3 {
+		t.Errorf("expected 3 parts, got %d", partCount)
+	}
+
+	// Verify part offsets point to valid FourCCs.
+	for i := uint32(0); i < partCount; i++ {
+		off := binary.LittleEndian.Uint32(data[32+4*i:])
+		if int(off) >= len(data)-4 {
+			t.Errorf("part %d offset %d out of range", i, off)
+			continue
+		}
+		fc := binary.LittleEndian.Uint32(data[off:])
+		switch fc {
+		case container.FourCCSFI0, container.FourCCDXIL, container.FourCCHASH:
+			// OK
+		default:
+			t.Errorf("part %d: unexpected FourCC 0x%08X", i, fc)
+		}
+	}
+}
+
+func TestBypassHash(t *testing.T) {
+	data := make([]byte, 28)
+	binary.LittleEndian.PutUint32(data[0:4], container.FourCCDXBC)
+	container.SetBypassHash(data)
+
+	for i := 4; i < 20; i++ {
+		if data[i] != 0x01 {
+			t.Errorf("byte %d: got 0x%02X, want 0x01", i, data[i])
+		}
+	}
+}

--- a/dxil/internal/bitcode/writer.go
+++ b/dxil/internal/bitcode/writer.go
@@ -1,0 +1,268 @@
+// Package bitcode implements a bit-level writer for LLVM 3.7 bitcode format.
+//
+// DXIL uses LLVM 3.7 bitcode as its binary encoding. This writer implements
+// the primitives specified in the LLVM Bitcode Format documentation:
+// https://releases.llvm.org/3.7.1/docs/BitCodeFormat.html
+//
+// The writer supports fixed-width integers, variable-width integers (VBR),
+// 6-bit character encoding, block enter/exit with size backpatching, and
+// unabbreviated record emission.
+//
+// Reference implementation: Mesa's dxil_buffer.c + dxil_module.c
+// (src/microsoft/compiler/ in the Mesa source tree).
+package bitcode
+
+import (
+	"encoding/binary"
+	"fmt"
+)
+
+// Abbreviation IDs defined by the LLVM bitstream format.
+const (
+	EndBlock       = 0 // END_BLOCK — marks end of current block
+	EnterSubblock  = 1 // ENTER_SUBBLOCK — begins a new block
+	DefineAbbrev   = 2 // DEFINE_ABBREV — defines a new abbreviation
+	UnabbrevRecord = 3 // UNABBREV_RECORD — unabbreviated record
+)
+
+// Writer writes individual bits to build LLVM 3.7 bitcode output.
+//
+// Bits accumulate in a 64-bit buffer and are flushed as little-endian
+// 32-bit words when the buffer reaches 32 bits, matching Mesa's
+// dxil_buffer implementation.
+type Writer struct {
+	data    []byte // output bytes (always multiple of 4 after flush)
+	buf     uint64 // bit accumulator (up to 63 bits)
+	bufBits uint   // number of valid bits in buf
+
+	abbrevWidth uint // current abbreviation ID width
+
+	// Block stack for enter/exit with size backpatching.
+	blocks []blockState
+}
+
+// blockState saves the state when entering a sub-block, so it can be
+// restored when the block is exited.
+type blockState struct {
+	abbrevWidth uint // outer block's abbrev width
+	sizeOffset  int  // byte offset of the 32-bit size placeholder
+}
+
+// NewWriter creates a Writer with the given initial abbreviation ID width.
+// The LLVM bitstream starts with abbrevWidth=2 for the outermost scope.
+func NewWriter(abbrevWidth uint) *Writer {
+	return &Writer{
+		data:        make([]byte, 0, 256),
+		abbrevWidth: abbrevWidth,
+	}
+}
+
+// flushDword writes the lower 32 bits of buf to data.
+func (w *Writer) flushDword() {
+	var tmp [4]byte
+	binary.LittleEndian.PutUint32(tmp[:], uint32(w.buf&0xFFFFFFFF))
+	w.data = append(w.data, tmp[:]...)
+	w.buf >>= 32
+	w.bufBits -= 32
+}
+
+// WriteBits writes the lowest `width` bits of data to the bitstream.
+// width must be in [1, 32] and data must fit in width bits.
+func (w *Writer) WriteBits(data uint32, width uint) {
+	w.buf |= uint64(data) << w.bufBits
+	w.bufBits += width
+	if w.bufBits >= 32 {
+		w.flushDword()
+	}
+}
+
+// WriteFixed writes a fixed-width integer value. If width is 0, nothing
+// is written. For values > 32 bits wide, the value is split across two
+// WriteBits calls.
+func (w *Writer) WriteFixed(value uint64, width uint) {
+	if width == 0 {
+		return
+	}
+	if value > 0xFFFFFFFF {
+		w.WriteBits(uint32(value&0xFFFFFFFF), width)          //nolint:mnd // bit mask
+		w.WriteBits(uint32((value>>32)&0xFFFFFFFF), width-32) //nolint:mnd // bit mask
+	} else {
+		w.WriteBits(uint32(value&0xFFFFFFFF), width) //nolint:mnd // bit mask
+	}
+}
+
+// WriteVBR writes a variable bit-rate encoded integer.
+//
+// VBR(n) splits the value into chunks of (n-1) data bits. The high bit
+// of each chunk is set to 1 if more chunks follow, 0 for the last chunk.
+//
+// For example, VBR(4) encoding of 27:
+//
+//	27 = 0b11011
+//	First chunk: 011 with continuation=1 → 1011
+//	Second chunk: 011 with continuation=0 → 0011
+//	Written as: 1011 0011
+//
+// width must be >= 2.
+func (w *Writer) WriteVBR(value uint64, width uint) {
+	tag := uint32(1) << (width - 1)
+	mask := tag - 1
+	for value > uint64(mask) {
+		chunk := uint32(value&uint64(mask)) | tag //nolint:gosec // masked to fit
+		value >>= width - 1
+		w.WriteBits(chunk, width)
+	}
+	w.WriteBits(uint32(value&0xFFFFFFFF), width) //nolint:mnd // bit mask
+}
+
+// WriteChar6 writes a 6-bit character code. Only the characters
+// [a-zA-Z0-9._] are representable.
+func (w *Writer) WriteChar6(ch byte) {
+	w.WriteBits(EncodeChar6(ch), 6)
+}
+
+// EncodeChar6 converts a character to its 6-bit encoding.
+//
+//	'a'..'z' → 0..25
+//	'A'..'Z' → 26..51
+//	'0'..'9' → 52..61
+//	'.'      → 62
+//	'_'      → 63
+func EncodeChar6(ch byte) uint32 {
+	switch {
+	case ch >= 'a' && ch <= 'z':
+		return uint32(ch - 'a')
+	case ch >= 'A' && ch <= 'Z':
+		return 26 + uint32(ch-'A')
+	case ch >= '0' && ch <= '9':
+		return 52 + uint32(ch-'0')
+	case ch == '.':
+		return 62
+	case ch == '_':
+		return 63
+	default:
+		panic(fmt.Sprintf("bitcode: invalid char6 character: %q", ch))
+	}
+}
+
+// IsChar6String returns true if all bytes in s are representable in char6.
+func IsChar6String(s string) bool {
+	for i := 0; i < len(s); i++ {
+		if !isChar6(s[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+func isChar6(ch byte) bool {
+	return (ch >= 'a' && ch <= 'z') ||
+		(ch >= 'A' && ch <= 'Z') ||
+		(ch >= '0' && ch <= '9') ||
+		ch == '.' || ch == '_'
+}
+
+// Align32 pads the bitstream with zero bits until the bit position is
+// a multiple of 32. This is required after END_BLOCK and before
+// the block size word in ENTER_SUBBLOCK.
+func (w *Writer) Align32() {
+	if w.bufBits > 0 {
+		w.bufBits = 32
+		w.flushDword()
+	}
+}
+
+// emitAbbrevID writes the abbreviation ID using the current block's
+// abbreviation width.
+func (w *Writer) emitAbbrevID(id uint32) {
+	w.WriteBits(id, w.abbrevWidth)
+}
+
+// EnterBlock begins a new sub-block with the given block ID and
+// abbreviation width for the block body.
+//
+// Format: [ENTER_SUBBLOCK, blockID(vbr8), newAbbrevLen(vbr4), <align32>, blockLen(32)]
+//
+// The block length is backpatched when ExitBlock is called.
+func (w *Writer) EnterBlock(blockID uint, abbrevLen uint) {
+	w.emitAbbrevID(EnterSubblock)
+	w.WriteVBR(uint64(blockID), 8)
+	w.WriteVBR(uint64(abbrevLen), 4)
+	w.Align32()
+
+	// Save current state on the block stack.
+	w.blocks = append(w.blocks, blockState{
+		abbrevWidth: w.abbrevWidth,
+		sizeOffset:  len(w.data), // position where size word goes
+	})
+
+	// Write a placeholder for the block size (in 32-bit words).
+	w.data = append(w.data, 0, 0, 0, 0)
+
+	// Switch to the new abbreviation width.
+	w.abbrevWidth = abbrevLen
+}
+
+// ExitBlock ends the current sub-block.
+//
+// Format: [END_BLOCK, <align32>]
+//
+// The block size placeholder written by EnterBlock is backpatched with
+// the actual size in 32-bit words.
+func (w *Writer) ExitBlock() {
+	w.emitAbbrevID(EndBlock)
+	w.Align32()
+
+	// Pop the block stack and compute the block body size.
+	n := len(w.blocks) - 1
+	state := w.blocks[n]
+	w.blocks = w.blocks[:n]
+
+	// Size = number of 32-bit words in block body (after the size word).
+	bodyStart := state.sizeOffset + 4
+	bodySize := len(w.data) - bodyStart
+	wordSize := bodySize / 4
+	binary.LittleEndian.PutUint32(w.data[state.sizeOffset:], uint32(wordSize)) //nolint:gosec // block size always fits in uint32
+
+	// Restore the outer block's abbreviation width.
+	w.abbrevWidth = state.abbrevWidth
+}
+
+// EmitRecord writes an unabbreviated record.
+//
+// Format: [UNABBREV_RECORD, code(vbr6), numops(vbr6), [op(vbr6)]*]
+func (w *Writer) EmitRecord(code uint, values []uint64) {
+	w.emitAbbrevID(UnabbrevRecord)
+	w.WriteVBR(uint64(code), 6)
+	w.WriteVBR(uint64(len(values)), 6)
+	for _, v := range values {
+		w.WriteVBR(v, 6)
+	}
+}
+
+// EmitRecordWithBlob writes an unabbreviated record followed by a blob.
+// This is used for encoding raw byte data (e.g., strings) in records.
+func (w *Writer) EmitRecordWithBlob(code uint, values []uint64, blob []byte) {
+	// Emit the record first.
+	allValues := make([]uint64, len(values)+len(blob))
+	copy(allValues, values)
+	for i, b := range blob {
+		allValues[len(values)+i] = uint64(b)
+	}
+	w.EmitRecord(code, allValues)
+}
+
+// Bytes returns the finalized bitcode output. The caller must ensure
+// all blocks have been exited before calling this method.
+func (w *Writer) Bytes() []byte {
+	// Flush any remaining bits.
+	if w.bufBits > 0 {
+		w.Align32()
+	}
+	return w.data
+}
+
+// Len returns the current output size in bytes.
+func (w *Writer) Len() int {
+	return len(w.data)
+}

--- a/dxil/internal/bitcode/writer_test.go
+++ b/dxil/internal/bitcode/writer_test.go
@@ -1,0 +1,377 @@
+package bitcode
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestWriteBits_SingleBit(t *testing.T) {
+	w := NewWriter(2)
+	w.WriteBits(1, 1)
+	w.Align32()
+	got := w.Bytes()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 bytes, got %d", len(got))
+	}
+	if got[0] != 1 {
+		t.Errorf("expected byte 0x01, got 0x%02x", got[0])
+	}
+}
+
+func TestWriteBits_MultipleBits(t *testing.T) {
+	w := NewWriter(2)
+	// Write 0b1101 (13) in 4 bits
+	w.WriteBits(0b1101, 4)
+	w.Align32()
+	got := w.Bytes()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 bytes, got %d", len(got))
+	}
+	// Little-endian: low bits first → byte 0 = 0x0D
+	if got[0] != 0x0D {
+		t.Errorf("expected byte 0x0D, got 0x%02x", got[0])
+	}
+}
+
+func TestWriteBits_CrossDword(t *testing.T) {
+	w := NewWriter(2)
+	// Write 28 bits, then 8 more → should cross the 32-bit boundary
+	w.WriteBits(0x0FFFFFFF, 28)
+	w.WriteBits(0xAB, 8)
+	w.Align32()
+	got := w.Bytes()
+	if len(got) != 8 {
+		t.Fatalf("expected 8 bytes, got %d", len(got))
+	}
+	dw0 := binary.LittleEndian.Uint32(got[0:4])
+	dw1 := binary.LittleEndian.Uint32(got[4:8])
+	// First 28 bits = 0x0FFFFFFF, next 4 bits from 0xAB (low nibble 0xB) fill dword 0
+	// Remaining 4 bits of 0xAB (high nibble 0xA) go to dword 1
+	expect0 := uint32(0x0FFFFFFF) | (uint32(0xAB&0x0F) << 28)
+	expect1 := uint32(0xAB >> 4)
+	if dw0 != expect0 {
+		t.Errorf("dword0: expected 0x%08X, got 0x%08X", expect0, dw0)
+	}
+	if dw1 != expect1 {
+		t.Errorf("dword1: expected 0x%08X, got 0x%08X", expect1, dw1)
+	}
+}
+
+func TestWriteVBR_SmallValue(t *testing.T) {
+	// VBR(4): values 0-7 fit in one chunk (3 data bits + 0 continuation)
+	tests := []struct {
+		name  string
+		value uint64
+		width uint
+		want  uint32 // expected bits written
+		bits  uint   // total bits used
+	}{
+		{"zero_vbr4", 0, 4, 0b0000, 4},
+		{"seven_vbr4", 7, 4, 0b0111, 4},
+		{"one_vbr6", 1, 6, 0b000001, 6},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			w := NewWriter(2)
+			w.WriteVBR(tt.value, tt.width)
+			w.Align32()
+			got := binary.LittleEndian.Uint32(w.Bytes()[:4])
+			mask := uint32((1 << tt.bits) - 1)
+			if got&mask != tt.want {
+				t.Errorf("VBR(%d) of %d: got 0x%X, want 0x%X (mask 0x%X)",
+					tt.width, tt.value, got&mask, tt.want, mask)
+			}
+		})
+	}
+}
+
+func TestWriteVBR_LargeValue(t *testing.T) {
+	// VBR(4) encoding of 27:
+	// 27 = 0b11011
+	// Chunk 1: 011 | 1 (continuation) = 1011 (0xB)
+	// Chunk 2: 011 | 0 (last)         = 0011 (0x3)
+	// Total: 0011_1011 in bit order = 0x3B when read as 8 bits
+	w := NewWriter(2)
+	w.WriteVBR(27, 4)
+	w.Align32()
+	got := binary.LittleEndian.Uint32(w.Bytes()[:4])
+	// First 4 bits: 1011 (0xB), next 4 bits: 0011 (0x3)
+	first := got & 0xF
+	second := (got >> 4) & 0xF
+	if first != 0xB {
+		t.Errorf("VBR(4) of 27, first chunk: got 0x%X, want 0xB", first)
+	}
+	if second != 0x3 {
+		t.Errorf("VBR(4) of 27, second chunk: got 0x%X, want 0x3", second)
+	}
+}
+
+func TestWriteVBR_ThreeChunks(t *testing.T) {
+	// VBR(4) encoding of 256:
+	// 256 = 0b100000000
+	// Chunk 1: 000 | 1 = 1000 (low 3 bits of 256 = 0, continuation)
+	// Chunk 2: 000 | 1 = 1000 (next 3 bits = 0, continuation)
+	// Chunk 3: 100 | 0 = 0100 (final 3 bits = 4, done)
+	w := NewWriter(2)
+	w.WriteVBR(256, 4)
+	w.Align32()
+	got := binary.LittleEndian.Uint32(w.Bytes()[:4])
+	c1 := got & 0xF
+	c2 := (got >> 4) & 0xF
+	c3 := (got >> 8) & 0xF
+	if c1 != 0x8 {
+		t.Errorf("chunk1: got 0x%X, want 0x8", c1)
+	}
+	if c2 != 0x8 {
+		t.Errorf("chunk2: got 0x%X, want 0x8", c2)
+	}
+	if c3 != 0x4 {
+		t.Errorf("chunk3: got 0x%X, want 0x4", c3)
+	}
+}
+
+func TestEncodeChar6(t *testing.T) {
+	tests := []struct {
+		ch   byte
+		want uint32
+	}{
+		{'a', 0}, {'z', 25},
+		{'A', 26}, {'Z', 51},
+		{'0', 52}, {'9', 61},
+		{'.', 62}, {'_', 63},
+	}
+	for _, tt := range tests {
+		got := EncodeChar6(tt.ch)
+		if got != tt.want {
+			t.Errorf("EncodeChar6(%q) = %d, want %d", tt.ch, got, tt.want)
+		}
+	}
+}
+
+func TestIsChar6String(t *testing.T) {
+	tests := []struct {
+		s    string
+		want bool
+	}{
+		{"dxil.ms.dx", true},
+		{"hello_world", true},
+		{"ABC123", true},
+		{"hello world", false},  // space
+		{"hello-world", false},  // hyphen
+		{"hello\nworld", false}, // newline
+		{"", true},
+	}
+	for _, tt := range tests {
+		got := IsChar6String(tt.s)
+		if got != tt.want {
+			t.Errorf("IsChar6String(%q) = %v, want %v", tt.s, got, tt.want)
+		}
+	}
+}
+
+func TestWriteChar6(t *testing.T) {
+	w := NewWriter(2)
+	// Write "dxil" in char6
+	for _, ch := range []byte("dxil") {
+		w.WriteChar6(ch)
+	}
+	w.Align32()
+	got := binary.LittleEndian.Uint32(w.Bytes()[:4])
+	// 'd' = 3, 'x' = 23, 'i' = 8, 'l' = 11
+	// Bits: 000011 010111 001000 001011
+	// In order: 3(6bits) | 23(6bits) | 8(6bits) | 11(6bits) = 24 bits
+	d := got & 0x3F
+	x := (got >> 6) & 0x3F
+	i := (got >> 12) & 0x3F
+	l := (got >> 18) & 0x3F
+	if d != 3 || x != 23 || i != 8 || l != 11 {
+		t.Errorf("char6(dxil): got d=%d x=%d i=%d l=%d, want 3 23 8 11",
+			d, x, i, l)
+	}
+}
+
+func TestEnterExitBlock(t *testing.T) {
+	w := NewWriter(2)
+	// Enter a block with ID=8 (MODULE), abbrev width=3
+	w.EnterBlock(8, 3)
+	// The block body is empty
+	w.ExitBlock()
+
+	got := w.Bytes()
+	if len(got) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	// The output should be a valid sequence that starts with ENTER_SUBBLOCK
+	// and the block size should be backpatched to 1 (one 32-bit word for END_BLOCK+align).
+}
+
+func TestEnterExitBlock_NestedBlocks(t *testing.T) {
+	w := NewWriter(2)
+	w.EnterBlock(8, 3)  // outer block
+	w.EnterBlock(17, 4) // inner block (TYPE_BLOCK)
+	w.ExitBlock()       // exit inner
+	w.ExitBlock()       // exit outer
+
+	got := w.Bytes()
+	if len(got) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	// Check that all data is 32-bit aligned
+	if len(got)%4 != 0 {
+		t.Errorf("output length %d not 32-bit aligned", len(got))
+	}
+}
+
+func TestEnterExitBlock_SizeBackpatch(t *testing.T) {
+	w := NewWriter(2)
+	w.EnterBlock(8, 3)
+
+	// Write some data inside the block
+	w.EmitRecord(1, []uint64{42})
+
+	w.ExitBlock()
+
+	got := w.Bytes()
+	// Output should be 32-bit aligned
+	if len(got)%4 != 0 {
+		t.Errorf("output length %d not 32-bit aligned", len(got))
+	}
+}
+
+func TestEmitRecord_Empty(t *testing.T) {
+	w := NewWriter(2)
+	w.EnterBlock(8, 3)
+	w.EmitRecord(1, nil)
+	w.ExitBlock()
+
+	got := w.Bytes()
+	if len(got) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+}
+
+func TestEmitRecord_WithValues(t *testing.T) {
+	w := NewWriter(2)
+	w.EnterBlock(8, 3)
+	w.EmitRecord(7, []uint64{32}) // TYPE_CODE_INTEGER, 32 bits
+	w.ExitBlock()
+
+	got := w.Bytes()
+	if len(got) == 0 {
+		t.Fatal("expected non-empty output")
+	}
+	if len(got)%4 != 0 {
+		t.Errorf("output length %d not 32-bit aligned", len(got))
+	}
+}
+
+func TestBitcodeHeader(t *testing.T) {
+	// LLVM bitcode files start with magic: 'B','C', 0xC0, 0xDE
+	w := NewWriter(2)
+	w.WriteBits('B', 8)
+	w.WriteBits('C', 8)
+	w.WriteBits(0xC0, 8)
+	w.WriteBits(0xDE, 8)
+	got := w.Bytes()
+	if len(got) < 4 {
+		t.Fatalf("expected at least 4 bytes, got %d", len(got))
+	}
+	if got[0] != 'B' || got[1] != 'C' || got[2] != 0xC0 || got[3] != 0xDE {
+		t.Errorf("magic: got %02X %02X %02X %02X, want 42 43 C0 DE",
+			got[0], got[1], got[2], got[3])
+	}
+}
+
+func TestAlign32_NoOp(t *testing.T) {
+	w := NewWriter(2)
+	// Already aligned — Align32 should be a no-op
+	w.Align32()
+	if len(w.Bytes()) != 0 {
+		t.Errorf("expected empty output, got %d bytes", len(w.Bytes()))
+	}
+}
+
+func TestAlign32_WithPendingBits(t *testing.T) {
+	w := NewWriter(2)
+	w.WriteBits(1, 1) // 1 bit pending
+	w.Align32()
+	got := w.Bytes()
+	if len(got) != 4 {
+		t.Fatalf("expected 4 bytes, got %d", len(got))
+	}
+	// Only the lowest bit should be set
+	dw := binary.LittleEndian.Uint32(got)
+	if dw != 1 {
+		t.Errorf("expected 0x00000001, got 0x%08X", dw)
+	}
+}
+
+func TestWriteFixed_ZeroWidth(t *testing.T) {
+	w := NewWriter(2)
+	w.WriteFixed(999, 0) // should write nothing
+	if w.bufBits != 0 {
+		t.Errorf("expected 0 buf bits after WriteFixed(0), got %d", w.bufBits)
+	}
+}
+
+func TestWriteVBR_Zero(t *testing.T) {
+	w := NewWriter(2)
+	w.WriteVBR(0, 6)
+	w.Align32()
+	got := binary.LittleEndian.Uint32(w.Bytes()[:4])
+	// VBR(6) of 0 should be 000000
+	if got&0x3F != 0 {
+		t.Errorf("VBR(6) of 0: got 0x%X, want 0x0", got&0x3F)
+	}
+}
+
+func TestEmitRecord_LargeValues(t *testing.T) {
+	w := NewWriter(2)
+	w.EnterBlock(8, 4)
+	// Emit a record with several values to exercise the VBR encoding
+	values := []uint64{1, 2, 3, 100, 1000, 65535}
+	w.EmitRecord(42, values)
+	w.ExitBlock()
+
+	got := w.Bytes()
+	if len(got)%4 != 0 {
+		t.Errorf("output length %d not 32-bit aligned", len(got))
+	}
+}
+
+func TestFullBitcodeModule(t *testing.T) {
+	// Integration test: write a minimal bitcode structure
+	// Magic + MODULE_BLOCK(id=8) with VERSION record (code=1, value=1)
+	w := NewWriter(2)
+
+	// Magic
+	w.WriteBits('B', 8)
+	w.WriteBits('C', 8)
+	w.WriteBits(0xC0, 8)
+	w.WriteBits(0xDE, 8)
+
+	// MODULE_BLOCK (id=8, abbrev=3)
+	w.EnterBlock(8, 3)
+
+	// VERSION record: code=1, value=1 (LLVM 3.7)
+	w.EmitRecord(1, []uint64{1})
+
+	w.ExitBlock()
+
+	got := w.Bytes()
+
+	// Verify magic
+	if got[0] != 'B' || got[1] != 'C' || got[2] != 0xC0 || got[3] != 0xDE {
+		t.Error("invalid magic")
+	}
+
+	// Verify 32-bit aligned
+	if len(got)%4 != 0 {
+		t.Errorf("output not 32-bit aligned: %d bytes", len(got))
+	}
+
+	// Verify non-trivial size (magic + enter + size + record + exit)
+	if len(got) < 12 {
+		t.Errorf("output too small: %d bytes", len(got))
+	}
+}

--- a/dxil/internal/container/container.go
+++ b/dxil/internal/container/container.go
@@ -1,0 +1,176 @@
+// Package container implements the DXBC container format used to wrap
+// DXIL shader bitcode.
+//
+// A DXBC container consists of a header followed by a series of parts,
+// each identified by a FourCC code. The DXIL bitcode is stored in the
+// DXIL part, and the container hash is stored in the HASH part.
+//
+// Reference implementation: Mesa's dxil_container.c
+package container
+
+import (
+	"encoding/binary"
+)
+
+// FourCC codes for container parts.
+var (
+	FourCCDXBC = fourCC('D', 'X', 'B', 'C')
+	FourCCDXIL = fourCC('D', 'X', 'I', 'L')
+	FourCCSFI0 = fourCC('S', 'F', 'I', '0')
+	FourCCHASH = fourCC('H', 'A', 'S', 'H')
+	FourCCISG1 = fourCC('I', 'S', 'G', '1')
+	FourCCOSG1 = fourCC('O', 'S', 'G', '1')
+	FourCCPSV0 = fourCC('P', 'S', 'V', '0')
+)
+
+func fourCC(a, b, c, d byte) uint32 {
+	return uint32(a) | uint32(b)<<8 | uint32(c)<<16 | uint32(d)<<24
+}
+
+// MaxParts is the maximum number of parts in a container.
+const MaxParts = 8
+
+// Container represents a DXBC container holding shader parts.
+type Container struct {
+	parts []part
+}
+
+type part struct {
+	fourCC uint32
+	data   []byte
+}
+
+// New creates an empty DXBC container.
+func New() *Container {
+	return &Container{}
+}
+
+// AddDXILPart adds the DXIL bitcode part to the container.
+//
+// The DXIL part has a program header before the bitcode:
+//
+//	ProgramVersion: (shaderKind << 16) | (majorVersion << 4) | minorVersion
+//	ProgramSize:    total size in 32-bit words (header + bitcode)
+//	DXILMagic:      0x4C495844 ("DXIL" in LE)
+//	DXILVersion:    0x100 (DXIL bitcode version)
+//	BitcodeOffset:  16 (bytes from DXIL magic to bitcode start)
+//	BitcodeSize:    size of bitcode in bytes
+func (c *Container) AddDXILPart(shaderKind uint32, majorVer, minorVer uint32, bitcodeData []byte) {
+	// Program header: 6 uint32s = 24 bytes.
+	version := (shaderKind << 16) | (majorVer << 4) | minorVer
+	totalSize := 6*4 + uint32(len(bitcodeData)) //nolint:gosec // shader bytecode always fits in uint32
+	wordSize := totalSize / 4
+
+	var hdr [24]byte
+	binary.LittleEndian.PutUint32(hdr[0:], version)
+	binary.LittleEndian.PutUint32(hdr[4:], wordSize)
+	binary.LittleEndian.PutUint32(hdr[8:], 0x4C495844)                // DXIL magic
+	binary.LittleEndian.PutUint32(hdr[12:], 0x100)                    // DXIL version
+	binary.LittleEndian.PutUint32(hdr[16:], 16)                       // bitcode offset
+	binary.LittleEndian.PutUint32(hdr[20:], uint32(len(bitcodeData))) //nolint:gosec // same as totalSize check above
+
+	data := make([]byte, len(hdr)+len(bitcodeData))
+	copy(data, hdr[:])
+	copy(data[len(hdr):], bitcodeData)
+
+	c.parts = append(c.parts, part{fourCC: FourCCDXIL, data: data})
+}
+
+// AddFeaturesPart adds the SFI0 (Shader Feature Info) part.
+// The features are encoded as a 64-bit bitmask.
+func (c *Container) AddFeaturesPart(features uint64) {
+	var data [8]byte
+	binary.LittleEndian.PutUint64(data[:], features)
+	c.parts = append(c.parts, part{fourCC: FourCCSFI0, data: data[:]})
+}
+
+// AddHashPart adds the HASH part with the BYPASS sentinel.
+func (c *Container) AddHashPart() {
+	// BYPASS sentinel: 01010101...01010101 (16 bytes).
+	data := make([]byte, 16)
+	for i := range data {
+		data[i] = 0x01
+	}
+	c.parts = append(c.parts, part{fourCC: FourCCHASH, data: data})
+}
+
+// AddRawPart adds an arbitrary part with the given FourCC and data.
+func (c *Container) AddRawPart(fc uint32, data []byte) {
+	c.parts = append(c.parts, part{fourCC: fc, data: data})
+}
+
+// Bytes serializes the container to the DXBC binary format.
+//
+// Layout:
+//
+//	[Header: 28 bytes]
+//	  Magic:      "DXBC" (0x44584243)
+//	  Digest:     16 bytes (zeros = unsigned, or BYPASS sentinel)
+//	  Version:    uint16 major=1, uint16 minor=0
+//	  FileSize:   uint32 total size
+//	  PartCount:  uint32
+//
+//	[PartOffsets: 4 * PartCount bytes]
+//	  uint32 offsets from start of file to each part
+//
+//	[Parts:]
+//	  For each part:
+//	    FourCC:   uint32
+//	    PartSize: uint32
+//	    Data:     PartSize bytes
+func (c *Container) Bytes() []byte {
+	numParts := len(c.parts)
+	headerSize := 32 + 4*numParts // header (32) + part offset table
+
+	// Calculate total size.
+	totalSize := headerSize
+	for _, p := range c.parts {
+		totalSize += 8 + len(p.data) // fourCC(4) + size(4) + data
+	}
+
+	out := make([]byte, totalSize)
+	pos := 0
+
+	// Offset 0: Magic "DXBC"
+	binary.LittleEndian.PutUint32(out[pos:], FourCCDXBC)
+	pos += 4
+
+	// Offset 4: Digest (16 zero bytes = unsigned).
+	pos += 16
+
+	// Offset 20: Version major=1, minor=0.
+	binary.LittleEndian.PutUint16(out[pos:], 1)
+	pos += 2
+	binary.LittleEndian.PutUint16(out[pos:], 0)
+	pos += 2
+
+	// Offset 24: Container total size.
+	binary.LittleEndian.PutUint32(out[pos:], uint32(totalSize)) //nolint:gosec // container < 4GB
+	pos += 4
+
+	// Offset 28: Part count.
+	binary.LittleEndian.PutUint32(out[pos:], uint32(numParts)) //nolint:gosec // max 8 parts
+	pos += 4
+
+	// Offset 32: Part offset table (4 bytes per part).
+	offsetTableStart := pos
+	pos += 4 * numParts
+
+	// Parts data follows the offset table.
+	for i, p := range c.parts {
+		// Record the offset of this part (from file start).
+		binary.LittleEndian.PutUint32(out[offsetTableStart+4*i:], uint32(pos)) //nolint:gosec // pos < totalSize < 4GB
+
+		// Part header: FourCC + size.
+		binary.LittleEndian.PutUint32(out[pos:], p.fourCC)
+		pos += 4
+		binary.LittleEndian.PutUint32(out[pos:], uint32(len(p.data))) //nolint:gosec // part data < 4GB
+		pos += 4
+
+		// Part data.
+		copy(out[pos:], p.data)
+		pos += len(p.data)
+	}
+
+	return out
+}

--- a/dxil/internal/container/container_test.go
+++ b/dxil/internal/container/container_test.go
@@ -1,0 +1,194 @@
+package container
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestNew(t *testing.T) {
+	c := New()
+	if c == nil {
+		t.Fatal("New() returned nil")
+	}
+	data := c.Bytes()
+	// Minimum header: magic(4) + digest(16) + version(4) + size(4) + partCount(4) = 32
+	if len(data) < 32 {
+		t.Fatalf("empty container too small: %d bytes", len(data))
+	}
+	magic := binary.LittleEndian.Uint32(data[0:4])
+	if magic != FourCCDXBC {
+		t.Errorf("magic: got 0x%08X, want 0x%08X", magic, FourCCDXBC)
+	}
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 0 {
+		t.Errorf("empty container part count: got %d, want 0", partCount)
+	}
+}
+
+func TestFourCC(t *testing.T) {
+	tests := []struct {
+		name string
+		got  uint32
+		want uint32
+	}{
+		{"DXBC", FourCCDXBC, 0x43425844},
+		{"DXIL", FourCCDXIL, 0x4C495844},
+		{"SFI0", FourCCSFI0, 0x30494653},
+		{"HASH", FourCCHASH, 0x48534148},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if tt.got != tt.want {
+				t.Errorf("FourCC %s: got 0x%08X, want 0x%08X", tt.name, tt.got, tt.want)
+			}
+		})
+	}
+}
+
+func TestAddFeaturesPart(t *testing.T) {
+	c := New()
+	c.AddFeaturesPart(0)
+	data := c.Bytes()
+
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 1 {
+		t.Fatalf("part count: got %d, want 1", partCount)
+	}
+
+	// Part offset is at position 32.
+	offset := binary.LittleEndian.Uint32(data[32:36])
+	fc := binary.LittleEndian.Uint32(data[offset:])
+	if fc != FourCCSFI0 {
+		t.Errorf("part FourCC: got 0x%08X, want SFI0 0x%08X", fc, FourCCSFI0)
+	}
+
+	partSize := binary.LittleEndian.Uint32(data[offset+4:])
+	if partSize != 8 {
+		t.Errorf("features part size: got %d, want 8", partSize)
+	}
+}
+
+func TestAddDXILPart(t *testing.T) {
+	c := New()
+	bitcode := []byte{0x42, 0x43, 0xC0, 0xDE, 0, 0, 0, 0} // minimal bitcode
+	c.AddDXILPart(1, 1, 0, bitcode)
+	data := c.Bytes()
+
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 1 {
+		t.Fatalf("part count: got %d, want 1", partCount)
+	}
+
+	offset := binary.LittleEndian.Uint32(data[32:36])
+	fc := binary.LittleEndian.Uint32(data[offset:])
+	if fc != FourCCDXIL {
+		t.Errorf("part FourCC: got 0x%08X, want DXIL 0x%08X", fc, FourCCDXIL)
+	}
+
+	// Part size = program header (24) + bitcode (8) = 32.
+	partSize := binary.LittleEndian.Uint32(data[offset+4:])
+	if partSize != 32 {
+		t.Errorf("DXIL part size: got %d, want 32", partSize)
+	}
+
+	// Verify program header fields.
+	hdrOff := int(offset) + 8
+	version := binary.LittleEndian.Uint32(data[hdrOff:])
+	// shaderKind=1(VS) << 16 | major=1 << 4 | minor=0 = 0x10010
+	wantVer := uint32(1<<16 | 1<<4)
+	if version != wantVer {
+		t.Errorf("program version: got 0x%08X, want 0x%08X", version, wantVer)
+	}
+
+	dxilMagic := binary.LittleEndian.Uint32(data[hdrOff+8:])
+	if dxilMagic != 0x4C495844 {
+		t.Errorf("DXIL magic: got 0x%08X, want 0x4C495844", dxilMagic)
+	}
+}
+
+func TestContainerFileSize(t *testing.T) {
+	c := New()
+	c.AddFeaturesPart(0)
+	c.AddDXILPart(1, 1, 0, make([]byte, 16))
+	c.AddHashPart()
+	data := c.Bytes()
+
+	fileSize := binary.LittleEndian.Uint32(data[24:28])
+	if fileSize != uint32(len(data)) {
+		t.Errorf("file size field: got %d, actual %d", fileSize, len(data))
+	}
+}
+
+func TestSetBypassHash_Applied(t *testing.T) {
+	data := make([]byte, 32)
+	binary.LittleEndian.PutUint32(data[0:4], FourCCDXBC)
+	SetBypassHash(data)
+
+	for i := 4; i < 20; i++ {
+		if data[i] != 0x01 {
+			t.Errorf("byte %d: got 0x%02X, want 0x01", i, data[i])
+		}
+	}
+}
+
+func TestSetBypassHash_TooSmall(t *testing.T) {
+	// Should not panic on small input.
+	data := make([]byte, 10)
+	SetBypassHash(data) // no-op, should not panic
+}
+
+func TestComputeRetailHash(t *testing.T) {
+	// Create a minimal valid container.
+	c := New()
+	c.AddFeaturesPart(0)
+	data := c.Bytes()
+
+	// Compute retail hash (modified MD5).
+	ComputeRetailHash(data)
+
+	// The digest (bytes 4-19) should NOT be all zeros after hashing.
+	allZero := true
+	for i := 4; i < 20; i++ {
+		if data[i] != 0 {
+			allZero = false
+			break
+		}
+	}
+	if allZero {
+		t.Error("retail hash produced all-zero digest")
+	}
+
+	// It should also NOT be the BYPASS sentinel.
+	isBypass := true
+	for i := 4; i < 20; i++ {
+		if data[i] != 0x01 {
+			isBypass = false
+			break
+		}
+	}
+	if isBypass {
+		t.Error("retail hash produced BYPASS sentinel (impossible for real MD5)")
+	}
+}
+
+func TestAddRawPart(t *testing.T) {
+	c := New()
+	c.AddRawPart(FourCCISG1, []byte{1, 2, 3, 4})
+	data := c.Bytes()
+
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 1 {
+		t.Fatalf("part count: got %d, want 1", partCount)
+	}
+
+	offset := binary.LittleEndian.Uint32(data[32:36])
+	fc := binary.LittleEndian.Uint32(data[offset:])
+	if fc != FourCCISG1 {
+		t.Errorf("raw part FourCC: got 0x%08X, want ISG1 0x%08X", fc, FourCCISG1)
+	}
+
+	partSize := binary.LittleEndian.Uint32(data[offset+4:])
+	if partSize != 4 {
+		t.Errorf("raw part size: got %d, want 4", partSize)
+	}
+}

--- a/dxil/internal/container/hash.go
+++ b/dxil/internal/container/hash.go
@@ -1,0 +1,307 @@
+// Package container implements DXIL container hashing.
+//
+// This file implements the BYPASS hash sentinel and the retail hash
+// algorithm from Microsoft's INF-0004 specification.
+
+package container
+
+import "encoding/binary"
+
+// BypassHash is the BYPASS sentinel hash value.
+// When this 16-byte value is placed in the container header's digest field,
+// the D3D12 runtime (AgilitySDK 1.615+) allows the shader to execute
+// without validating the hash.
+//
+// Reference: https://github.com/microsoft/hlsl-specs/blob/main/proposals/infra/INF-0004-validator-hashing.md
+var BypassHash = [16]byte{
+	0x01, 0x01, 0x01, 0x01,
+	0x01, 0x01, 0x01, 0x01,
+	0x01, 0x01, 0x01, 0x01,
+	0x01, 0x01, 0x01, 0x01,
+}
+
+// PreviewBypassHash is the PREVIEW_BYPASS sentinel.
+// Shaders with this hash only execute when developer mode and
+// D3D12ExperimentalShaderModels are enabled.
+var PreviewBypassHash = [16]byte{
+	0x02, 0x02, 0x02, 0x02,
+	0x02, 0x02, 0x02, 0x02,
+	0x02, 0x02, 0x02, 0x02,
+	0x02, 0x02, 0x02, 0x02,
+}
+
+// SetBypassHash writes the BYPASS sentinel hash into the container's
+// digest field (bytes 4-19 of the DXBC header).
+func SetBypassHash(containerData []byte) {
+	if len(containerData) < 20 {
+		return
+	}
+	copy(containerData[4:20], BypassHash[:])
+}
+
+// ComputeRetailHash computes the retail (modified MD5) hash of the
+// container data and writes it into the digest field.
+//
+// This implements the "Retail Hash" algorithm from INF-0004, which is
+// a modified MD5 that puts the byte count at x[0] instead of x[14],
+// and uses a different x[15] encoding.
+//
+// The hash is computed over the entire container EXCEPT the 16-byte
+// digest field itself (bytes 4-19). During hashing, the digest field
+// is treated as zeros.
+func ComputeRetailHash(containerData []byte) {
+	if len(containerData) < 20 {
+		return
+	}
+
+	// Zero the digest area for hashing.
+	for i := 4; i < 20; i++ {
+		containerData[i] = 0
+	}
+
+	hash := retailMD5(containerData)
+	copy(containerData[4:20], hash[:])
+}
+
+// retailMD5 computes the modified MD5 hash per INF-0004.
+//
+//nolint:gosec // intentional uint32<->byte conversions throughout (MD5 algorithm)
+func retailMD5(data []byte) [16]byte {
+	byteCount := uint32(len(data))
+	leftOver := byteCount & 0x3f
+	var padAmount uint32
+	twoRowsPadding := false
+	if leftOver < 56 {
+		padAmount = 56 - leftOver
+	} else {
+		padAmount = 120 - leftOver
+		twoRowsPadding = true
+	}
+
+	state := [4]uint32{0x67452301, 0xefcdab89, 0x98badcfe, 0x10325476}
+	n := (byteCount + padAmount + 8) >> 6
+
+	offset := uint32(0)
+	nextEndState := n - 1
+	if twoRowsPadding {
+		nextEndState = n - 2
+	}
+
+	for i := uint32(0); i < n; i++ {
+		pX := retailMD5Block(data, byteCount, offset, i, n, &nextEndState,
+			twoRowsPadding, padAmount)
+		md5Transform(&state, pX)
+		offset += 64
+	}
+
+	var result [16]byte
+	binary.LittleEndian.PutUint32(result[0:], state[0])
+	binary.LittleEndian.PutUint32(result[4:], state[1])
+	binary.LittleEndian.PutUint32(result[8:], state[2])
+	binary.LittleEndian.PutUint32(result[12:], state[3])
+	return result
+}
+
+// retailMD5Block prepares the 16-word input block for iteration i.
+func retailMD5Block(data []byte, byteCount, offset, i, n uint32,
+	nextEndState *uint32, twoRowsPadding bool, padAmount uint32,
+) []uint32 {
+	if i != *nextEndState {
+		return bytesToUint32s(data[offset : offset+64])
+	}
+
+	var x [16]uint32
+	if !twoRowsPadding && i == n-1 {
+		remainder := byteCount - offset
+		x[0] = byteCount << 3
+		copyBytesToUint32s(x[:], 4, data[offset:offset+remainder])
+		padIntoUint32s(x[:], 4+remainder, padAmount)
+		x[15] = 1 | (byteCount << 1)
+	} else if twoRowsPadding {
+		if i == n-2 {
+			remainder := byteCount - offset
+			copyBytesToUint32s(x[:], 0, data[offset:offset+remainder])
+			padIntoUint32s(x[:], remainder, padAmount-56)
+			*nextEndState = n - 1
+		} else if i == n-1 {
+			x[0] = byteCount << 3
+			padIntoUint32sFromOffset(x[:], 4, padAmount-56)
+			x[15] = 1 | (byteCount << 1)
+		}
+	}
+	return x[:]
+}
+
+// md5Transform performs one MD5 block transformation on state using
+// the 16-word input block pX. This is a direct port of the MD5 algorithm
+// from RFC 1321 / INF-0004 and cannot be meaningfully decomposed.
+//
+//nolint:funlen // MD5 algorithm: 64 fixed operations per RFC 1321
+func md5Transform(state *[4]uint32, pX []uint32) {
+	a, b, c, d := state[0], state[1], state[2], state[3]
+
+	// Round 1
+	a = ff(a, b, c, d, pX[0], 7, 0xd76aa478)
+	d = ff(d, a, b, c, pX[1], 12, 0xe8c7b756)
+	c = ff(c, d, a, b, pX[2], 17, 0x242070db)
+	b = ff(b, c, d, a, pX[3], 22, 0xc1bdceee)
+	a = ff(a, b, c, d, pX[4], 7, 0xf57c0faf)
+	d = ff(d, a, b, c, pX[5], 12, 0x4787c62a)
+	c = ff(c, d, a, b, pX[6], 17, 0xa8304613)
+	b = ff(b, c, d, a, pX[7], 22, 0xfd469501)
+	a = ff(a, b, c, d, pX[8], 7, 0x698098d8)
+	d = ff(d, a, b, c, pX[9], 12, 0x8b44f7af)
+	c = ff(c, d, a, b, pX[10], 17, 0xffff5bb1)
+	b = ff(b, c, d, a, pX[11], 22, 0x895cd7be)
+	a = ff(a, b, c, d, pX[12], 7, 0x6b901122)
+	d = ff(d, a, b, c, pX[13], 12, 0xfd987193)
+	c = ff(c, d, a, b, pX[14], 17, 0xa679438e)
+	b = ff(b, c, d, a, pX[15], 22, 0x49b40821)
+
+	// Round 2
+	a = gg(a, b, c, d, pX[1], 5, 0xf61e2562)
+	d = gg(d, a, b, c, pX[6], 9, 0xc040b340)
+	c = gg(c, d, a, b, pX[11], 14, 0x265e5a51)
+	b = gg(b, c, d, a, pX[0], 20, 0xe9b6c7aa)
+	a = gg(a, b, c, d, pX[5], 5, 0xd62f105d)
+	d = gg(d, a, b, c, pX[10], 9, 0x02441453)
+	c = gg(c, d, a, b, pX[15], 14, 0xd8a1e681)
+	b = gg(b, c, d, a, pX[4], 20, 0xe7d3fbc8)
+	a = gg(a, b, c, d, pX[9], 5, 0x21e1cde6)
+	d = gg(d, a, b, c, pX[14], 9, 0xc33707d6)
+	c = gg(c, d, a, b, pX[3], 14, 0xf4d50d87)
+	b = gg(b, c, d, a, pX[8], 20, 0x455a14ed)
+	a = gg(a, b, c, d, pX[13], 5, 0xa9e3e905)
+	d = gg(d, a, b, c, pX[2], 9, 0xfcefa3f8)
+	c = gg(c, d, a, b, pX[7], 14, 0x676f02d9)
+	b = gg(b, c, d, a, pX[12], 20, 0x8d2a4c8a)
+
+	// Round 3
+	a = hh(a, b, c, d, pX[5], 4, 0xfffa3942)
+	d = hh(d, a, b, c, pX[8], 11, 0x8771f681)
+	c = hh(c, d, a, b, pX[11], 16, 0x6d9d6122)
+	b = hh(b, c, d, a, pX[14], 23, 0xfde5380c)
+	a = hh(a, b, c, d, pX[1], 4, 0xa4beea44)
+	d = hh(d, a, b, c, pX[4], 11, 0x4bdecfa9)
+	c = hh(c, d, a, b, pX[7], 16, 0xf6bb4b60)
+	b = hh(b, c, d, a, pX[10], 23, 0xbebfbc70)
+	a = hh(a, b, c, d, pX[13], 4, 0x289b7ec6)
+	d = hh(d, a, b, c, pX[0], 11, 0xeaa127fa)
+	c = hh(c, d, a, b, pX[3], 16, 0xd4ef3085)
+	b = hh(b, c, d, a, pX[6], 23, 0x04881d05)
+	a = hh(a, b, c, d, pX[9], 4, 0xd9d4d039)
+	d = hh(d, a, b, c, pX[12], 11, 0xe6db99e5)
+	c = hh(c, d, a, b, pX[15], 16, 0x1fa27cf8)
+	b = hh(b, c, d, a, pX[2], 23, 0xc4ac5665)
+
+	// Round 4
+	a = ii(a, b, c, d, pX[0], 6, 0xf4292244)
+	d = ii(d, a, b, c, pX[7], 10, 0x432aff97)
+	c = ii(c, d, a, b, pX[14], 15, 0xab9423a7)
+	b = ii(b, c, d, a, pX[5], 21, 0xfc93a039)
+	a = ii(a, b, c, d, pX[12], 6, 0x655b59c3)
+	d = ii(d, a, b, c, pX[3], 10, 0x8f0ccc92)
+	c = ii(c, d, a, b, pX[10], 15, 0xffeff47d)
+	b = ii(b, c, d, a, pX[1], 21, 0x85845dd1)
+	a = ii(a, b, c, d, pX[8], 6, 0x6fa87e4f)
+	d = ii(d, a, b, c, pX[15], 10, 0xfe2ce6e0)
+	c = ii(c, d, a, b, pX[6], 15, 0xa3014314)
+	b = ii(b, c, d, a, pX[13], 21, 0x4e0811a1)
+	a = ii(a, b, c, d, pX[4], 6, 0xf7537e82)
+	d = ii(d, a, b, c, pX[11], 10, 0xbd3af235)
+	c = ii(c, d, a, b, pX[2], 15, 0x2ad7d2bb)
+	b = ii(b, c, d, a, pX[9], 21, 0xeb86d391)
+
+	state[0] += a
+	state[1] += b
+	state[2] += c
+	state[3] += d
+}
+
+// MD5 round helper functions.
+
+func ff(a, b, c, d, x uint32, s uint8, ac uint32) uint32 {
+	a += ((b & c) | (^b & d)) + x + ac
+	a = (a << s) | (a >> (32 - s))
+	return a + b
+}
+
+func gg(a, b, c, d, x uint32, s uint8, ac uint32) uint32 {
+	a += ((b & d) | (c & ^d)) + x + ac
+	a = (a << s) | (a >> (32 - s))
+	return a + b
+}
+
+func hh(a, b, c, d, x uint32, s uint8, ac uint32) uint32 {
+	a += (b ^ c ^ d) + x + ac
+	a = (a << s) | (a >> (32 - s))
+	return a + b
+}
+
+func ii(a, b, c, d, x uint32, s uint8, ac uint32) uint32 {
+	a += (c ^ (b | ^d)) + x + ac
+	a = (a << s) | (a >> (32 - s))
+	return a + b
+}
+
+// MD5 padding constant.
+var md5Padding = [64]byte{0x80}
+
+// copyBytesToUint32s copies src bytes into dst uint32 array starting
+// at byte offset byteOff.
+func copyBytesToUint32s(dst []uint32, byteOff uint32, src []byte) {
+	buf := uint32sToBytes(dst)
+	copy(buf[byteOff:], src)
+	for i := range dst {
+		dst[i] = bytesToUint32LE(buf[i*4:])
+	}
+}
+
+// padIntoUint32s writes MD5 padding into dst starting at byte offset.
+func padIntoUint32s(dst []uint32, byteOff, padLen uint32) {
+	buf := uint32sToBytes(dst)
+	for i := uint32(0); i < padLen && i < uint32(len(md5Padding)); i++ {
+		if int(byteOff+i) < len(buf) {
+			buf[byteOff+i] = md5Padding[i]
+		}
+	}
+	for i := range dst {
+		dst[i] = bytesToUint32LE(buf[i*4:])
+	}
+}
+
+// padIntoUint32sFromOffset writes MD5 padding from a given padding offset.
+func padIntoUint32sFromOffset(dst []uint32, byteOff uint32, padOffset uint32) {
+	buf := uint32sToBytes(dst)
+	remaining := uint32(len(md5Padding)) - padOffset
+	for i := uint32(0); i < remaining; i++ {
+		idx := int(byteOff + i)
+		if idx < len(buf) {
+			buf[idx] = md5Padding[padOffset+i]
+		}
+	}
+	for i := range dst {
+		dst[i] = bytesToUint32LE(buf[i*4:])
+	}
+}
+
+func uint32sToBytes(u []uint32) []byte {
+	buf := make([]byte, len(u)*4)
+	for i, v := range u {
+		binary.LittleEndian.PutUint32(buf[i*4:], v)
+	}
+	return buf
+}
+
+func bytesToUint32s(data []byte) []uint32 {
+	n := len(data) / 4
+	result := make([]uint32, n)
+	for i := 0; i < n; i++ {
+		result[i] = bytesToUint32LE(data[i*4:])
+	}
+	return result
+}
+
+func bytesToUint32LE(b []byte) uint32 {
+	return uint32(b[0]) | uint32(b[1])<<8 | uint32(b[2])<<16 | uint32(b[3])<<24
+}

--- a/dxil/internal/container/psv.go
+++ b/dxil/internal/container/psv.go
@@ -1,0 +1,222 @@
+// Package container — PSV0 (Pipeline State Validation) part encoding.
+//
+// PSV0 contains runtime information used by the D3D12 driver to validate
+// pipeline state without running the shader. The format consists of:
+//
+//  1. PSV runtime info size (uint32) + runtime info struct
+//  2. Resource count (uint32) + optional resource bindings
+//  3. String table (uint32 size + data, 4-byte aligned)
+//  4. Semantic index table (uint32 count + data)
+//  5. Optional: PSV signature elements
+//  6. Optional: I/O dependency tables
+//
+// For SM 6.0 (validator < 1.6), the runtime info is PSVRuntimeInfo1
+// (the minimum required version that includes signature element counts).
+//
+// Reference: Mesa dxil_container.c dxil_container_add_state_validation(),
+// Mesa dxil_signature.h struct dxil_psv_runtime_info_*.
+package container
+
+import (
+	"encoding/binary"
+)
+
+// PSVShaderKind matches DXIL's PSVShaderKind enum (used in PSV1.ShaderStage).
+type PSVShaderKind uint8
+
+const (
+	PSVVertex  PSVShaderKind = 0
+	PSVPixel   PSVShaderKind = 1
+	PSVCompute PSVShaderKind = 5
+)
+
+// PSVInfo holds the data needed to build a PSV0 part.
+type PSVInfo struct {
+	ShaderStage PSVShaderKind
+
+	// Vertex shader specific.
+	OutputPositionPresent bool
+
+	// Pixel shader specific.
+	DepthOutput     bool
+	SampleFrequency bool
+
+	// Signature element counts (for PSV1).
+	SigInputElements  uint8
+	SigOutputElements uint8
+
+	// Number of packed signature vectors.
+	SigInputVectors  uint8
+	SigOutputVectors uint8
+
+	// Wave lane counts (0 = unused, 0xFFFFFFFF = any).
+	MinWaveLaneCount uint32
+	MaxWaveLaneCount uint32
+
+	// Semantic string table entries (null-terminated, will be 4-byte aligned).
+	StringTable []byte
+
+	// Semantic index table entries.
+	SemanticIndexTable []uint32
+
+	// PSV signature elements (optional).
+	PSVSigInputs  []PSVSignatureElement
+	PSVSigOutputs []PSVSignatureElement
+}
+
+// PSVSignatureElement matches Mesa's dxil_psv_signature_element (8 bytes).
+type PSVSignatureElement struct {
+	SemanticNameOffset    uint32
+	SemanticIndexesOffset uint32
+	Rows                  uint8
+	StartRow              uint8
+	ColsAndStart          uint8 // 0:4=Cols, 4:6=StartCol, 6:7=Allocated
+	SemanticKind          uint8
+	ComponentType         uint8
+	InterpolationMode     uint8
+	DynamicMaskAndStream  uint8
+	Reserved              uint8
+}
+
+// psvSignatureElementSize is the wire size of one PSVSignatureElement.
+const psvSignatureElementSize = 4 + 4 + 8 // two uint32 + 8 bytes = 16 bytes
+
+// runtimeInfo1Size is the wire size of PSVRuntimeInfo1 as defined by Mesa.
+// PSVRuntimeInfo0 = 24 bytes (union 14 bytes padded to 16 + 4 + 4)
+// PSVRuntimeInfo1 = PSVRuntimeInfo0(24) + 1(stage) + 1(uses_view_id) +
+//
+//	2(union) + 3(sig elements) + 1(sig_input_vectors) + 4(sig_output_vectors[4]) = 36
+const runtimeInfo1Size = 36
+
+// EncodePSV0 serializes PSVInfo into the PSV0 part binary format.
+func EncodePSV0(info PSVInfo) []byte {
+	// We emit PSVRuntimeInfo1 format (required for signature element counts).
+	psvSize := uint32(runtimeInfo1Size)
+
+	// Calculate total part size.
+	resourceCount := uint32(0) // no resource bindings for now
+
+	// String table: 4-byte aligned.
+	stringTableData := info.StringTable
+	stringTableSize := uint32(len(stringTableData)) //nolint:gosec // bounded
+	alignedStringTableSize := (stringTableSize + 3) & ^uint32(3)
+
+	// Semantic index table.
+	semIndexCount := uint32(len(info.SemanticIndexTable)) //nolint:gosec // bounded
+
+	totalSize := 4 + psvSize + // psv_size field + runtime info
+		4 + // resource_count
+		4 + alignedStringTableSize + // string_table_size + data
+		4 + semIndexCount*4 // sem_index_count + data
+
+	// Add PSV signature elements if present.
+	numSigInputs := len(info.PSVSigInputs)
+	numSigOutputs := len(info.PSVSigOutputs)
+	if numSigInputs > 0 || numSigOutputs > 0 {
+		totalSize += 4                                                       // element size field
+		totalSize += uint32(numSigInputs) * uint32(psvSignatureElementSize)  //nolint:gosec // bounded
+		totalSize += uint32(numSigOutputs) * uint32(psvSignatureElementSize) //nolint:gosec // bounded
+	}
+
+	out := make([]byte, totalSize)
+	pos := 0
+
+	// 1. PSV runtime info size.
+	binary.LittleEndian.PutUint32(out[pos:], psvSize)
+	pos += 4
+
+	// 2. PSV runtime info (PSVRuntimeInfo1).
+	// PSVRuntimeInfo0 (24 bytes):
+	//   Bytes 0-15: stage-specific union (max 16 bytes padded)
+	//   Bytes 16-19: min_expected_wave_lane_count
+	//   Bytes 20-23: max_expected_wave_lane_count
+	switch info.ShaderStage {
+	case PSVVertex:
+		if info.OutputPositionPresent {
+			out[pos] = 1
+		}
+	case PSVPixel:
+		if info.DepthOutput {
+			out[pos] = 1
+		}
+		if info.SampleFrequency {
+			out[pos+1] = 1
+		}
+	}
+	binary.LittleEndian.PutUint32(out[pos+16:], info.MinWaveLaneCount)
+	binary.LittleEndian.PutUint32(out[pos+20:], info.MaxWaveLaneCount)
+
+	// PSVRuntimeInfo1 extension (12 bytes at offset 24):
+	//   Byte 0: shader_stage
+	//   Byte 1: uses_view_id
+	//   Bytes 2-3: union (max_vertex_count / sig_patch_const)
+	//   Byte 4: sig_input_elements
+	//   Byte 5: sig_output_elements
+	//   Byte 6: sig_patch_const_or_prim_elements
+	//   Byte 7: sig_input_vectors
+	//   Bytes 8-11: sig_output_vectors[4]
+	out[pos+24] = uint8(info.ShaderStage)
+	// uses_view_id = 0
+	// union = 0
+	out[pos+28] = info.SigInputElements
+	out[pos+29] = info.SigOutputElements
+	// sig_patch_const = 0
+	out[pos+31] = info.SigInputVectors
+	out[pos+32] = info.SigOutputVectors
+	pos += int(psvSize)
+
+	// 3. Resource count.
+	binary.LittleEndian.PutUint32(out[pos:], resourceCount)
+	pos += 4
+
+	// No resource bindings (resourceCount == 0).
+
+	// 4. String table.
+	binary.LittleEndian.PutUint32(out[pos:], alignedStringTableSize)
+	pos += 4
+	copy(out[pos:], stringTableData)
+	pos += int(alignedStringTableSize)
+
+	// 5. Semantic index table.
+	binary.LittleEndian.PutUint32(out[pos:], semIndexCount)
+	pos += 4
+	for _, idx := range info.SemanticIndexTable {
+		binary.LittleEndian.PutUint32(out[pos:], idx)
+		pos += 4
+	}
+
+	// 6. PSV signature elements.
+	if numSigInputs > 0 || numSigOutputs > 0 {
+		binary.LittleEndian.PutUint32(out[pos:], uint32(psvSignatureElementSize))
+		pos += 4
+
+		for i := range info.PSVSigInputs {
+			pos = writePSVSigElement(out, pos, &info.PSVSigInputs[i])
+		}
+		for i := range info.PSVSigOutputs {
+			pos = writePSVSigElement(out, pos, &info.PSVSigOutputs[i])
+		}
+	}
+
+	return out
+}
+
+func writePSVSigElement(out []byte, pos int, elem *PSVSignatureElement) int {
+	binary.LittleEndian.PutUint32(out[pos:], elem.SemanticNameOffset)
+	binary.LittleEndian.PutUint32(out[pos+4:], elem.SemanticIndexesOffset)
+	out[pos+8] = elem.Rows
+	out[pos+9] = elem.StartRow
+	out[pos+10] = elem.ColsAndStart
+	out[pos+11] = elem.SemanticKind
+	out[pos+12] = elem.ComponentType
+	out[pos+13] = elem.InterpolationMode
+	out[pos+14] = elem.DynamicMaskAndStream
+	out[pos+15] = elem.Reserved
+	return pos + psvSignatureElementSize
+}
+
+// AddPSV0 adds a PSV0 part to the container.
+func (c *Container) AddPSV0(info PSVInfo) {
+	data := EncodePSV0(info)
+	c.parts = append(c.parts, part{fourCC: FourCCPSV0, data: data})
+}

--- a/dxil/internal/container/psv_test.go
+++ b/dxil/internal/container/psv_test.go
@@ -1,0 +1,164 @@
+package container
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestPSV0Basic_VertexShader(t *testing.T) {
+	info := PSVInfo{
+		ShaderStage:           PSVVertex,
+		OutputPositionPresent: true,
+		SigInputElements:      1,
+		SigOutputElements:     1,
+		SigInputVectors:       1,
+		SigOutputVectors:      1,
+		MinWaveLaneCount:      0,
+		MaxWaveLaneCount:      0xFFFFFFFF,
+	}
+
+	data := EncodePSV0(info)
+
+	// First 4 bytes = runtime info size.
+	psvSize := binary.LittleEndian.Uint32(data[0:4])
+	if psvSize != runtimeInfo1Size {
+		t.Errorf("psv size: got %d, want %d", psvSize, runtimeInfo1Size)
+	}
+
+	// Output position present flag (first byte of union).
+	if data[4] != 1 {
+		t.Errorf("output_position_present: got %d, want 1", data[4])
+	}
+
+	// Min/max wave lane count.
+	minWave := binary.LittleEndian.Uint32(data[4+16:])
+	if minWave != 0 {
+		t.Errorf("min_wave_lane_count: got %d, want 0", minWave)
+	}
+	maxWave := binary.LittleEndian.Uint32(data[4+20:])
+	if maxWave != 0xFFFFFFFF {
+		t.Errorf("max_wave_lane_count: got 0x%08X, want 0xFFFFFFFF", maxWave)
+	}
+
+	// Shader stage (byte at offset 24 in runtime info = offset 28 in data).
+	stage := data[4+24]
+	if stage != uint8(PSVVertex) {
+		t.Errorf("shader_stage: got %d, want %d", stage, PSVVertex)
+	}
+
+	// Signature element counts.
+	sigInputElems := data[4+28]
+	if sigInputElems != 1 {
+		t.Errorf("sig_input_elements: got %d, want 1", sigInputElems)
+	}
+	sigOutputElems := data[4+29]
+	if sigOutputElems != 1 {
+		t.Errorf("sig_output_elements: got %d, want 1", sigOutputElems)
+	}
+
+	// Resource count should be 0.
+	resourceCount := binary.LittleEndian.Uint32(data[4+runtimeInfo1Size:])
+	if resourceCount != 0 {
+		t.Errorf("resource_count: got %d, want 0", resourceCount)
+	}
+}
+
+func TestPSV0Basic_PixelShader(t *testing.T) {
+	info := PSVInfo{
+		ShaderStage:      PSVPixel,
+		DepthOutput:      true,
+		SampleFrequency:  false,
+		MinWaveLaneCount: 0,
+		MaxWaveLaneCount: 0xFFFFFFFF,
+	}
+
+	data := EncodePSV0(info)
+
+	// Depth output flag.
+	if data[4] != 1 {
+		t.Errorf("depth_output: got %d, want 1", data[4])
+	}
+
+	// Sample frequency flag.
+	if data[5] != 0 {
+		t.Errorf("sample_frequency: got %d, want 0", data[5])
+	}
+
+	stage := data[4+24]
+	if stage != uint8(PSVPixel) {
+		t.Errorf("shader_stage: got %d, want %d", stage, PSVPixel)
+	}
+}
+
+func TestPSV0WithStringTable(t *testing.T) {
+	info := PSVInfo{
+		ShaderStage:        PSVVertex,
+		MinWaveLaneCount:   0,
+		MaxWaveLaneCount:   0xFFFFFFFF,
+		StringTable:        []byte("POSITION\x00TEXCOORD\x00"),
+		SemanticIndexTable: []uint32{0, 0},
+	}
+
+	data := EncodePSV0(info)
+
+	// Find string table after runtime info + resource count.
+	pos := 4 + runtimeInfo1Size + 4 // psv_size(4) + runtime(36) + resource_count(4)
+
+	// String table size (4-byte aligned).
+	stringTableSize := binary.LittleEndian.Uint32(data[pos:])
+	if stringTableSize != 20 { // "POSITION\0TEXCOORD\0" = 18 bytes, aligned to 20
+		t.Errorf("string_table_size: got %d, want 20", stringTableSize)
+	}
+	pos += 4
+
+	// Read POSITION string from table.
+	name := readNullTermString(data, pos)
+	if name != "POSITION" {
+		t.Errorf("first string: got %q, want %q", name, "POSITION")
+	}
+	pos += int(stringTableSize)
+
+	// Semantic index table count.
+	semIdxCount := binary.LittleEndian.Uint32(data[pos:])
+	if semIdxCount != 2 {
+		t.Errorf("sem_index_count: got %d, want 2", semIdxCount)
+	}
+}
+
+func TestContainerWithPSV0(t *testing.T) {
+	c := New()
+	c.AddFeaturesPart(0)
+	c.AddPSV0(PSVInfo{
+		ShaderStage:      PSVVertex,
+		MinWaveLaneCount: 0,
+		MaxWaveLaneCount: 0xFFFFFFFF,
+	})
+	c.AddDXILPart(1, 1, 0, make([]byte, 16))
+	c.AddHashPart()
+	data := c.Bytes()
+
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 4 {
+		t.Fatalf("part count: got %d, want 4", partCount)
+	}
+
+	// Find PSV0 part.
+	foundPSV0 := false
+	offsetTableStart := 32
+	for i := 0; i < int(partCount); i++ {
+		offset := binary.LittleEndian.Uint32(data[offsetTableStart+4*i:])
+		fc := binary.LittleEndian.Uint32(data[offset:])
+		if fc == FourCCPSV0 {
+			foundPSV0 = true
+		}
+	}
+	if !foundPSV0 {
+		t.Error("PSV0 part not found in container")
+	}
+
+	// Verify file size.
+	fileSize := binary.LittleEndian.Uint32(data[24:28])
+	if fileSize != uint32(len(data)) {
+		t.Errorf("file size: got %d, actual %d", fileSize, len(data))
+	}
+}

--- a/dxil/internal/container/semantic.go
+++ b/dxil/internal/container/semantic.go
@@ -1,0 +1,74 @@
+// Package container — naga IR binding to DXIL semantic mapping.
+//
+// Maps naga IR bindings (BuiltinBinding, LocationBinding) to DXIL
+// semantic names and system value kinds used in ISG1/OSG1 signatures.
+//
+// Reference: Mesa dxil_signature.c fill_io_signature().
+package container
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/ir"
+)
+
+// SemanticMapping maps a naga IR binding to its DXIL semantic representation.
+type SemanticMapping struct {
+	SemanticName  string
+	SemanticIndex uint32
+	SystemValue   SystemValueKind
+}
+
+// MapBuiltinToSemantic converts a naga BuiltinValue to a DXIL semantic.
+func MapBuiltinToSemantic(builtin ir.BuiltinValue) SemanticMapping {
+	switch builtin {
+	case ir.BuiltinPosition:
+		return SemanticMapping{"SV_Position", 0, SVPosition}
+	case ir.BuiltinVertexIndex:
+		return SemanticMapping{"SV_VertexID", 0, SVVertexID}
+	case ir.BuiltinInstanceIndex:
+		return SemanticMapping{"SV_InstanceID", 0, SVInstanceID}
+	case ir.BuiltinFrontFacing:
+		return SemanticMapping{"SV_IsFrontFace", 0, SVIsFrontFace}
+	case ir.BuiltinFragDepth:
+		return SemanticMapping{"SV_Depth", 0, SVDepth}
+	case ir.BuiltinSampleIndex:
+		return SemanticMapping{"SV_SampleIndex", 0, SVSampleIndex}
+	case ir.BuiltinClipDistance:
+		return SemanticMapping{"SV_ClipDistance", 0, SVClipDistance}
+	default:
+		return SemanticMapping{fmt.Sprintf("SV_Unknown%d", builtin), 0, SVArbitrary}
+	}
+}
+
+// MapLocationToInputSemantic converts a location binding to an input semantic.
+// Input locations use TEXCOORD semantics by convention.
+func MapLocationToInputSemantic(loc uint32) SemanticMapping {
+	return SemanticMapping{"TEXCOORD", loc, SVArbitrary}
+}
+
+// MapLocationToOutputSemantic converts a location binding to an output semantic.
+// For fragment shader outputs, locations map to SV_Target.
+// For vertex shader outputs, locations use TEXCOORD.
+func MapLocationToOutputSemantic(loc uint32, isFragment bool) SemanticMapping {
+	if isFragment {
+		return SemanticMapping{"SV_Target", loc, SVTarget}
+	}
+	return SemanticMapping{"TEXCOORD", loc, SVArbitrary}
+}
+
+// MapBindingToSemantic converts any naga IR binding to a DXIL semantic.
+// isOutput and isFragment control the semantic mapping for LocationBindings.
+func MapBindingToSemantic(binding ir.Binding, isOutput bool, isFragment bool) SemanticMapping {
+	switch b := binding.(type) {
+	case ir.BuiltinBinding:
+		return MapBuiltinToSemantic(b.Builtin)
+	case ir.LocationBinding:
+		if isOutput {
+			return MapLocationToOutputSemantic(b.Location, isFragment)
+		}
+		return MapLocationToInputSemantic(b.Location)
+	default:
+		return SemanticMapping{"UNKNOWN", 0, SVArbitrary}
+	}
+}

--- a/dxil/internal/container/semantic_test.go
+++ b/dxil/internal/container/semantic_test.go
@@ -1,0 +1,115 @@
+package container
+
+import (
+	"testing"
+
+	"github.com/gogpu/naga/ir"
+)
+
+func TestMapBuiltinToSemantic(t *testing.T) {
+	tests := []struct {
+		name     string
+		builtin  ir.BuiltinValue
+		wantName string
+		wantSV   SystemValueKind
+	}{
+		{"Position", ir.BuiltinPosition, "SV_Position", SVPosition},
+		{"VertexIndex", ir.BuiltinVertexIndex, "SV_VertexID", SVVertexID},
+		{"InstanceIndex", ir.BuiltinInstanceIndex, "SV_InstanceID", SVInstanceID},
+		{"FrontFacing", ir.BuiltinFrontFacing, "SV_IsFrontFace", SVIsFrontFace},
+		{"FragDepth", ir.BuiltinFragDepth, "SV_Depth", SVDepth},
+		{"SampleIndex", ir.BuiltinSampleIndex, "SV_SampleIndex", SVSampleIndex},
+		{"ClipDistance", ir.BuiltinClipDistance, "SV_ClipDistance", SVClipDistance},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			m := MapBuiltinToSemantic(tt.builtin)
+			if m.SemanticName != tt.wantName {
+				t.Errorf("name: got %q, want %q", m.SemanticName, tt.wantName)
+			}
+			if m.SystemValue != tt.wantSV {
+				t.Errorf("system value: got %d, want %d", m.SystemValue, tt.wantSV)
+			}
+		})
+	}
+}
+
+func TestMapLocationToInputSemantic(t *testing.T) {
+	tests := []struct {
+		loc       uint32
+		wantName  string
+		wantIndex uint32
+	}{
+		{0, "TEXCOORD", 0},
+		{1, "TEXCOORD", 1},
+		{5, "TEXCOORD", 5},
+	}
+
+	for _, tt := range tests {
+		m := MapLocationToInputSemantic(tt.loc)
+		if m.SemanticName != tt.wantName {
+			t.Errorf("loc %d: name: got %q, want %q", tt.loc, m.SemanticName, tt.wantName)
+		}
+		if m.SemanticIndex != tt.wantIndex {
+			t.Errorf("loc %d: index: got %d, want %d", tt.loc, m.SemanticIndex, tt.wantIndex)
+		}
+		if m.SystemValue != SVArbitrary {
+			t.Errorf("loc %d: system value: got %d, want SVArbitrary", tt.loc, m.SystemValue)
+		}
+	}
+}
+
+func TestMapLocationToOutputSemantic_Fragment(t *testing.T) {
+	m := MapLocationToOutputSemantic(0, true)
+	if m.SemanticName != "SV_Target" {
+		t.Errorf("name: got %q, want %q", m.SemanticName, "SV_Target")
+	}
+	if m.SemanticIndex != 0 {
+		t.Errorf("index: got %d, want 0", m.SemanticIndex)
+	}
+	if m.SystemValue != SVTarget {
+		t.Errorf("system value: got %d, want %d", m.SystemValue, SVTarget)
+	}
+
+	m2 := MapLocationToOutputSemantic(2, true)
+	if m2.SemanticIndex != 2 {
+		t.Errorf("loc 2 index: got %d, want 2", m2.SemanticIndex)
+	}
+}
+
+func TestMapLocationToOutputSemantic_Vertex(t *testing.T) {
+	m := MapLocationToOutputSemantic(0, false)
+	if m.SemanticName != "TEXCOORD" {
+		t.Errorf("name: got %q, want %q", m.SemanticName, "TEXCOORD")
+	}
+	if m.SystemValue != SVArbitrary {
+		t.Errorf("system value: got %d, want SVArbitrary", m.SystemValue)
+	}
+}
+
+func TestMapBindingToSemantic(t *testing.T) {
+	// Builtin input.
+	m := MapBindingToSemantic(ir.BuiltinBinding{Builtin: ir.BuiltinPosition}, false, false)
+	if m.SemanticName != "SV_Position" {
+		t.Errorf("builtin input: got %q, want %q", m.SemanticName, "SV_Position")
+	}
+
+	// Location input.
+	m2 := MapBindingToSemantic(ir.LocationBinding{Location: 3}, false, false)
+	if m2.SemanticName != "TEXCOORD" || m2.SemanticIndex != 3 {
+		t.Errorf("location input: got %q/%d, want TEXCOORD/3", m2.SemanticName, m2.SemanticIndex)
+	}
+
+	// Location output for fragment.
+	m3 := MapBindingToSemantic(ir.LocationBinding{Location: 1}, true, true)
+	if m3.SemanticName != "SV_Target" || m3.SemanticIndex != 1 {
+		t.Errorf("fragment output: got %q/%d, want SV_Target/1", m3.SemanticName, m3.SemanticIndex)
+	}
+
+	// Location output for vertex.
+	m4 := MapBindingToSemantic(ir.LocationBinding{Location: 0}, true, false)
+	if m4.SemanticName != "TEXCOORD" || m4.SemanticIndex != 0 {
+		t.Errorf("vertex output: got %q/%d, want TEXCOORD/0", m4.SemanticName, m4.SemanticIndex)
+	}
+}

--- a/dxil/internal/container/signature.go
+++ b/dxil/internal/container/signature.go
@@ -1,0 +1,155 @@
+// Package container — signature encoding for ISG1/OSG1 parts.
+//
+// Each signature part has the layout:
+//
+//	Header:
+//	  ParamCount  uint32   // total number of signature elements
+//	  ParamOffset uint32   // byte offset from part start to first element (always 8)
+//	Elements:
+//	  [ParamCount]SignatureElement  // each 32 bytes
+//	StringTable:
+//	  null-terminated semantic name strings, 4-byte aligned
+//
+// Reference: Mesa dxil_container.c dxil_container_add_io_signature(),
+// Mesa dxil_signature.h struct dxil_signature_element.
+package container
+
+import (
+	"encoding/binary"
+)
+
+// SystemValueKind identifies DXIL system-value semantics.
+// Values match Mesa's enum dxil_semantic_kind.
+type SystemValueKind uint32
+
+const (
+	SVArbitrary    SystemValueKind = 0  // User-defined (TEXCOORD, COLOR, etc.)
+	SVVertexID     SystemValueKind = 1  // SV_VertexID
+	SVInstanceID   SystemValueKind = 2  // SV_InstanceID
+	SVPosition     SystemValueKind = 3  // SV_Position
+	SVTarget       SystemValueKind = 16 // SV_Target
+	SVDepth        SystemValueKind = 17 // SV_Depth
+	SVSampleIndex  SystemValueKind = 12 // SV_SampleIndex
+	SVIsFrontFace  SystemValueKind = 13 // SV_IsFrontFace
+	SVClipDistance SystemValueKind = 6  // SV_ClipDistance
+)
+
+// ProgSigCompType identifies the component data type in a signature element.
+// Values match Mesa's enum dxil_prog_sig_comp_type.
+type ProgSigCompType uint32
+
+const (
+	CompTypeUnknown ProgSigCompType = 0
+	CompTypeUint32  ProgSigCompType = 1
+	CompTypeSint32  ProgSigCompType = 2
+	CompTypeFloat32 ProgSigCompType = 3
+)
+
+// SignatureElement describes one element of an input or output signature.
+type SignatureElement struct {
+	SemanticName  string
+	SemanticIndex uint32
+	SystemValue   SystemValueKind
+	CompType      ProgSigCompType
+	Register      uint32
+	Mask          uint8 // Component mask: x=1, y=2, z=4, w=8
+	RWMask        uint8 // NeverWritesMask (output) or AlwaysReadsMask (input)
+}
+
+// signatureElementSize is the binary size of one dxil_signature_element.
+// Layout (32 bytes total):
+//
+//	stream:               uint32 (offset 0)
+//	semantic_name_offset: uint32 (offset 4)
+//	semantic_index:       uint32 (offset 8)
+//	system_value:         uint32 (offset 12)
+//	comp_type:            uint32 (offset 16)
+//	register:             uint32 (offset 20)
+//	mask:                 uint8  (offset 24)
+//	rw_mask:              uint8  (offset 25)
+//	pad:                  uint16 (offset 26)
+//	min_precision:        uint32 (offset 28)
+const signatureElementSize = 32
+
+// EncodeSignature serializes a list of SignatureElements into the ISG1/OSG1
+// binary format. The result is the part data (not including the FourCC/size
+// part envelope).
+func EncodeSignature(elements []SignatureElement) []byte {
+	if len(elements) == 0 {
+		// Empty signature: header only.
+		var hdr [8]byte
+		// paramCount = 0, paramOffset = 8
+		binary.LittleEndian.PutUint32(hdr[4:], 8)
+		return hdr[:]
+	}
+
+	// Build string table with deduplication for SV_ names.
+	headerSize := 8 // paramCount + paramOffset
+	fixedSize := headerSize + signatureElementSize*len(elements)
+
+	nameOffsets := make([]uint32, len(elements))
+	svCache := make(map[string]uint32) // deduplicate SV_ names
+	var stringTable []byte
+
+	for i, elem := range elements {
+		name := elem.SemanticName
+		if len(name) >= 3 && name[:3] == "SV_" {
+			if off, ok := svCache[name]; ok {
+				nameOffsets[i] = off
+				continue
+			}
+		}
+		off := uint32(fixedSize + len(stringTable)) //nolint:gosec // bounded by signature size
+		nameOffsets[i] = off
+		if len(name) >= 3 && name[:3] == "SV_" {
+			svCache[name] = off
+		}
+		stringTable = append(stringTable, []byte(name)...)
+		stringTable = append(stringTable, 0) // null terminator
+	}
+
+	// 4-byte align the string table.
+	for len(stringTable)%4 != 0 {
+		stringTable = append(stringTable, 0)
+	}
+
+	totalSize := fixedSize + len(stringTable)
+	out := make([]byte, totalSize)
+
+	// Header.
+	binary.LittleEndian.PutUint32(out[0:], uint32(len(elements))) //nolint:gosec // bounded
+	binary.LittleEndian.PutUint32(out[4:], uint32(headerSize))
+
+	// Elements.
+	for i, elem := range elements {
+		base := headerSize + i*signatureElementSize
+		// stream = 0
+		binary.LittleEndian.PutUint32(out[base+0:], 0)
+		binary.LittleEndian.PutUint32(out[base+4:], nameOffsets[i])
+		binary.LittleEndian.PutUint32(out[base+8:], elem.SemanticIndex)
+		binary.LittleEndian.PutUint32(out[base+12:], uint32(elem.SystemValue))
+		binary.LittleEndian.PutUint32(out[base+16:], uint32(elem.CompType))
+		binary.LittleEndian.PutUint32(out[base+20:], elem.Register)
+		out[base+24] = elem.Mask
+		out[base+25] = elem.RWMask
+		// pad (uint16) at offset 26 = 0
+		// min_precision (uint32) at offset 28 = 0
+	}
+
+	// String table.
+	copy(out[fixedSize:], stringTable)
+
+	return out
+}
+
+// AddInputSignature adds an ISG1 part to the container.
+func (c *Container) AddInputSignature(elements []SignatureElement) {
+	data := EncodeSignature(elements)
+	c.parts = append(c.parts, part{fourCC: FourCCISG1, data: data})
+}
+
+// AddOutputSignature adds an OSG1 part to the container.
+func (c *Container) AddOutputSignature(elements []SignatureElement) {
+	data := EncodeSignature(elements)
+	c.parts = append(c.parts, part{fourCC: FourCCOSG1, data: data})
+}

--- a/dxil/internal/container/signature_test.go
+++ b/dxil/internal/container/signature_test.go
@@ -1,0 +1,294 @@
+package container
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeSignature_Empty(t *testing.T) {
+	data := EncodeSignature(nil)
+	if len(data) != 8 {
+		t.Fatalf("empty signature size: got %d, want 8", len(data))
+	}
+	paramCount := binary.LittleEndian.Uint32(data[0:4])
+	if paramCount != 0 {
+		t.Errorf("paramCount: got %d, want 0", paramCount)
+	}
+	paramOffset := binary.LittleEndian.Uint32(data[4:8])
+	if paramOffset != 8 {
+		t.Errorf("paramOffset: got %d, want 8", paramOffset)
+	}
+}
+
+func TestEncodeInputSignature(t *testing.T) {
+	// Vertex shader with 2 inputs: POSITION (float4) + TEXCOORD0 (float2).
+	elements := []SignatureElement{
+		{
+			SemanticName:  "POSITION",
+			SemanticIndex: 0,
+			SystemValue:   SVArbitrary,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F, // xyzw
+			RWMask:        0x0F,
+		},
+		{
+			SemanticName:  "TEXCOORD",
+			SemanticIndex: 0,
+			SystemValue:   SVArbitrary,
+			CompType:      CompTypeFloat32,
+			Register:      1,
+			Mask:          0x03, // xy
+			RWMask:        0x03,
+		},
+	}
+
+	data := EncodeSignature(elements)
+
+	// Header.
+	paramCount := binary.LittleEndian.Uint32(data[0:4])
+	if paramCount != 2 {
+		t.Errorf("paramCount: got %d, want 2", paramCount)
+	}
+	paramOffset := binary.LittleEndian.Uint32(data[4:8])
+	if paramOffset != 8 {
+		t.Errorf("paramOffset: got %d, want 8", paramOffset)
+	}
+
+	// Element 0: POSITION.
+	e0Base := 8
+	stream := binary.LittleEndian.Uint32(data[e0Base:])
+	if stream != 0 {
+		t.Errorf("elem0 stream: got %d, want 0", stream)
+	}
+	semIdx := binary.LittleEndian.Uint32(data[e0Base+8:])
+	if semIdx != 0 {
+		t.Errorf("elem0 semantic_index: got %d, want 0", semIdx)
+	}
+	sysVal := binary.LittleEndian.Uint32(data[e0Base+12:])
+	if sysVal != uint32(SVArbitrary) {
+		t.Errorf("elem0 system_value: got %d, want %d", sysVal, SVArbitrary)
+	}
+	compType := binary.LittleEndian.Uint32(data[e0Base+16:])
+	if compType != uint32(CompTypeFloat32) {
+		t.Errorf("elem0 comp_type: got %d, want %d", compType, CompTypeFloat32)
+	}
+	reg := binary.LittleEndian.Uint32(data[e0Base+20:])
+	if reg != 0 {
+		t.Errorf("elem0 register: got %d, want 0", reg)
+	}
+	if data[e0Base+24] != 0x0F {
+		t.Errorf("elem0 mask: got 0x%02X, want 0x0F", data[e0Base+24])
+	}
+
+	// Element 1: TEXCOORD at register 1.
+	e1Base := 8 + signatureElementSize
+	reg1 := binary.LittleEndian.Uint32(data[e1Base+20:])
+	if reg1 != 1 {
+		t.Errorf("elem1 register: got %d, want 1", reg1)
+	}
+	if data[e1Base+24] != 0x03 {
+		t.Errorf("elem1 mask: got 0x%02X, want 0x03", data[e1Base+24])
+	}
+
+	// Verify semantic name offsets point to valid strings.
+	fixedSize := 8 + signatureElementSize*2
+	nameOff0 := binary.LittleEndian.Uint32(data[e0Base+4:])
+	if int(nameOff0) < fixedSize || int(nameOff0) >= len(data) {
+		t.Errorf("elem0 name offset %d out of range [%d, %d)", nameOff0, fixedSize, len(data))
+	}
+
+	// Read string at offset.
+	name0 := readNullTermString(data, int(nameOff0))
+	if name0 != "POSITION" {
+		t.Errorf("elem0 semantic name: got %q, want %q", name0, "POSITION")
+	}
+
+	nameOff1 := binary.LittleEndian.Uint32(data[e1Base+4:])
+	name1 := readNullTermString(data, int(nameOff1))
+	if name1 != "TEXCOORD" {
+		t.Errorf("elem1 semantic name: got %q, want %q", name1, "TEXCOORD")
+	}
+
+	// Verify total data is 4-byte aligned.
+	if len(data)%4 != 0 {
+		t.Errorf("signature data not 4-byte aligned: %d bytes", len(data))
+	}
+}
+
+func TestEncodeOutputSignature(t *testing.T) {
+	// Vertex shader output: SV_Position + TEXCOORD0.
+	elements := []SignatureElement{
+		{
+			SemanticName:  "SV_Position",
+			SemanticIndex: 0,
+			SystemValue:   SVPosition,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F,
+			RWMask:        0x00, // neverWritesMask = none written for outputs
+		},
+		{
+			SemanticName:  "TEXCOORD",
+			SemanticIndex: 0,
+			SystemValue:   SVArbitrary,
+			CompType:      CompTypeFloat32,
+			Register:      1,
+			Mask:          0x03,
+			RWMask:        0x00,
+		},
+	}
+
+	data := EncodeSignature(elements)
+
+	// Check SV_Position has correct system value.
+	e0Base := 8
+	sysVal := binary.LittleEndian.Uint32(data[e0Base+12:])
+	if sysVal != uint32(SVPosition) {
+		t.Errorf("SV_Position system_value: got %d, want %d", sysVal, SVPosition)
+	}
+}
+
+func TestFragmentSignatures(t *testing.T) {
+	// Fragment shader output: SV_Target0 (float4).
+	elements := []SignatureElement{
+		{
+			SemanticName:  "SV_Target",
+			SemanticIndex: 0,
+			SystemValue:   SVTarget,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F,
+			RWMask:        0x00,
+		},
+	}
+
+	data := EncodeSignature(elements)
+
+	paramCount := binary.LittleEndian.Uint32(data[0:4])
+	if paramCount != 1 {
+		t.Errorf("paramCount: got %d, want 1", paramCount)
+	}
+
+	e0Base := 8
+	sysVal := binary.LittleEndian.Uint32(data[e0Base+12:])
+	if sysVal != uint32(SVTarget) {
+		t.Errorf("SV_Target system_value: got %d, want %d", sysVal, SVTarget)
+	}
+
+	name := readNullTermString(data, int(binary.LittleEndian.Uint32(data[e0Base+4:])))
+	if name != "SV_Target" {
+		t.Errorf("semantic name: got %q, want %q", name, "SV_Target")
+	}
+}
+
+func TestSVNameDeduplication(t *testing.T) {
+	// Two SV_Target elements should share the same name offset.
+	elements := []SignatureElement{
+		{
+			SemanticName:  "SV_Target",
+			SemanticIndex: 0,
+			SystemValue:   SVTarget,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F,
+		},
+		{
+			SemanticName:  "SV_Target",
+			SemanticIndex: 1,
+			SystemValue:   SVTarget,
+			CompType:      CompTypeFloat32,
+			Register:      1,
+			Mask:          0x0F,
+		},
+	}
+
+	data := EncodeSignature(elements)
+
+	e0Base := 8
+	e1Base := 8 + signatureElementSize
+
+	nameOff0 := binary.LittleEndian.Uint32(data[e0Base+4:])
+	nameOff1 := binary.LittleEndian.Uint32(data[e1Base+4:])
+
+	if nameOff0 != nameOff1 {
+		t.Errorf("SV_ name offsets should be deduplicated: got %d and %d", nameOff0, nameOff1)
+	}
+
+	// Semantic indices should differ.
+	si0 := binary.LittleEndian.Uint32(data[e0Base+8:])
+	si1 := binary.LittleEndian.Uint32(data[e1Base+8:])
+	if si0 != 0 || si1 != 1 {
+		t.Errorf("semantic indices: got %d,%d want 0,1", si0, si1)
+	}
+}
+
+func TestContainerWithSignatures(t *testing.T) {
+	c := New()
+	c.AddFeaturesPart(0)
+	c.AddInputSignature([]SignatureElement{
+		{
+			SemanticName:  "POSITION",
+			SemanticIndex: 0,
+			SystemValue:   SVArbitrary,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F,
+			RWMask:        0x0F,
+		},
+	})
+	c.AddOutputSignature([]SignatureElement{
+		{
+			SemanticName:  "SV_Position",
+			SemanticIndex: 0,
+			SystemValue:   SVPosition,
+			CompType:      CompTypeFloat32,
+			Register:      0,
+			Mask:          0x0F,
+		},
+	})
+	c.AddDXILPart(1, 1, 0, make([]byte, 16))
+	c.AddHashPart()
+	data := c.Bytes()
+
+	// Verify part count = 5 (SFI0, ISG1, OSG1, DXIL, HASH).
+	partCount := binary.LittleEndian.Uint32(data[28:32])
+	if partCount != 5 {
+		t.Fatalf("part count: got %d, want 5", partCount)
+	}
+
+	// Verify file size matches.
+	fileSize := binary.LittleEndian.Uint32(data[24:28])
+	if fileSize != uint32(len(data)) {
+		t.Errorf("file size: got %d, actual %d", fileSize, len(data))
+	}
+
+	// Find ISG1 and OSG1 parts.
+	foundISG1, foundOSG1 := false, false
+	offsetTableStart := 32
+	for i := 0; i < int(partCount); i++ {
+		offset := binary.LittleEndian.Uint32(data[offsetTableStart+4*i:])
+		fc := binary.LittleEndian.Uint32(data[offset:])
+		switch fc {
+		case FourCCISG1:
+			foundISG1 = true
+		case FourCCOSG1:
+			foundOSG1 = true
+		}
+	}
+	if !foundISG1 {
+		t.Error("ISG1 part not found in container")
+	}
+	if !foundOSG1 {
+		t.Error("OSG1 part not found in container")
+	}
+}
+
+// readNullTermString reads a null-terminated string from data at the given offset.
+func readNullTermString(data []byte, offset int) string {
+	end := offset
+	for end < len(data) && data[end] != 0 {
+		end++
+	}
+	return string(data[offset:end])
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -2811,3 +2811,519 @@ func TestEmitLocalInLoop(t *testing.T) {
 	t.Logf("local-in-loop: %d BBs, alloca=%d, store=%d, load=%d, %d bytes bitcode",
 		len(mainFn.BasicBlocks), allocaCount, storeCount, loadCount, len(bc))
 }
+
+// --- Swizzle tests ---
+
+// buildSwizzleShader creates a fragment shader that swizzles vec4.xzy:
+//
+//	@fragment fn main(@location(0) v: vec4<f32>) -> @location(0) vec4<f32> {
+//	    return v.xzy;  // actually returns vec4(v.xzy, 1.0) for valid output
+//	}
+func buildSwizzleShader() *ir.Module {
+	vec4Handle := ir.TypeHandle(0)
+	vec3Handle := ir.TypeHandle(1)
+	f32Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(3)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: vec4Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}}, // [0] v (vec4)
+			{Kind: ir.ExprSwizzle{ // [1] v.xzy (vec3)
+				Vector:  0,
+				Pattern: [4]ir.SwizzleComponent{0, 2, 1, 0}, // x, z, y
+				Size:    3,
+			}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [2] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{1, 1, 1, 2}}}, // [3] vec4 result (simplified)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec4Handle}, // v
+			{Handle: &vec3Handle}, // swizzle
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 4}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+func TestEmitSwizzle(t *testing.T) {
+	irMod := buildSwizzleShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := findMainFunc(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("swizzle: %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+// --- Derivative tests ---
+
+// buildDerivativeShader creates a fragment shader with a derivative expression.
+func buildDerivativeShader(axis ir.DerivativeAxis, control ir.DerivativeControl) *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v
+			{Kind: ir.ExprDerivative{Axis: axis, Control: control, Expr: 0}},      // [1] derivative
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [2] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{1, 2, 2, 3}}}, // [4] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},  // v
+			{Handle: &f32Handle},  // derivative
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+func TestEmitDerivativeCoarseX(t *testing.T) {
+	irMod := buildDerivativeShader(ir.DerivativeX, ir.DerivativeCoarse)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Verify dx.op.derivCoarseX function was created.
+	found := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.derivCoarseX.f32" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.op.derivCoarseX.f32 function not found")
+	}
+
+	mainFn := findMainFunc(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	hasCall := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil && instr.CalledFunc.Name == "dx.op.derivCoarseX.f32" {
+				hasCall = true
+			}
+		}
+	}
+	if !hasCall {
+		t.Error("no call to dx.op.derivCoarseX.f32 found in main")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("derivCoarseX: %d functions, %d bytes", len(mod.Functions), len(bc))
+}
+
+func TestEmitDerivativeFineY(t *testing.T) {
+	irMod := buildDerivativeShader(ir.DerivativeY, ir.DerivativeFine)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	found := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.derivFineY.f32" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.op.derivFineY.f32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("derivFineY: %d functions, %d bytes", len(mod.Functions), len(bc))
+}
+
+func TestEmitDerivativeWidth(t *testing.T) {
+	irMod := buildDerivativeShader(ir.DerivativeWidth, ir.DerivativeNone)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// fwidth decomposes into derivCoarseX + derivCoarseY + fabs + fadd.
+	hasDerivX := false
+	hasDerivY := false
+	hasFAbs := false
+	for _, fn := range mod.Functions {
+		switch fn.Name {
+		case "dx.op.derivCoarseX.f32":
+			hasDerivX = true
+		case "dx.op.derivCoarseY.f32":
+			hasDerivY = true
+		case "dx.op.fabs.f32":
+			hasFAbs = true
+		}
+	}
+	if !hasDerivX {
+		t.Error("dx.op.derivCoarseX.f32 not found (needed for fwidth)")
+	}
+	if !hasDerivY {
+		t.Error("dx.op.derivCoarseY.f32 not found (needed for fwidth)")
+	}
+	if !hasFAbs {
+		t.Error("dx.op.fabs.f32 not found (needed for fwidth)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("fwidth: %d functions, %d bytes", len(mod.Functions), len(bc))
+}
+
+// --- Relational tests ---
+
+// buildRelationalShader creates a fragment shader with a relational expression.
+func buildRelationalShader(relFn ir.RelationalFunction) *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(5)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v
+			{Kind: ir.ExprRelational{Fun: relFn, Argument: 0}},                    // [1] relational(v)
+			{Kind: ir.ExprAs{Expr: 1, Kind: ir.ScalarFloat, Convert: ptrU8(4)}},   // [2] f32(result)
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [4] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{2, 3, 3, 4}}}, // [5] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},  // v
+			{Handle: &boolHandle}, // relational result
+			{Handle: &f32Handle},  // cast to f32
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 6}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+func TestEmitRelationalIsNaN(t *testing.T) {
+	irMod := buildRelationalShader(ir.RelationalIsNan)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	found := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.isNaN.f32" {
+			found = true
+			// Unary dx.op: ret(i32, TYPE) = 2 params.
+			if len(fn.FuncType.ParamTypes) != 2 {
+				t.Errorf("dx.op.isNaN.f32 params: got %d, want 2", len(fn.FuncType.ParamTypes))
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.op.isNaN.f32 function not found")
+	}
+
+	mainFn := findMainFunc(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	hasCall := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil && instr.CalledFunc.Name == "dx.op.isNaN.f32" {
+				hasCall = true
+			}
+		}
+	}
+	if !hasCall {
+		t.Error("no call to dx.op.isNaN.f32 found in main")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("isNaN: %d functions, %d bytes", len(mod.Functions), len(bc))
+}
+
+func TestEmitRelationalIsInf(t *testing.T) {
+	irMod := buildRelationalShader(ir.RelationalIsInf)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	found := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.isInf.f32" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.op.isInf.f32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("isInf: %d functions, %d bytes", len(mod.Functions), len(bc))
+}
+
+// --- Error handling tests ---
+
+func TestEmitUnsupportedExpression(t *testing.T) {
+	// ExprArrayLength should return an error, not a placeholder.
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(1)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}}, // [0] v
+			{Kind: ir.ExprArrayLength{Array: 0}},      // [1] arrayLength — not implemented
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 2}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	_, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err == nil {
+		t.Fatal("expected error for ExprArrayLength, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestEmitUnsupportedStatement(t *testing.T) {
+	// StmtSwitch should return an error (not silently skip).
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(0)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}}, // [0] v
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtSwitch{Selector: 0}}, // unsupported
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	_, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err == nil {
+		t.Fatal("expected error for StmtSwitch, got nil")
+	}
+	t.Logf("got expected error: %v", err)
+}
+
+func TestEmitStmtKillSilentSkip(t *testing.T) {
+	// StmtKill should be silently skipped (not error) since it's Phase 2.
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(0)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}}, // [0] v
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+			{Kind: ir.StmtKill{}}, // should be silently skipped
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	_, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("StmtKill should be silently skipped, got error: %v", err)
+	}
+	t.Log("StmtKill correctly silently skipped")
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -1,0 +1,568 @@
+package emit
+
+import (
+	"testing"
+
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
+// buildPassthroughVertex creates a minimal vertex shader IR module:
+//
+//	@vertex fn main(@builtin(position) pos: vec4<f32>) -> @builtin(position) vec4<f32> {
+//	    return pos;
+//	}
+func buildPassthroughVertex() *ir.Module {
+	// Types: vec4<f32>
+	vec4f32Handle := ir.TypeHandle(0)
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	// Entry point with one argument and a result.
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	resultBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	retHandle := ir.ExpressionHandle(0)
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "pos", Type: vec4f32Handle, Binding: &posBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	return mod
+}
+
+// buildSimpleTransformVertex creates a vertex shader that constructs vec4 from vec2:
+//
+//	@vertex fn main(@location(0) pos: vec2<f32>) -> @builtin(position) vec4<f32> {
+//	    return vec4(pos, 0.0, 1.0);
+//	}
+func buildSimpleTransformVertex() *ir.Module {
+	vec2f32Handle := ir.TypeHandle(0)
+	vec4f32Handle := ir.TypeHandle(1)
+	f32Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	posBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	retHandle := ir.ExpressionHandle(4) // compose result
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "pos", Type: vec2f32Handle, Binding: &posBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] pos
+			{Kind: ir.ExprAccessIndex{Base: 0, Index: 0}},                         // [1] pos.x
+			{Kind: ir.ExprAccessIndex{Base: 0, Index: 1}},                         // [2] pos.y
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [4] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{1, 2, 3, 4}}}, // [5] vec4(pos.x, pos.y, 0.0, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec2f32Handle}, // pos
+			{Handle: &f32Handle},     // pos.x
+			{Handle: &f32Handle},     // pos.y
+			{Handle: &f32Handle},     // 0.0
+			{Handle: &f32Handle},     // 1.0
+			{Handle: &vec4f32Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 6}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	// Fix: retHandle should point to compose (index 5)
+	retHandle = 5
+	fn.Body[1] = ir.Statement{Kind: ir.StmtReturn{Value: &retHandle}}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	return mod
+}
+
+// buildSimpleFragmentShader creates a minimal fragment shader:
+//
+//	@fragment fn main() -> @location(0) vec4<f32> {
+//	    return vec4(1.0, 0.0, 0.0, 1.0);
+//	}
+func buildSimpleFragmentShader() *ir.Module {
+	vec4f32Handle := ir.TypeHandle(0)
+	f32Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4) // compose result
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [0] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [1] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [2] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{0, 1, 2, 3}}}, // [4] vec4(...)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	return mod
+}
+
+// buildBinaryArithmeticVertex creates a vertex shader with arithmetic:
+//
+//	@vertex fn main(@location(0) a: f32, @location(1) b: f32) -> @builtin(position) vec4<f32> {
+//	    let sum = a + b;
+//	    return vec4(sum, sum, 0.0, 1.0);
+//	}
+func buildBinaryArithmeticVertex() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4f32Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	bBinding := ir.Binding(ir.LocationBinding{Location: 1})
+	resultBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	retHandle := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "a", Type: f32Handle, Binding: &aBinding},
+			{Name: "b", Type: f32Handle, Binding: &bBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] a
+			{Kind: ir.ExprFunctionArgument{Index: 1}},                             // [1] b
+			{Kind: ir.ExprBinary{Op: ir.BinaryAdd, Left: 0, Right: 1}},            // [2] a + b
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [4] 1.0
+			{Kind: ir.ExprSplat{Value: 2, Size: ir.VectorSize(4)}},                // not used
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{2, 2, 3, 4}}}, // [6] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &vec4f32Handle},
+			{Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	return mod
+}
+
+func TestEmitPassthroughVertex(t *testing.T) {
+	irMod := buildPassthroughVertex()
+
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Verify module structure.
+	if mod.ShaderKind != module.VertexShader {
+		t.Errorf("shader kind: got %d, want VertexShader (%d)", mod.ShaderKind, module.VertexShader)
+	}
+
+	// Must have at least one function definition (main).
+	if len(mod.Functions) == 0 {
+		t.Fatal("no functions emitted")
+	}
+
+	// Main function should have a non-empty body.
+	var mainFn *module.Function
+	for i := range mod.Functions {
+		if mod.Functions[i].Name == "main" {
+			mainFn = mod.Functions[i]
+			break
+		}
+	}
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+	if len(mainFn.BasicBlocks) == 0 {
+		t.Fatal("main function has no basic blocks")
+	}
+	if len(mainFn.BasicBlocks[0].Instructions) == 0 {
+		t.Fatal("entry block has no instructions")
+	}
+
+	// Must have named metadata.
+	metadataNames := make(map[string]bool)
+	for _, nm := range mod.NamedMetadata {
+		metadataNames[nm.Name] = true
+	}
+	for _, required := range []string{"dx.version", "dx.shaderModel", "dx.entryPoints"} {
+		if !metadataNames[required] {
+			t.Errorf("missing required metadata: %s", required)
+		}
+	}
+
+	// Serialize to verify it produces valid bitcode.
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	if bc[0] != 'B' || bc[1] != 'C' || bc[2] != 0xC0 || bc[3] != 0xDE {
+		t.Errorf("invalid bitcode magic: %02X %02X %02X %02X", bc[0], bc[1], bc[2], bc[3])
+	}
+	if len(bc)%4 != 0 {
+		t.Errorf("bitcode not 32-bit aligned: %d bytes", len(bc))
+	}
+
+	t.Logf("passthrough vertex: %d types, %d functions, %d constants, %d metadata nodes, %d bytes bitcode",
+		len(mod.Types), len(mod.Functions), len(mod.Constants), len(mod.Metadata), len(bc))
+}
+
+func TestEmitSimpleTransformVertex(t *testing.T) {
+	irMod := buildSimpleTransformVertex()
+
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	if mod.ShaderKind != module.VertexShader {
+		t.Errorf("shader kind: got %d, want VertexShader", mod.ShaderKind)
+	}
+
+	// Must have float constants for 0.0 and 1.0.
+	hasFloatConst := false
+	for _, c := range mod.Constants {
+		if c.ConstType.Kind == module.TypeFloat {
+			hasFloatConst = true
+			break
+		}
+	}
+	if !hasFloatConst {
+		t.Error("no float constants emitted (expected 0.0, 1.0)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("simple transform vertex: %d types, %d functions, %d constants, %d bytes bitcode",
+		len(mod.Types), len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitSimpleFragment(t *testing.T) {
+	irMod := buildSimpleFragmentShader()
+
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	if mod.ShaderKind != module.PixelShader {
+		t.Errorf("shader kind: got %d, want PixelShader (%d)", mod.ShaderKind, module.PixelShader)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("simple fragment: %d types, %d functions, %d constants, %d bytes bitcode",
+		len(mod.Types), len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitBinaryArithmeticVertex(t *testing.T) {
+	irMod := buildBinaryArithmeticVertex()
+
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Verify that binary operations generated instructions.
+	var mainFn *module.Function
+	for i := range mod.Functions {
+		if mod.Functions[i].Name == "main" {
+			mainFn = mod.Functions[i]
+			break
+		}
+	}
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	hasBinOp := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrBinOp {
+				hasBinOp = true
+			}
+		}
+	}
+	if !hasBinOp {
+		t.Error("no binary operation instructions found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("binary arithmetic vertex: %d types, %d functions, %d constants, %d bytes bitcode",
+		len(mod.Types), len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitNoEntryPoints(t *testing.T) {
+	irMod := &ir.Module{}
+	_, err := Emit(irMod, EmitOptions{})
+	if err == nil {
+		t.Fatal("expected error for module with no entry points")
+	}
+}
+
+func TestStageMapping(t *testing.T) {
+	tests := []struct {
+		stage ir.ShaderStage
+		want  module.ShaderKind
+	}{
+		{ir.StageVertex, module.VertexShader},
+		{ir.StageFragment, module.PixelShader},
+		{ir.StageCompute, module.ComputeShader},
+	}
+	for _, tt := range tests {
+		got := stageToShaderKind(tt.stage)
+		if got != tt.want {
+			t.Errorf("stageToShaderKind(%d) = %d, want %d", tt.stage, got, tt.want)
+		}
+	}
+}
+
+func TestShaderKindString(t *testing.T) {
+	tests := []struct {
+		kind module.ShaderKind
+		want string
+	}{
+		{module.VertexShader, "vs"},
+		{module.PixelShader, "ps"},
+		{module.ComputeShader, "cs"},
+		{module.GeometryShader, "gs"},
+		{module.HullShader, "hs"},
+		{module.DomainShader, "ds"},
+	}
+	for _, tt := range tests {
+		got := shaderKindString(tt.kind)
+		if got != tt.want {
+			t.Errorf("shaderKindString(%d) = %q, want %q", tt.kind, got, tt.want)
+		}
+	}
+}
+
+func TestOverloadForScalar(t *testing.T) {
+	tests := []struct {
+		scalar ir.ScalarType
+		want   overloadType
+	}{
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, overloadF32},
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}, overloadF64},
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 2}, overloadF16},
+		{ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, overloadI32},
+		{ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, overloadI32},
+		{ir.ScalarType{Kind: ir.ScalarSint, Width: 8}, overloadI64},
+		{ir.ScalarType{Kind: ir.ScalarBool, Width: 1}, overloadI1},
+	}
+	for _, tt := range tests {
+		got := overloadForScalar(tt.scalar)
+		if got != tt.want {
+			t.Errorf("overloadForScalar(%v) = %d, want %d", tt.scalar, got, tt.want)
+		}
+	}
+}
+
+func TestComponentCount(t *testing.T) {
+	tests := []struct {
+		inner ir.TypeInner
+		want  int
+	}{
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, 1},
+		{ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, 2},
+		{ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, 3},
+		{ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, 4},
+		{ir.MatrixType{Columns: 4, Rows: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, 16},
+	}
+	for _, tt := range tests {
+		got := componentCount(tt.inner)
+		if got != tt.want {
+			t.Errorf("componentCount(%T) = %d, want %d", tt.inner, got, tt.want)
+		}
+	}
+}
+
+func TestScalarOfType(t *testing.T) {
+	tests := []struct {
+		inner    ir.TypeInner
+		wantOK   bool
+		wantKind ir.ScalarKind
+	}{
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, true, ir.ScalarFloat},
+		{ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarSint, Width: 4}}, true, ir.ScalarSint},
+		{ir.MatrixType{Columns: 2, Rows: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}, true, ir.ScalarFloat},
+	}
+	for _, tt := range tests {
+		s, ok := scalarOfType(tt.inner)
+		if ok != tt.wantOK {
+			t.Errorf("scalarOfType(%T): ok=%v, want %v", tt.inner, ok, tt.wantOK)
+			continue
+		}
+		if ok && s.Kind != tt.wantKind {
+			t.Errorf("scalarOfType(%T): kind=%v, want %v", tt.inner, s.Kind, tt.wantKind)
+		}
+	}
+}
+
+func TestTypeMappingScalar(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+	irMod := &ir.Module{}
+
+	tests := []struct {
+		inner    ir.TypeInner
+		wantKind module.TypeKind
+	}{
+		{ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, module.TypeFloat},
+		{ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, module.TypeInteger},
+		{ir.ScalarType{Kind: ir.ScalarBool, Width: 1}, module.TypeInteger},
+	}
+	for _, tt := range tests {
+		ty, err := typeToDXIL(mod, irMod, tt.inner)
+		if err != nil {
+			t.Errorf("typeToDXIL(%T): %v", tt.inner, err)
+			continue
+		}
+		if ty.Kind != tt.wantKind {
+			t.Errorf("typeToDXIL(%T): kind=%v, want %v", tt.inner, ty.Kind, tt.wantKind)
+		}
+	}
+}
+
+func TestTypeMappingVectorReturnsScalar(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+	irMod := &ir.Module{}
+
+	// DXIL has no vectors — typeToDXIL should return the scalar element type.
+	vec := ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}
+	ty, err := typeToDXIL(mod, irMod, vec)
+	if err != nil {
+		t.Fatalf("typeToDXIL(vec4<f32>): %v", err)
+	}
+	if ty.Kind != module.TypeFloat {
+		t.Errorf("typeToDXIL(vec4<f32>): kind=%v, want TypeFloat", ty.Kind)
+	}
+}
+
+func TestIsFloatType(t *testing.T) {
+	if !isFloatType(ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}) {
+		t.Error("isFloatType(f32) should be true")
+	}
+	if isFloatType(ir.ScalarType{Kind: ir.ScalarSint, Width: 4}) {
+		t.Error("isFloatType(i32) should be false")
+	}
+	if !isFloatType(ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}) {
+		t.Error("isFloatType(vec4<f32>) should be true")
+	}
+}
+
+func TestBuiltinSemanticIndex(t *testing.T) {
+	tests := []struct {
+		builtin ir.BuiltinValue
+		want    int
+	}{
+		{ir.BuiltinPosition, 0},
+		{ir.BuiltinVertexIndex, 1},
+		{ir.BuiltinInstanceIndex, 2},
+		{ir.BuiltinFrontFacing, 0},
+		{ir.BuiltinFragDepth, 0},
+	}
+	for _, tt := range tests {
+		got := builtinSemanticIndex(tt.builtin)
+		if got != tt.want {
+			t.Errorf("builtinSemanticIndex(%d) = %d, want %d", tt.builtin, got, tt.want)
+		}
+	}
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -566,3 +566,1239 @@ func TestBuiltinSemanticIndex(t *testing.T) {
 		}
 	}
 }
+
+// buildMathBinaryShader creates a fragment shader with a binary math function:
+//
+//	@fragment fn main(@location(0) a: f32, @location(1) b: f32) -> @location(0) vec4<f32> {
+//	    let r = mathFn(a, b);
+//	    return vec4(r, r, r, 1.0);
+//	}
+func buildMathBinaryShader(mathFn ir.MathFunction, scalarKind ir.ScalarKind) *ir.Module {
+	var scalarWidth byte = 4
+	scalar := ir.ScalarType{Kind: scalarKind, Width: scalarWidth}
+	scalarHandle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: scalar},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	bBinding := ir.Binding(ir.LocationBinding{Location: 1})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	arg1Handle := ir.ExpressionHandle(1)
+	retHandle := ir.ExpressionHandle(5)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "a", Type: scalarHandle, Binding: &aBinding},
+			{Name: "b", Type: scalarHandle, Binding: &bBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] a
+			{Kind: ir.ExprFunctionArgument{Index: 1}},                             // [1] b
+			{Kind: ir.ExprMath{Fun: mathFn, Arg: 0, Arg1: &arg1Handle}},           // [2] mathFn(a, b)
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [4] 0.0 (padding)
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{2, 2, 2, 3}}}, // [5] vec4(r, r, r, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &scalarHandle}, // a
+			{Handle: &scalarHandle}, // b
+			{Handle: &scalarHandle}, // result
+			{Handle: &scalarHandle}, // 1.0
+			{Handle: &scalarHandle}, // 0.0
+			{Handle: &vec4Handle},   // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 6}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildMathTernaryShader creates a fragment shader with a ternary math function.
+func buildMathTernaryShader(mathFn ir.MathFunction) *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	bBinding := ir.Binding(ir.LocationBinding{Location: 1})
+	cBinding := ir.Binding(ir.LocationBinding{Location: 2})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	arg1Handle := ir.ExpressionHandle(1)
+	arg2Handle := ir.ExpressionHandle(2)
+	retHandle := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "a", Type: f32Handle, Binding: &aBinding},
+			{Name: "b", Type: f32Handle, Binding: &bBinding},
+			{Name: "c", Type: f32Handle, Binding: &cBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                                      // [0] a
+			{Kind: ir.ExprFunctionArgument{Index: 1}},                                      // [1] b
+			{Kind: ir.ExprFunctionArgument{Index: 2}},                                      // [2] c
+			{Kind: ir.ExprMath{Fun: mathFn, Arg: 0, Arg1: &arg1Handle, Arg2: &arg2Handle}}, // [3] mathFn(a, b, c)
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                                  // [4] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                                  // [5] 0.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{3, 3, 3, 4}}},          // [6] vec4(r, r, r, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},  // a
+			{Handle: &f32Handle},  // b
+			{Handle: &f32Handle},  // c
+			{Handle: &f32Handle},  // result
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildDotProductShader creates a fragment shader with dot product:
+//
+//	@fragment fn main(@location(0) a: vec3<f32>, @location(1) b: vec3<f32>) -> @location(0) vec4<f32> {
+//	    let d = dot(a, b);
+//	    return vec4(d, d, d, 1.0);
+//	}
+func buildDotProductShader(vecSize ir.VectorSize) *ir.Module {
+	vecHandle := ir.TypeHandle(0)
+	f32Handle := ir.TypeHandle(1)
+	vec4Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: vecSize, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	bBinding := ir.Binding(ir.LocationBinding{Location: 1})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	arg1Handle := ir.ExpressionHandle(1)
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "a", Type: vecHandle, Binding: &aBinding},
+			{Name: "b", Type: vecHandle, Binding: &bBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] a
+			{Kind: ir.ExprFunctionArgument{Index: 1}},                             // [1] b
+			{Kind: ir.ExprMath{Fun: ir.MathDot, Arg: 0, Arg1: &arg1Handle}},       // [2] dot(a, b)
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{2, 2, 2, 3}}}, // [4] vec4(d, d, d, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vecHandle},  // a
+			{Handle: &vecHandle},  // b
+			{Handle: &f32Handle},  // dot result (scalar)
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildCrossProductShader creates a fragment shader with cross product.
+func buildCrossProductShader() *ir.Module {
+	vec3Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	f32Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	bBinding := ir.Binding(ir.LocationBinding{Location: 1})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	arg1Handle := ir.ExpressionHandle(1)
+	retHandle := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "a", Type: vec3Handle, Binding: &aBinding},
+			{Name: "b", Type: vec3Handle, Binding: &bBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] a (vec3)
+			{Kind: ir.ExprFunctionArgument{Index: 1}},                             // [1] b (vec3)
+			{Kind: ir.ExprMath{Fun: ir.MathCross, Arg: 0, Arg1: &arg1Handle}},     // [2] cross(a, b) -> vec3
+			{Kind: ir.ExprAccessIndex{Base: 2, Index: 0}},                         // [3] cross.x
+			{Kind: ir.ExprAccessIndex{Base: 2, Index: 1}},                         // [4] cross.y
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [5] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{3, 4, 3, 5}}}, // [6] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec3Handle}, // a
+			{Handle: &vec3Handle}, // b
+			{Handle: &vec3Handle}, // cross result
+			{Handle: &f32Handle},  // cross.x
+			{Handle: &f32Handle},  // cross.y
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildLengthShader creates a fragment shader with length(vec3).
+func buildLengthShader() *ir.Module {
+	vec3Handle := ir.TypeHandle(0)
+	f32Handle := ir.TypeHandle(1)
+	vec4Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(3)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: vec3Handle, Binding: &aBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v (vec3)
+			{Kind: ir.ExprMath{Fun: ir.MathLength, Arg: 0}},                       // [1] length(v) -> scalar
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [2] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{1, 1, 1, 2}}}, // [3] vec4(l, l, l, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec3Handle}, // v
+			{Handle: &f32Handle},  // length result
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 4}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+func TestEmitMathMinFloat(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathMin, ir.ScalarFloat)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Verify dx.op.fmin function was created.
+	hasFMin := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.fmin.f32" {
+			hasFMin = true
+			// Binary dx.op: ret(i32, TYPE, TYPE) = 3 params.
+			if len(fn.FuncType.ParamTypes) != 3 {
+				t.Errorf("dx.op.fmin.f32 params: got %d, want 3", len(fn.FuncType.ParamTypes))
+			}
+			break
+		}
+	}
+	if !hasFMin {
+		t.Error("dx.op.fmin.f32 function not found")
+	}
+
+	// Must have call instructions for the dx.op.
+	mainFn := findMainFunc(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+	hasCall := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil && instr.CalledFunc.Name == "dx.op.fmin.f32" {
+				hasCall = true
+			}
+		}
+	}
+	if !hasCall {
+		t.Error("no call to dx.op.fmin.f32 found in main")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("min(f32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathMaxSint(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathMax, ir.ScalarSint)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	hasIMax := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.imax.i32" {
+			hasIMax = true
+			break
+		}
+	}
+	if !hasIMax {
+		t.Error("dx.op.imax.i32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("max(i32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathMaxUint(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathMax, ir.ScalarUint)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	hasUMax := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.umax.i32" {
+			hasUMax = true
+			break
+		}
+	}
+	if !hasUMax {
+		t.Error("dx.op.umax.i32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+}
+
+func TestEmitMathClamp(t *testing.T) {
+	irMod := buildMathTernaryShader(ir.MathClamp)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Clamp(float) uses fmax + fmin.
+	hasFMax := false
+	hasFMin := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.fmax.f32" {
+			hasFMax = true
+		}
+		if fn.Name == "dx.op.fmin.f32" {
+			hasFMin = true
+		}
+	}
+	if !hasFMax {
+		t.Error("dx.op.fmax.f32 function not found (needed for clamp)")
+	}
+	if !hasFMin {
+		t.Error("dx.op.fmin.f32 function not found (needed for clamp)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("clamp(f32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathMix(t *testing.T) {
+	irMod := buildMathTernaryShader(ir.MathMix)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Mix uses fmad (b-a subtraction + fmad(t, b-a, a)).
+	hasFMad := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.fmad.f32" {
+			hasFMad = true
+			// Ternary dx.op: ret(i32, TYPE, TYPE, TYPE) = 4 params.
+			if len(fn.FuncType.ParamTypes) != 4 {
+				t.Errorf("dx.op.fmad.f32 params: got %d, want 4", len(fn.FuncType.ParamTypes))
+			}
+			break
+		}
+	}
+	if !hasFMad {
+		t.Error("dx.op.fmad.f32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("mix(f32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathFma(t *testing.T) {
+	irMod := buildMathTernaryShader(ir.MathFma)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	hasFma := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.fma.f32" {
+			hasFma = true
+			break
+		}
+	}
+	if !hasFma {
+		t.Error("dx.op.fma.f32 function not found")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+}
+
+func TestEmitMathPow(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathPow, ir.ScalarFloat)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Pow decomposes into log2 + fmul + exp2.
+	hasLog := false
+	hasExp := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.log.f32" {
+			hasLog = true
+		}
+		if fn.Name == "dx.op.exp.f32" {
+			hasExp = true
+		}
+	}
+	if !hasLog {
+		t.Error("dx.op.log.f32 function not found (needed for pow)")
+	}
+	if !hasExp {
+		t.Error("dx.op.exp.f32 function not found (needed for pow)")
+	}
+
+	// Check for binary op instruction (fmul for log2(base)*exp).
+	mainFn := findMainFunc(mod)
+	hasBinOp := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrBinOp {
+				hasBinOp = true
+			}
+		}
+	}
+	if !hasBinOp {
+		t.Error("no binary op instruction found (needed for pow log*exp)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("pow(f32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathStep(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathStep, ir.ScalarFloat)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Step uses fcmp + select.
+	mainFn := findMainFunc(mod)
+	hasCmp := false
+	hasSelect := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCmp {
+				hasCmp = true
+			}
+			if instr.Kind == module.InstrSelect {
+				hasSelect = true
+			}
+		}
+	}
+	if !hasCmp {
+		t.Error("no comparison instruction found (needed for step)")
+	}
+	if !hasSelect {
+		t.Error("no select instruction found (needed for step)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+}
+
+func TestEmitMathSmoothStep(t *testing.T) {
+	irMod := buildMathTernaryShader(ir.MathSmoothStep)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// SmoothStep uses fmax, fmin (for clamp), plus several fmul/fsub.
+	hasFMax := false
+	hasFMin := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.fmax.f32" {
+			hasFMax = true
+		}
+		if fn.Name == "dx.op.fmin.f32" {
+			hasFMin = true
+		}
+	}
+	if !hasFMax {
+		t.Error("dx.op.fmax.f32 not found (needed for smoothstep clamp)")
+	}
+	if !hasFMin {
+		t.Error("dx.op.fmin.f32 not found (needed for smoothstep clamp)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("smoothstep(f32): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitDotProduct(t *testing.T) {
+	tests := []struct {
+		name    string
+		vecSize ir.VectorSize
+		dotName string
+	}{
+		{"dot2", 2, "dx.op.dot2.f32"},
+		{"dot3", 3, "dx.op.dot3.f32"},
+		{"dot4", 4, "dx.op.dot4.f32"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			irMod := buildDotProductShader(tt.vecSize)
+			mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+			if err != nil {
+				t.Fatalf("Emit failed: %v", err)
+			}
+
+			hasDot := false
+			for _, fn := range mod.Functions {
+				if fn.Name == tt.dotName {
+					hasDot = true
+					// Dot params: i32 + 2*size scalar values.
+					wantParams := 1 + 2*int(tt.vecSize)
+					if len(fn.FuncType.ParamTypes) != wantParams {
+						t.Errorf("%s params: got %d, want %d", tt.dotName, len(fn.FuncType.ParamTypes), wantParams)
+					}
+					break
+				}
+			}
+			if !hasDot {
+				t.Errorf("%s function not found", tt.dotName)
+			}
+
+			bc := module.Serialize(mod)
+			if len(bc) == 0 {
+				t.Fatal("serialization produced empty bitcode")
+			}
+			t.Logf("%s: %d functions, %d constants, %d bytes", tt.name, len(mod.Functions), len(mod.Constants), len(bc))
+		})
+	}
+}
+
+func TestEmitCrossProduct(t *testing.T) {
+	irMod := buildCrossProductShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Cross product uses 6 fmul + 3 fsub = 9 binary ops total.
+	// Note: finalize remaps operand values including the binop code,
+	// so we count InstrBinOp instructions rather than checking op codes.
+	mainFn := findMainFunc(mod)
+	binOpCount := 0
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrBinOp {
+				binOpCount++
+			}
+		}
+	}
+	// Cross product should generate at least 9 binary ops (6 mul + 3 sub).
+	if binOpCount < 9 {
+		t.Errorf("cross product: expected >= 9 binary ops, got %d", binOpCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("cross(vec3): %d binops, %d functions, %d bytes", binOpCount, len(mod.Functions), len(bc))
+}
+
+func TestEmitMathLength(t *testing.T) {
+	irMod := buildLengthShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Length(vec3) = sqrt(dot3(v, v)).
+	hasDot3 := false
+	hasSqrt := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.dot3.f32" {
+			hasDot3 = true
+		}
+		if fn.Name == "dx.op.sqrt.f32" {
+			hasSqrt = true
+		}
+	}
+	if !hasDot3 {
+		t.Error("dx.op.dot3.f32 not found (needed for length)")
+	}
+	if !hasSqrt {
+		t.Error("dx.op.sqrt.f32 not found (needed for length)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("length(vec3): %d functions, %d constants, %d bytes", len(mod.Functions), len(mod.Constants), len(bc))
+}
+
+func TestEmitMathAtan2(t *testing.T) {
+	irMod := buildMathBinaryShader(ir.MathAtan2, ir.ScalarFloat)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Atan2 decomposes into fdiv + atan.
+	hasAtan := false
+	for _, fn := range mod.Functions {
+		if fn.Name == "dx.op.atan.f32" {
+			hasAtan = true
+			break
+		}
+	}
+	if !hasAtan {
+		t.Error("dx.op.atan.f32 not found (needed for atan2)")
+	}
+
+	// Check for binary op instruction (fdiv for y/x).
+	mainFn := findMainFunc(mod)
+	hasBinOp := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrBinOp {
+				hasBinOp = true
+			}
+		}
+	}
+	if !hasBinOp {
+		t.Error("no binary op instruction found (needed for atan2 y/x)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+}
+
+func TestOverloadSuffix(t *testing.T) {
+	tests := []struct {
+		ol   overloadType
+		want string
+	}{
+		{overloadF32, ".f32"},
+		{overloadF64, ".f64"},
+		{overloadF16, ".f16"},
+		{overloadI32, ".i32"},
+		{overloadI64, ".i64"},
+		{overloadI16, ".i16"},
+		{overloadI1, ".i1"},
+		{overloadVoid, ""},
+	}
+	for _, tt := range tests {
+		got := overloadSuffix(tt.ol)
+		if got != tt.want {
+			t.Errorf("overloadSuffix(%d) = %q, want %q", tt.ol, got, tt.want)
+		}
+	}
+}
+
+func TestGetDxOpBinaryFunc(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+	irMod := &ir.Module{}
+	e := &Emitter{
+		ir:          irMod,
+		mod:         mod,
+		exprValues:  make(map[ir.ExpressionHandle]int),
+		dxOpFuncs:   make(map[dxOpKey]*module.Function),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+		undefID:     -1,
+		constMap:    make(map[int]*module.Constant),
+	}
+
+	fn := e.getDxOpBinaryFunc("dx.op.fmin", overloadF32)
+	if fn.Name != "dx.op.fmin.f32" {
+		t.Errorf("name: got %q, want %q", fn.Name, "dx.op.fmin.f32")
+	}
+	if len(fn.FuncType.ParamTypes) != 3 {
+		t.Errorf("params: got %d, want 3", len(fn.FuncType.ParamTypes))
+	}
+
+	// Second call should return cached.
+	fn2 := e.getDxOpBinaryFunc("dx.op.fmin", overloadF32)
+	if fn != fn2 {
+		t.Error("getDxOpBinaryFunc did not return cached function")
+	}
+}
+
+func TestGetDxOpTernaryFunc(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+	irMod := &ir.Module{}
+	e := &Emitter{
+		ir:          irMod,
+		mod:         mod,
+		exprValues:  make(map[ir.ExpressionHandle]int),
+		dxOpFuncs:   make(map[dxOpKey]*module.Function),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+		undefID:     -1,
+		constMap:    make(map[int]*module.Constant),
+	}
+
+	fn := e.getDxOpTernaryFunc("dx.op.fmad", overloadF32)
+	if fn.Name != "dx.op.fmad.f32" {
+		t.Errorf("name: got %q, want %q", fn.Name, "dx.op.fmad.f32")
+	}
+	if len(fn.FuncType.ParamTypes) != 4 {
+		t.Errorf("params: got %d, want 4", len(fn.FuncType.ParamTypes))
+	}
+}
+
+func TestGetDxOpDotFunc(t *testing.T) {
+	mod := module.NewModule(module.VertexShader)
+	irMod := &ir.Module{}
+	e := &Emitter{
+		ir:          irMod,
+		mod:         mod,
+		exprValues:  make(map[ir.ExpressionHandle]int),
+		dxOpFuncs:   make(map[dxOpKey]*module.Function),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+		undefID:     -1,
+		constMap:    make(map[int]*module.Constant),
+	}
+
+	fn := e.getDxOpDotFunc(3, overloadF32)
+	if fn.Name != "dx.op.dot3.f32" {
+		t.Errorf("name: got %q, want %q", fn.Name, "dx.op.dot3.f32")
+	}
+	// dot3: i32 + 3*2 = 7 params
+	if len(fn.FuncType.ParamTypes) != 7 {
+		t.Errorf("params: got %d, want 7", len(fn.FuncType.ParamTypes))
+	}
+
+	fn4 := e.getDxOpDotFunc(4, overloadF32)
+	if fn4.Name != "dx.op.dot4.f32" {
+		t.Errorf("name: got %q, want %q", fn4.Name, "dx.op.dot4.f32")
+	}
+	if len(fn4.FuncType.ParamTypes) != 9 {
+		t.Errorf("params: got %d, want 9", len(fn4.FuncType.ParamTypes))
+	}
+}
+
+// findMainFunc finds the "main" function in a module.
+func findMainFunc(mod *module.Module) *module.Function {
+	for _, fn := range mod.Functions {
+		if fn.Name == "main" {
+			return fn
+		}
+	}
+	return nil
+}
+
+// --- Type cast (ExprAs) tests ---
+
+// buildCastShader creates a fragment shader that casts a scalar input to a different type:
+//
+//	@fragment fn main(@location(0) v: srcType) -> @location(0) vec4<f32> {
+//	    let c = dstType(v);
+//	    return vec4(f32(c), 0.0, 0.0, 1.0);
+//	}
+//
+// The ExprAs is at expression [1] with the given kind and convert width.
+func buildCastShader(srcScalar ir.ScalarType, dstKind ir.ScalarKind, convertWidth *uint8) *ir.Module {
+	srcHandle := ir.TypeHandle(0)
+	f32Handle := ir.TypeHandle(1)
+	vec4Handle := ir.TypeHandle(2)
+
+	// Determine dst scalar for type resolution.
+	var dstWidth uint8
+	if convertWidth != nil {
+		dstWidth = *convertWidth
+	} else {
+		dstWidth = srcScalar.Width
+	}
+	dstScalar := ir.ScalarType{Kind: dstKind, Width: dstWidth}
+	dstHandle := ir.TypeHandle(3)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: srcScalar},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: dstScalar},
+		},
+	}
+
+	aBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: srcHandle, Binding: &aBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v
+			{Kind: ir.ExprAs{Expr: 0, Kind: dstKind, Convert: convertWidth}},      // [1] cast(v)
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [2] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [4] 1.0
+			{Kind: ir.ExprAs{Expr: 1, Kind: ir.ScalarFloat, Convert: ptrU8(4)}},   // [5] f32(c) - for output
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{5, 2, 3, 4}}}, // [6] vec4(...)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &srcHandle},  // v
+			{Handle: &dstHandle},  // cast(v)
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &f32Handle},  // f32(c)
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// ptrU8 returns a pointer to a uint8 value.
+func ptrU8(v uint8) *uint8 { return &v }
+
+// countInstrKind counts the number of instructions of the given kind in the main function.
+func countInstrKind(mod *module.Module, kind module.InstrKind) int {
+	mainFn := findMainFunc(mod)
+	if mainFn == nil {
+		return 0
+	}
+	count := 0
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == kind {
+				count++
+			}
+		}
+	}
+	return count
+}
+
+func TestSelectDXILCastOp(t *testing.T) {
+	tests := []struct {
+		name string
+		src  ir.ScalarType
+		dst  ir.ScalarType
+		want CastOpKind
+	}{
+		// Float → Int
+		{"f32_to_i32", ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, CastFPToSI},
+		{"f32_to_u32", ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, CastFPToUI},
+		{"f64_to_i32", ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}, ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, CastFPToSI},
+
+		// Int → Float
+		{"i32_to_f32", ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, CastSIToFP},
+		{"u32_to_f32", ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, CastUIToFP},
+		{"i32_to_f64", ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}, CastSIToFP},
+
+		// Float → Float
+		{"f64_to_f32", ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, CastFPTrunc},
+		{"f32_to_f64", ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}, CastFPExt},
+		{"f32_to_f16", ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 2}, CastFPTrunc},
+		{"f16_to_f32", ir.ScalarType{Kind: ir.ScalarFloat, Width: 2}, ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}, CastFPExt},
+
+		// Int → Int (same signedness)
+		{"i32_to_i64", ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, ir.ScalarType{Kind: ir.ScalarSint, Width: 8}, CastSExt},
+		{"i64_to_i32", ir.ScalarType{Kind: ir.ScalarSint, Width: 8}, ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, CastTrunc},
+		{"u32_to_u64", ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, ir.ScalarType{Kind: ir.ScalarUint, Width: 8}, CastZExt},
+		{"u64_to_u32", ir.ScalarType{Kind: ir.ScalarUint, Width: 8}, ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, CastTrunc},
+
+		// Int → Int (different signedness, same width)
+		{"i32_to_u32", ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, CastBitcast},
+		{"u32_to_i32", ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, CastBitcast},
+
+		// Int → Int (different signedness, different width)
+		{"i32_to_u64", ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, ir.ScalarType{Kind: ir.ScalarUint, Width: 8}, CastZExt},
+		{"u64_to_i32", ir.ScalarType{Kind: ir.ScalarUint, Width: 8}, ir.ScalarType{Kind: ir.ScalarSint, Width: 4}, CastTrunc},
+		{"u32_to_i64", ir.ScalarType{Kind: ir.ScalarUint, Width: 4}, ir.ScalarType{Kind: ir.ScalarSint, Width: 8}, CastSExt},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := selectDXILCastOp(tt.src, tt.dst)
+			if err != nil {
+				t.Fatalf("selectDXILCastOp: unexpected error: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("got %d, want %d", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestEmitAsF32ToI32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+		ir.ScalarSint,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction, got %d", castCount)
+	}
+	t.Logf("f32→i32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsF32ToU32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+		ir.ScalarUint,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction, got %d", castCount)
+	}
+	t.Logf("f32→u32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsI32ToF32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarSint, Width: 4},
+		ir.ScalarFloat,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction, got %d", castCount)
+	}
+	t.Logf("i32→f32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsU32ToF32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarUint, Width: 4},
+		ir.ScalarFloat,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction, got %d", castCount)
+	}
+	t.Logf("u32→f32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsF64ToF32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 8},
+		ir.ScalarFloat,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (FPTrunc), got %d", castCount)
+	}
+	t.Logf("f64→f32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsF32ToF64(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+		ir.ScalarFloat,
+		ptrU8(8),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (FPExt), got %d", castCount)
+	}
+	t.Logf("f32→f64: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsBitcastF32U32(t *testing.T) {
+	// Convert == nil means bitcast.
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+		ir.ScalarUint,
+		nil, // bitcast
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (bitcast), got %d", castCount)
+	}
+	t.Logf("f32↔u32 bitcast: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsI32ToI64(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarSint, Width: 4},
+		ir.ScalarSint,
+		ptrU8(8),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (SExt), got %d", castCount)
+	}
+	t.Logf("i32→i64: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsI64ToI32(t *testing.T) {
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarSint, Width: 8},
+		ir.ScalarSint,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (Trunc), got %d", castCount)
+	}
+	t.Logf("i64→i32: %d casts, %d functions, %d constants", castCount, len(mod.Functions), len(mod.Constants))
+}
+
+func TestEmitAsSameType(t *testing.T) {
+	// Casting f32 to f32 should be a no-op (no cast instructions for the primary cast).
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarFloat, Width: 4},
+		ir.ScalarFloat,
+		ptrU8(4), // same width
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	// The primary cast (f32→f32) should be a no-op, but the second ExprAs
+	// (expression [5]: dstType→f32 for output) is also f32→f32, so no casts at all.
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount != 0 {
+		t.Errorf("expected 0 cast instructions for identity cast, got %d", castCount)
+	}
+	t.Logf("f32→f32 (no-op): %d casts", castCount)
+}
+
+func TestEmitAsBoolToInt(t *testing.T) {
+	// bool → i32 should produce ZExt.
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarBool, Width: 1},
+		ir.ScalarSint,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	if castCount < 1 {
+		t.Errorf("expected at least 1 cast instruction (ZExt for bool→int), got %d", castCount)
+	}
+	t.Logf("bool→i32: %d casts", castCount)
+}
+
+func TestEmitAsBoolToFloat(t *testing.T) {
+	// bool → f32 should produce two-step: ZExt i1→i32, then UIToFP i32→f32.
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarBool, Width: 1},
+		ir.ScalarFloat,
+		ptrU8(4),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	castCount := countInstrKind(mod, module.InstrCast)
+	// Two casts from bool→f32 (ZExt + UIToFP), plus one for the f32(c)→f32 output
+	// which is a no-op, so minimum 2.
+	if castCount < 2 {
+		t.Errorf("expected at least 2 cast instructions (ZExt + UIToFP for bool→float), got %d", castCount)
+	}
+	t.Logf("bool→f32: %d casts", castCount)
+}
+
+func TestEmitAsIntToBool(t *testing.T) {
+	// i32 → bool should produce ICmp NE (comparison, not cast instruction).
+	irMod := buildCastShader(
+		ir.ScalarType{Kind: ir.ScalarSint, Width: 4},
+		ir.ScalarBool,
+		ptrU8(1),
+	)
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+	// int→bool uses CmpInstr (ICmpNE), not CastInstr.
+	cmpCount := countInstrKind(mod, module.InstrCmp)
+	if cmpCount < 1 {
+		t.Errorf("expected at least 1 cmp instruction (ICmpNE for int→bool), got %d", cmpCount)
+	}
+	t.Logf("i32→bool: %d cmps, %d casts", cmpCount, countInstrKind(mod, module.InstrCast))
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -2361,3 +2361,453 @@ func TestEmitNestedIfLoop(t *testing.T) {
 	t.Logf("nested if/loop: %d BBs, %d branches, %d bytes bitcode",
 		len(mainFn.BasicBlocks), brCount, len(bc))
 }
+
+// --- Local Variable Tests (alloca + load + store) ---
+
+// buildLocalVarShader creates a shader with a local variable:
+//
+//	@fragment fn main() -> @location(0) vec4<f32> {
+//	    var x: f32 = 1.0;
+//	    x = 2.0;
+//	    return vec4(x, x, x, 1.0);
+//	}
+//
+// IR pattern:
+//
+//	LocalVars: [{Name: "x", Type: f32, Init: nil}]
+//	Expressions:
+//	  [0] ExprLocalVariable{Variable: 0}  → pointer to x
+//	  [1] Literal(1.0)
+//	  [2] ExprLocalVariable{Variable: 0}  → pointer to x (for second store)
+//	  [3] Literal(2.0)
+//	  [4] ExprLocalVariable{Variable: 0}  → pointer to x (for load)
+//	  [5] ExprLoad{Pointer: 4}            → loaded value of x
+//	  [6] Literal(1.0)
+//	  [7] ExprCompose{5, 5, 5, 6}         → vec4(x, x, x, 1.0)
+//	Body:
+//	  StmtStore{Pointer: 0, Value: 1}     → x = 1.0
+//	  StmtEmit{Range: 2..4}
+//	  StmtStore{Pointer: 2, Value: 3}     → x = 2.0
+//	  StmtEmit{Range: 4..8}
+//	  StmtReturn{Value: 7}
+func buildLocalVarShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4f32Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(7)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		LocalVars: []ir.LocalVariable{
+			{Name: "x", Type: f32Handle},
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                             // [0] &x
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [1] 1.0
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                             // [2] &x
+			{Kind: ir.Literal{Value: ir.LiteralF32(2.0)}},                         // [3] 2.0
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                             // [4] &x
+			{Kind: ir.ExprLoad{Pointer: 4}},                                       // [5] load x
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [6] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{5, 5, 5, 6}}}, // [7] vec4(x, x, x, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},     // &x → pointer
+			{Handle: &f32Handle},     // 1.0
+			{Handle: &f32Handle},     // &x
+			{Handle: &f32Handle},     // 2.0
+			{Handle: &f32Handle},     // &x
+			{Handle: &f32Handle},     // load x → f32
+			{Handle: &f32Handle},     // 1.0
+			{Handle: &vec4f32Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtStore{Pointer: 0, Value: 1}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 2, End: 4}}},
+			{Kind: ir.StmtStore{Pointer: 2, Value: 3}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 8}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildMultipleLocalsShader creates a shader with two independent local variables:
+//
+//	@fragment fn main() -> @location(0) vec4<f32> {
+//	    var a: f32 = 1.0;
+//	    var b: f32 = 2.0;
+//	    return vec4(a, b, 0.0, 1.0);
+//	}
+func buildMultipleLocalsShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4f32Handle := ir.TypeHandle(1)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(10)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		LocalVars: []ir.LocalVariable{
+			{Name: "a", Type: f32Handle},
+			{Name: "b", Type: f32Handle},
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                             // [0] &a
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [1] 1.0
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                             // [2] &b
+			{Kind: ir.Literal{Value: ir.LiteralF32(2.0)}},                         // [3] 2.0
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                             // [4] &a (for load)
+			{Kind: ir.ExprLoad{Pointer: 4}},                                       // [5] load a
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                             // [6] &b (for load)
+			{Kind: ir.ExprLoad{Pointer: 6}},                                       // [7] load b
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [8] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [9] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{5, 7, 8, 9}}}, // [10] vec4(a, b, 0, 1)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle}, {Handle: &f32Handle}, {Handle: &f32Handle}, {Handle: &f32Handle},
+			{Handle: &f32Handle}, {Handle: &f32Handle}, {Handle: &f32Handle}, {Handle: &f32Handle},
+			{Handle: &f32Handle}, {Handle: &f32Handle}, {Handle: &vec4f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtStore{Pointer: 0, Value: 1}},
+			{Kind: ir.StmtStore{Pointer: 2, Value: 3}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 11}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildLocalInLoopShader creates a shader with a local variable modified inside a loop:
+//
+//	@fragment fn main() -> @location(0) vec4<f32> {
+//	    var acc: f32 = 0.0;
+//	    var i: i32 = 0;
+//	    loop {
+//	        if i >= 4 { break; }
+//	        acc = acc + 1.0;
+//	        continuing { i = i + 1; }
+//	    }
+//	    return vec4(acc, acc, acc, 1.0);
+//	}
+func buildLocalInLoopShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4f32Handle := ir.TypeHandle(1)
+	i32Handle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarSint, Width: 4}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		LocalVars: []ir.LocalVariable{
+			{Name: "acc", Type: f32Handle},
+			{Name: "i", Type: i32Handle},
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                           // [0] &acc
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                       // [1] 0.0
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                           // [2] &i
+			{Kind: ir.Literal{Value: ir.LiteralI32(0)}},                         // [3] 0
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                           // [4] &i (for load)
+			{Kind: ir.ExprLoad{Pointer: 4}},                                     // [5] load i
+			{Kind: ir.Literal{Value: ir.LiteralI32(4)}},                         // [6] 4
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreaterEqual, Left: 5, Right: 6}}, // [7] i >= 4
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                           // [8] &acc (for load)
+			{Kind: ir.ExprLoad{Pointer: 8}},                                     // [9] load acc
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                       // [10] 1.0
+			{Kind: ir.ExprBinary{Op: ir.BinaryAdd, Left: 9, Right: 10}},         // [11] acc + 1.0
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                           // [12] &acc (for store)
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                           // [13] &i (for load in continuing)
+			{Kind: ir.ExprLoad{Pointer: 13}},                                    // [14] load i
+			{Kind: ir.Literal{Value: ir.LiteralI32(1)}},                         // [15] 1
+			{Kind: ir.ExprBinary{Op: ir.BinaryAdd, Left: 14, Right: 15}},        // [16] i + 1
+			// After loop: load acc, compose, return
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                                 // [17] &acc
+			{Kind: ir.ExprLoad{Pointer: 17}},                                          // [18] load acc (final)
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                             // [19] 1.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{18, 18, 18, 19}}}, // [20] vec4(acc, acc, acc, 1.0)
+		},
+		ExpressionTypes: func() []ir.TypeResolution {
+			res := make([]ir.TypeResolution, 21)
+			for i := range res {
+				res[i] = ir.TypeResolution{Handle: &f32Handle}
+			}
+			// Fix types for i32 expressions.
+			res[2] = ir.TypeResolution{Handle: &i32Handle}
+			res[3] = ir.TypeResolution{Handle: &i32Handle}
+			res[4] = ir.TypeResolution{Handle: &i32Handle}
+			res[5] = ir.TypeResolution{Handle: &i32Handle}
+			res[6] = ir.TypeResolution{Handle: &i32Handle}
+			res[13] = ir.TypeResolution{Handle: &i32Handle}
+			res[14] = ir.TypeResolution{Handle: &i32Handle}
+			res[15] = ir.TypeResolution{Handle: &i32Handle}
+			res[16] = ir.TypeResolution{Handle: &i32Handle}
+			res[20] = ir.TypeResolution{Handle: &vec4f32Handle}
+			return res
+		}(),
+		Body: []ir.Statement{
+			// Initialize locals.
+			{Kind: ir.StmtStore{Pointer: 0, Value: 1}}, // acc = 0.0
+			{Kind: ir.StmtStore{Pointer: 2, Value: 3}}, // i = 0
+			// Loop.
+			{Kind: ir.StmtLoop{
+				Body: ir.Block{
+					// if i >= 4 { break; }
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 8}}},
+					{Kind: ir.StmtIf{
+						Condition: 7,
+						Accept:    ir.Block{{Kind: ir.StmtBreak{}}},
+					}},
+					// acc = acc + 1.0
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 8, End: 12}}},
+					{Kind: ir.StmtStore{Pointer: 12, Value: 11}},
+				},
+				Continuing: ir.Block{
+					// i = i + 1
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 13, End: 17}}},
+					{Kind: ir.StmtStore{Pointer: 13, Value: 16}},
+				},
+			}},
+			// After loop: return vec4(acc, acc, acc, 1.0).
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 17, End: 21}}},
+			{Kind: ir.StmtReturn{Value: func() *ir.ExpressionHandle { h := ir.ExpressionHandle(20); return &h }()}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+func TestEmitLocalVariable(t *testing.T) {
+	irMod := buildLocalVarShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Verify alloca instruction was emitted.
+	allocaCount := countInstrKind(mod, module.InstrAlloca)
+	if allocaCount != 1 {
+		t.Errorf("expected 1 alloca instruction, got %d", allocaCount)
+	}
+
+	// Verify store instructions were emitted (2 stores: x = 1.0 and x = 2.0).
+	storeCount := countInstrKind(mod, module.InstrStore)
+	if storeCount != 2 {
+		t.Errorf("expected 2 store instructions, got %d", storeCount)
+	}
+
+	// Verify load instruction was emitted.
+	loadCount := countInstrKind(mod, module.InstrLoad)
+	if loadCount != 1 {
+		t.Errorf("expected 1 load instruction, got %d", loadCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("local-var: alloca=%d, store=%d, load=%d, %d bytes bitcode",
+		allocaCount, storeCount, loadCount, len(bc))
+}
+
+func TestEmitStoreLoad(t *testing.T) {
+	irMod := buildLocalVarShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Verify that store and load produce different instruction kinds.
+	foundStore := false
+	foundLoad := false
+	foundAlloca := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			switch instr.Kind {
+			case module.InstrStore:
+				foundStore = true
+				// Store should NOT have a value (it's a void operation).
+				if instr.HasValue {
+					t.Error("store instruction should not produce a value")
+				}
+			case module.InstrLoad:
+				foundLoad = true
+				// Load SHOULD produce a value.
+				if !instr.HasValue {
+					t.Error("load instruction should produce a value")
+				}
+			case module.InstrAlloca:
+				foundAlloca = true
+				// Alloca produces a pointer value.
+				if !instr.HasValue {
+					t.Error("alloca instruction should produce a value")
+				}
+				if instr.ResultType == nil || instr.ResultType.Kind != module.TypePointer {
+					t.Error("alloca result type should be a pointer")
+				}
+			}
+		}
+	}
+
+	if !foundAlloca {
+		t.Error("expected to find alloca instruction")
+	}
+	if !foundStore {
+		t.Error("expected to find store instruction")
+	}
+	if !foundLoad {
+		t.Error("expected to find load instruction")
+	}
+}
+
+func TestEmitMultipleLocals(t *testing.T) {
+	irMod := buildMultipleLocalsShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Two local variables should produce exactly 2 alloca instructions.
+	allocaCount := countInstrKind(mod, module.InstrAlloca)
+	if allocaCount != 2 {
+		t.Errorf("expected 2 alloca instructions for 2 local vars, got %d", allocaCount)
+	}
+
+	// 2 stores (a = 1.0, b = 2.0).
+	storeCount := countInstrKind(mod, module.InstrStore)
+	if storeCount != 2 {
+		t.Errorf("expected 2 store instructions, got %d", storeCount)
+	}
+
+	// 2 loads (load a, load b).
+	loadCount := countInstrKind(mod, module.InstrLoad)
+	if loadCount != 2 {
+		t.Errorf("expected 2 load instructions, got %d", loadCount)
+	}
+
+	// Verify alloca result types are pointer types to f32.
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrAlloca {
+				if instr.ResultType == nil || instr.ResultType.Kind != module.TypePointer {
+					t.Errorf("alloca should produce pointer type, got %v", instr.ResultType)
+				}
+			}
+		}
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("multiple-locals: alloca=%d, store=%d, load=%d, %d bytes bitcode",
+		allocaCount, storeCount, loadCount, len(bc))
+}
+
+func TestEmitLocalInLoop(t *testing.T) {
+	irMod := buildLocalInLoopShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Two local variables: acc (f32) and i (i32).
+	allocaCount := countInstrKind(mod, module.InstrAlloca)
+	if allocaCount != 2 {
+		t.Errorf("expected 2 alloca instructions (acc + i), got %d", allocaCount)
+	}
+
+	// Multiple stores: initial stores + stores inside loop body and continuing.
+	storeCount := countInstrKind(mod, module.InstrStore)
+	if storeCount < 4 {
+		t.Errorf("expected at least 4 store instructions, got %d", storeCount)
+	}
+
+	// Multiple loads: loop condition + loop body + after loop.
+	loadCount := countInstrKind(mod, module.InstrLoad)
+	if loadCount >= 1 {
+		t.Logf("local-in-loop: alloca=%d, store=%d, load=%d", allocaCount, storeCount, loadCount)
+	} else {
+		t.Errorf("expected at least 1 load instruction, got %d", loadCount)
+	}
+
+	// Verify loop structure (multiple basic blocks).
+	if len(mainFn.BasicBlocks) < 5 {
+		t.Errorf("expected at least 5 basic blocks for loop, got %d", len(mainFn.BasicBlocks))
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("local-in-loop: %d BBs, alloca=%d, store=%d, load=%d, %d bytes bitcode",
+		len(mainFn.BasicBlocks), allocaCount, storeCount, loadCount, len(bc))
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -1802,3 +1802,562 @@ func TestEmitAsIntToBool(t *testing.T) {
 	}
 	t.Logf("i32→bool: %d cmps, %d casts", cmpCount, countInstrKind(mod, module.InstrCast))
 }
+
+// --- Control Flow Tests ---
+
+// buildIfElseShader creates a fragment shader with if/else:
+//
+//	@fragment fn main(@location(0) v: f32) -> @location(0) vec4<f32> {
+//	    var r: f32;
+//	    if (v > 0.5) {
+//	        r = 1.0;
+//	    } else {
+//	        r = 0.0;
+//	    }
+//	    return vec4(r, r, r, 1.0);
+//	}
+func buildIfElseShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	retHandle := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.5)}},                         // [1] 0.5
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreater, Left: 0, Right: 1}},        // [2] v > 0.5 (bool)
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [4] 0.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [5] 1.0 (alpha)
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{3, 3, 3, 5}}}, // [6] vec4(r, r, r, 1.0)
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},  // v
+			{Handle: &f32Handle},  // 0.5
+			{Handle: &boolHandle}, // v > 0.5
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &f32Handle},  // 0.0
+			{Handle: &f32Handle},  // 1.0
+			{Handle: &vec4Handle}, // compose
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+			{Kind: ir.StmtIf{
+				Condition: 2,
+				Accept: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 3, End: 4}}},
+				},
+				Reject: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 5}}},
+				},
+			}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 5, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildIfNoElseShader creates a shader with if but no else.
+func buildIfNoElseShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	vBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(5)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "v", Type: f32Handle, Binding: &vBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                             // [0] v
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.5)}},                         // [1] 0.5
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreater, Left: 0, Right: 1}},        // [2] v > 0.5
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [3] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [4] 0.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{3, 3, 3, 4}}}, // [5] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &boolHandle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &vec4Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+			{Kind: ir.StmtIf{
+				Condition: 2,
+				Accept: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 3, End: 4}}},
+				},
+				Reject: nil, // no else
+			}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 6}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildSimpleLoopShader creates a shader with a simple loop:
+//
+//	loop {
+//	    if (i >= 10) { break; }
+//	    // body
+//	}
+func buildSimpleLoopShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [0] 1.0
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.5)}},                         // [1] 0.5
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreater, Left: 0, Right: 1}},        // [2] 1.0 > 0.5
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3] 0.0
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{0, 0, 0, 0}}}, // [4] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &boolHandle},
+			{Handle: &f32Handle},
+			{Handle: &vec4Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtLoop{
+				Body: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+					{Kind: ir.StmtIf{
+						Condition: 2,
+						Accept:    ir.Block{{Kind: ir.StmtBreak{}}},
+						Reject:    nil,
+					}},
+				},
+				Continuing: nil,
+			}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 3, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildLoopContinueShader creates a shader with continue in loop body.
+func buildLoopContinueShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [0]
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.5)}},                         // [1]
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreater, Left: 0, Right: 1}},        // [2] cond
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3]
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{0, 0, 0, 0}}}, // [4] vec4
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &boolHandle},
+			{Handle: &f32Handle},
+			{Handle: &vec4Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtLoop{
+				Body: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+					{Kind: ir.StmtIf{
+						Condition: 2,
+						Accept:    ir.Block{{Kind: ir.StmtContinue{}}},
+						Reject:    nil,
+					}},
+					// After continue, the rest is skipped for that iteration.
+					{Kind: ir.StmtIf{
+						Condition: 2,
+						Accept:    ir.Block{{Kind: ir.StmtBreak{}}},
+						Reject:    nil,
+					}},
+				},
+				Continuing: nil,
+			}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 3, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// buildNestedIfLoopShader creates a shader with if inside a loop.
+func buildNestedIfLoopShader() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	boolHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarBool, Width: 1}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},                         // [0]
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.5)}},                         // [1]
+			{Kind: ir.ExprBinary{Op: ir.BinaryGreater, Left: 0, Right: 1}},        // [2]
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},                         // [3]
+			{Kind: ir.ExprCompose{Components: []ir.ExpressionHandle{0, 0, 0, 0}}}, // [4]
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &boolHandle},
+			{Handle: &f32Handle},
+			{Handle: &vec4Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtLoop{
+				Body: ir.Block{
+					{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+					{Kind: ir.StmtIf{
+						Condition: 2,
+						Accept: ir.Block{
+							{Kind: ir.StmtIf{
+								Condition: 2,
+								Accept:    ir.Block{{Kind: ir.StmtBreak{}}},
+								Reject:    ir.Block{{Kind: ir.StmtContinue{}}},
+							}},
+						},
+						Reject: ir.Block{
+							{Kind: ir.StmtBreak{}},
+						},
+					}},
+				},
+				Continuing: nil,
+			}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 3, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+	return mod
+}
+
+// countBranchInstrs counts branch instructions across all basic blocks.
+func countBranchInstrs(mod *module.Module) int {
+	count := 0
+	for _, fn := range mod.Functions {
+		if fn.IsDeclaration {
+			continue
+		}
+		for _, bb := range fn.BasicBlocks {
+			for _, instr := range bb.Instructions {
+				if instr.Kind == module.InstrBr {
+					count++
+				}
+			}
+		}
+	}
+	return count
+}
+
+// getMainFn finds the main function in the module.
+func getMainFn(mod *module.Module) *module.Function {
+	for i := range mod.Functions {
+		if mod.Functions[i].Name == "main" {
+			return mod.Functions[i]
+		}
+	}
+	return nil
+}
+
+func TestEmitIfElse(t *testing.T) {
+	irMod := buildIfElseShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Expect at least 4 basic blocks: entry, then, else, merge.
+	if len(mainFn.BasicBlocks) < 4 {
+		t.Errorf("expected at least 4 basic blocks (entry/then/else/merge), got %d", len(mainFn.BasicBlocks))
+	}
+
+	// Expect at least 3 branch instructions: cond br, br-from-then, br-from-else.
+	brCount := countBranchInstrs(mod)
+	if brCount < 3 {
+		t.Errorf("expected at least 3 branch instructions, got %d", brCount)
+	}
+
+	// Verify serialization still works.
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+
+	t.Logf("if/else: %d BBs, %d branches, %d bytes bitcode",
+		len(mainFn.BasicBlocks), brCount, len(bc))
+}
+
+func TestEmitIfNoElse(t *testing.T) {
+	irMod := buildIfNoElseShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// No else: entry, then, merge (3 BBs minimum).
+	if len(mainFn.BasicBlocks) < 3 {
+		t.Errorf("expected at least 3 basic blocks (entry/then/merge), got %d", len(mainFn.BasicBlocks))
+	}
+
+	// Cond br + br-from-then = at least 2 branches.
+	brCount := countBranchInstrs(mod)
+	if brCount < 2 {
+		t.Errorf("expected at least 2 branch instructions, got %d", brCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+
+	t.Logf("if-no-else: %d BBs, %d branches, %d bytes bitcode",
+		len(mainFn.BasicBlocks), brCount, len(bc))
+}
+
+func TestEmitLoop(t *testing.T) {
+	irMod := buildSimpleLoopShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Loop creates: header, body, continuing, merge + entry and if blocks.
+	// Minimum: entry + header + body + continuing + merge = 5.
+	if len(mainFn.BasicBlocks) < 5 {
+		t.Errorf("expected at least 5 basic blocks for loop, got %d", len(mainFn.BasicBlocks))
+	}
+
+	// Must have back-edge branch (continuing -> header).
+	brCount := countBranchInstrs(mod)
+	if brCount < 3 {
+		t.Errorf("expected at least 3 branch instructions for loop, got %d", brCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+
+	t.Logf("loop: %d BBs, %d branches, %d bytes bitcode",
+		len(mainFn.BasicBlocks), brCount, len(bc))
+}
+
+func TestEmitLoopBreak(t *testing.T) {
+	irMod := buildSimpleLoopShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// The break inside the if should generate a branch to the merge BB.
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Find a branch that targets the loop merge block.
+	// The loop merge block is the last block before the return block.
+	foundBreakBranch := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrBr && len(instr.Operands) == 1 {
+				// Unconditional branch — could be the break.
+				foundBreakBranch = true
+			}
+		}
+	}
+	if !foundBreakBranch {
+		t.Error("no unconditional branch found (expected break -> merge)")
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("loop-break: %d BBs, %d bytes bitcode", len(mainFn.BasicBlocks), len(bc))
+}
+
+func TestEmitLoopContinue(t *testing.T) {
+	irMod := buildLoopContinueShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Continue generates a branch to continuing BB.
+	brCount := countBranchInstrs(mod)
+	if brCount < 4 {
+		t.Errorf("expected at least 4 branch instructions (continue + break + back-edge + entry->header), got %d", brCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("loop-continue: %d BBs, %d branches, %d bytes bitcode",
+		len(mainFn.BasicBlocks), brCount, len(bc))
+}
+
+func TestEmitNestedIfLoop(t *testing.T) {
+	irMod := buildNestedIfLoopShader()
+	mod, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := getMainFn(mod)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Nested if inside loop creates many BBs.
+	if len(mainFn.BasicBlocks) < 7 {
+		t.Errorf("expected at least 7 basic blocks for nested if/loop, got %d", len(mainFn.BasicBlocks))
+	}
+
+	brCount := countBranchInstrs(mod)
+	if brCount < 5 {
+		t.Errorf("expected at least 5 branch instructions, got %d", brCount)
+	}
+
+	bc := module.Serialize(mod)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+	t.Logf("nested if/loop: %d BBs, %d branches, %d bytes bitcode",
+		len(mainFn.BasicBlocks), brCount, len(bc))
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -3327,3 +3327,408 @@ func TestEmitStmtKillSilentSkip(t *testing.T) {
 	}
 	t.Log("StmtKill correctly silently skipped")
 }
+
+// --- Resource binding tests ---
+
+// buildCBVFragmentShader creates a fragment shader that reads from a uniform buffer:
+//
+//	struct Uniforms { color: vec4<f32> }
+//	@group(0) @binding(0) var<uniform> uniforms: Uniforms;
+//	@fragment fn main() -> @location(0) vec4<f32> {
+//	    return uniforms.color;
+//	}
+func buildCBVFragmentShader() *ir.Module {
+	vec4f32Handle := ir.TypeHandle(1)
+	structHandle := ir.TypeHandle(2)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "Uniforms", Inner: ir.StructType{
+				Members: []ir.StructMember{
+					{Name: "color", Type: vec4f32Handle, Offset: 0},
+				},
+				Span: 16,
+			}},
+		},
+		GlobalVariables: []ir.GlobalVariable{
+			{
+				Name:  "uniforms",
+				Space: ir.SpaceUniform,
+				Binding: &ir.ResourceBinding{
+					Group:   0,
+					Binding: 0,
+				},
+				Type: structHandle,
+			},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(2) // Load result
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprGlobalVariable{Variable: 0}},    // [0] &uniforms
+			{Kind: ir.ExprAccessIndex{Base: 0, Index: 0}}, // [1] &uniforms.color
+			{Kind: ir.ExprLoad{Pointer: 1}},               // [2] uniforms.color
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &structHandle},  // pointer to struct
+			{Handle: &vec4f32Handle}, // pointer to vec4
+			{Handle: &vec4f32Handle}, // loaded vec4
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 3}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	return mod
+}
+
+func TestResourceAnalysis(t *testing.T) {
+	mod := buildCBVFragmentShader()
+	e := &Emitter{
+		ir:              mod,
+		mod:             module.NewModule(module.PixelShader),
+		resourceHandles: make(map[ir.GlobalVariableHandle]int),
+	}
+	e.analyzeResources()
+
+	if len(e.resources) != 1 {
+		t.Fatalf("expected 1 resource, got %d", len(e.resources))
+	}
+
+	res := &e.resources[0]
+	if res.class != resourceClassCBV {
+		t.Errorf("expected CBV (class %d), got class %d", resourceClassCBV, res.class)
+	}
+	if res.name != "uniforms" {
+		t.Errorf("expected name 'uniforms', got %q", res.name)
+	}
+	if res.group != 0 || res.binding != 0 {
+		t.Errorf("expected group=0 binding=0, got group=%d binding=%d", res.group, res.binding)
+	}
+	if res.rangeID != 0 {
+		t.Errorf("expected rangeID 0, got %d", res.rangeID)
+	}
+}
+
+func TestResourceAnalysisMultiple(t *testing.T) {
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "Uniforms", Inner: ir.StructType{
+				Members: []ir.StructMember{{Name: "x", Type: 0, Offset: 0}},
+				Span:    4,
+			}},
+			{Name: "", Inner: ir.ImageType{Dim: ir.Dim2D, Class: ir.ImageClassSampled, SampledKind: ir.ScalarFloat}},
+			{Name: "", Inner: ir.SamplerType{Comparison: false}},
+		},
+		GlobalVariables: []ir.GlobalVariable{
+			{Name: "ub", Space: ir.SpaceUniform, Binding: &ir.ResourceBinding{Group: 0, Binding: 0}, Type: 1},
+			{Name: "tex", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 1}, Type: 2},
+			{Name: "samp", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 2}, Type: 3},
+		},
+	}
+
+	e := &Emitter{
+		ir:              mod,
+		mod:             module.NewModule(module.PixelShader),
+		resourceHandles: make(map[ir.GlobalVariableHandle]int),
+	}
+	e.analyzeResources()
+
+	if len(e.resources) != 3 {
+		t.Fatalf("expected 3 resources, got %d", len(e.resources))
+	}
+
+	// CBV
+	if e.resources[0].class != resourceClassCBV {
+		t.Errorf("resource 0: expected CBV, got class %d", e.resources[0].class)
+	}
+	// SRV (texture)
+	if e.resources[1].class != resourceClassSRV {
+		t.Errorf("resource 1: expected SRV, got class %d", e.resources[1].class)
+	}
+	// Sampler
+	if e.resources[2].class != resourceClassSampler {
+		t.Errorf("resource 2: expected Sampler, got class %d", e.resources[2].class)
+	}
+}
+
+func TestEmitCreateHandle(t *testing.T) {
+	mod := buildCBVFragmentShader()
+	result, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Verify that a dx.op.createHandle function declaration was created.
+	found := false
+	for _, fn := range result.Functions {
+		if fn.Name == "dx.op.createHandle" {
+			found = true
+			if !fn.IsDeclaration {
+				t.Error("dx.op.createHandle should be a declaration")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.op.createHandle function not found in module")
+	}
+
+	// Verify that the main function has a createHandle call instruction.
+	mainFn := findMainFunction(result)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	hasCreateHandle := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil &&
+				instr.CalledFunc.Name == "dx.op.createHandle" {
+				hasCreateHandle = true
+			}
+		}
+	}
+	if !hasCreateHandle {
+		t.Error("no dx.op.createHandle call found in main function")
+	}
+
+	t.Log("CBV createHandle emitted successfully")
+}
+
+func TestEmitCBVLoad(t *testing.T) {
+	mod := buildCBVFragmentShader()
+	result, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := findMainFunction(result)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Check for cbufferLoadLegacy call.
+	hasCBufLoad := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil {
+				if instr.CalledFunc.Name == "dx.op.cbufferLoadLegacy.f32" {
+					hasCBufLoad = true
+				}
+			}
+		}
+	}
+
+	// Note: CBV load depends on the Load expression being handled specially for CBV globals.
+	// Currently, the generic Load path is used; a full CBV load path would need detecting
+	// that the pointer chain leads to a CBV. For now we verify the createHandle exists.
+	t.Logf("CBV load presence: %v (full CBV load integration pending)", hasCBufLoad)
+}
+
+func TestEmitImageSample(t *testing.T) {
+	// Build a fragment shader with texture sampling:
+	//   @group(0) @binding(0) var tex: texture_2d<f32>;
+	//   @group(0) @binding(1) var samp: sampler;
+	//   @fragment fn main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32> {
+	//       return textureSample(tex, samp, uv);
+	//   }
+	f32Handle := ir.TypeHandle(0)
+	vec2f32Handle := ir.TypeHandle(1)
+	vec4f32Handle := ir.TypeHandle(2)
+	imageHandle := ir.TypeHandle(3)
+	samplerHandle := ir.TypeHandle(4)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ImageType{Dim: ir.Dim2D, Class: ir.ImageClassSampled, SampledKind: ir.ScalarFloat}},
+			{Name: "", Inner: ir.SamplerType{Comparison: false}},
+		},
+		GlobalVariables: []ir.GlobalVariable{
+			{Name: "tex", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 0}, Type: imageHandle},
+			{Name: "samp", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 1}, Type: samplerHandle},
+		},
+	}
+
+	uvBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retHandle := ir.ExpressionHandle(4)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "uv", Type: vec2f32Handle, Binding: &uvBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},     // [0] uv
+			{Kind: ir.ExprGlobalVariable{Variable: 0}},    // [1] tex
+			{Kind: ir.ExprGlobalVariable{Variable: 1}},    // [2] samp
+			{Kind: ir.ExprAccessIndex{Base: 0, Index: 0}}, // [3] uv.x (used by coordinate)
+			{Kind: ir.ExprImageSample{ // [4] textureSample(tex, samp, uv)
+				Image:      1,
+				Sampler:    2,
+				Coordinate: 0,
+				Level:      ir.SampleLevelAuto{},
+			}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec2f32Handle}, // uv
+			{Handle: &imageHandle},   // tex
+			{Handle: &samplerHandle}, // samp
+			{Handle: &f32Handle},     // uv.x
+			{Handle: &vec4f32Handle}, // sample result
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 5}}},
+			{Kind: ir.StmtReturn{Value: &retHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	result, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := findMainFunction(result)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Verify dx.op.sample.f32 call exists.
+	hasSample := false
+	hasCreateHandle := false
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil {
+				switch instr.CalledFunc.Name {
+				case "dx.op.sample.f32":
+					hasSample = true
+				case "dx.op.createHandle":
+					hasCreateHandle = true
+				}
+			}
+		}
+	}
+
+	if !hasCreateHandle {
+		t.Error("no dx.op.createHandle call found")
+	}
+	if !hasSample {
+		t.Error("no dx.op.sample.f32 call found")
+	}
+
+	// Verify extractvalue instructions exist (for extracting sample results).
+	extractCount := 0
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrExtractVal {
+				extractCount++
+			}
+		}
+	}
+	if extractCount < 4 {
+		t.Errorf("expected at least 4 extractvalue instructions for sample result, got %d", extractCount)
+	}
+
+	t.Logf("Image sample emitted: createHandle=%v, sample=%v, extracts=%d",
+		hasCreateHandle, hasSample, extractCount)
+}
+
+func TestResourceMetadata(t *testing.T) {
+	mod := buildCBVFragmentShader()
+	result, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Check dx.resources named metadata exists.
+	found := false
+	for _, nm := range result.NamedMetadata {
+		if nm.Name == "dx.resources" {
+			found = true
+			if len(nm.Operands) != 1 {
+				t.Errorf("dx.resources should have 1 operand, got %d", len(nm.Operands))
+			}
+			// The operand is a tuple of {srvs, uavs, cbvs, samplers}.
+			tuple := nm.Operands[0]
+			if tuple.Kind != module.MDTuple {
+				t.Error("dx.resources operand should be a tuple")
+			}
+			if len(tuple.SubNodes) != 4 {
+				t.Errorf("dx.resources tuple should have 4 elements, got %d", len(tuple.SubNodes))
+			}
+			// SRVs should be nil (no SRVs).
+			if tuple.SubNodes[0] != nil {
+				t.Error("SRVs should be nil for CBV-only shader")
+			}
+			// UAVs should be nil.
+			if tuple.SubNodes[1] != nil {
+				t.Error("UAVs should be nil for CBV-only shader")
+			}
+			// CBVs should have one entry.
+			if tuple.SubNodes[2] == nil {
+				t.Error("CBVs should not be nil")
+			}
+			// Samplers should be nil.
+			if tuple.SubNodes[3] != nil {
+				t.Error("Samplers should be nil for CBV-only shader")
+			}
+			break
+		}
+	}
+	if !found {
+		t.Error("dx.resources named metadata not found")
+	}
+}
+
+func TestNoResourcesNoMetadata(t *testing.T) {
+	// A shader without resources should not emit dx.resources.
+	mod := buildSimpleFragmentShader()
+	result, err := Emit(mod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	for _, nm := range result.NamedMetadata {
+		if nm.Name == "dx.resources" {
+			t.Error("dx.resources should not be present for a shader without resources")
+		}
+	}
+}
+
+// findMainFunction locates the non-declaration function named "main".
+func findMainFunction(m *module.Module) *module.Function {
+	for _, fn := range m.Functions {
+		if fn.Name == "main" && !fn.IsDeclaration {
+			return fn
+		}
+	}
+	return nil
+}

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -25,7 +25,11 @@ type Emitter struct {
 
 	// Current function being emitted.
 	currentBB *module.BasicBlock
-	nextValue int // next value ID to assign within a function
+	mainFn    *module.Function // the current function definition (for adding BBs)
+	nextValue int              // next value ID to assign within a function
+
+	// Loop context stack for break/continue targets.
+	loopStack []loopContext
 
 	// dx.op function declarations (lazily created).
 	dxOpFuncs map[dxOpKey]*module.Function
@@ -42,6 +46,13 @@ type Emitter struct {
 	// pendingComponents holds per-component IDs from the last
 	// emitCompose call. Used by emitExpression to store in exprComponents.
 	pendingComponents []int
+}
+
+// loopContext holds the branch targets for the innermost loop,
+// used by break and continue statements to emit correct branches.
+type loopContext struct {
+	continuingBBIndex int // basic block index for the continuing block
+	mergeBBIndex      int // basic block index for the merge (after-loop) block
 }
 
 // dxOpKey uniquely identifies a dx.op function declaration.
@@ -152,10 +163,12 @@ func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
 	funcTy := e.mod.GetFunctionType(voidTy, nil)
 
 	mainFn := e.mod.AddFunction("main", funcTy, false)
+	e.mainFn = mainFn
 	bb := mainFn.AddBasicBlock("entry")
 	e.currentBB = bb
 	e.exprValues = make(map[ir.ExpressionHandle]int)
 	e.exprComponents = make(map[ir.ExpressionHandle][]int)
+	e.loopStack = e.loopStack[:0]
 
 	fn := &ep.Function
 

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -1,0 +1,603 @@
+package emit
+
+import (
+	"fmt"
+	"math"
+
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
+// Emitter translates naga IR into a DXIL module.
+type Emitter struct {
+	ir   *ir.Module
+	mod  *module.Module
+	opts EmitOptions
+
+	// Value numbering: maps naga expression handles to DXIL value IDs.
+	// For scalar types, stores a single value ID.
+	// For vector types, stores per-component IDs in exprComponents.
+	exprValues map[ir.ExpressionHandle]int
+
+	// Per-component value IDs for vector expressions.
+	// Key is expression handle, value is slice of component IDs.
+	exprComponents map[ir.ExpressionHandle][]int
+
+	// Current function being emitted.
+	currentBB *module.BasicBlock
+	nextValue int // next value ID to assign within a function
+
+	// dx.op function declarations (lazily created).
+	dxOpFuncs map[dxOpKey]*module.Function
+
+	// Constant cache: maps from constant key to emitter value ID.
+	intConsts   map[int64]int  // int value -> emitter value ID
+	floatConsts map[uint64]int // float bits -> emitter value ID
+	undefID     int            // emitter value ID for undef, -1 if not created
+
+	// constMap maps emitter value IDs to module constants.
+	// Used during finalize to set proper Constant.ValueID.
+	constMap map[int]*module.Constant
+
+	// pendingComponents holds per-component IDs from the last
+	// emitCompose call. Used by emitExpression to store in exprComponents.
+	pendingComponents []int
+}
+
+// dxOpKey uniquely identifies a dx.op function declaration.
+type dxOpKey struct {
+	name     string
+	overload overloadType
+}
+
+// Overload suffix strings for dx.op function names.
+const (
+	suffixF32 = ".f32"
+	suffixI32 = ".i32"
+	suffixF64 = ".f64"
+)
+
+// overloadType indicates the type overload for a dx.op function.
+type overloadType int
+
+const (
+	overloadVoid overloadType = iota
+	overloadI1
+	overloadI16
+	overloadI32
+	overloadI64
+	overloadF16
+	overloadF32
+	overloadF64
+)
+
+// EmitOptions configures DXIL emission.
+type EmitOptions struct {
+	ShaderModelMajor uint32
+	ShaderModelMinor uint32
+}
+
+// Emit translates a naga IR module into a DXIL module.Module.
+//
+// The caller is responsible for serializing the result to bitcode
+// and wrapping it in a DXBC container.
+func Emit(irMod *ir.Module, opts EmitOptions) (*module.Module, error) {
+	if len(irMod.EntryPoints) == 0 {
+		return nil, fmt.Errorf("dxil/emit: module has no entry points")
+	}
+
+	ep := &irMod.EntryPoints[0]
+	shaderKind := stageToShaderKind(ep.Stage)
+
+	mod := module.NewModule(shaderKind)
+	mod.MajorVersion = 1
+	mod.MinorVersion = opts.ShaderModelMinor
+
+	e := &Emitter{
+		ir:          irMod,
+		mod:         mod,
+		opts:        opts,
+		exprValues:  make(map[ir.ExpressionHandle]int),
+		dxOpFuncs:   make(map[dxOpKey]*module.Function),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+		undefID:     -1,
+		constMap:    make(map[int]*module.Constant),
+	}
+
+	if err := e.emitEntryPoint(ep); err != nil {
+		return nil, fmt.Errorf("dxil/emit: entry point %q: %w", ep.Name, err)
+	}
+
+	return mod, nil
+}
+
+// stageToShaderKind maps naga ShaderStage to DXIL ShaderKind.
+func stageToShaderKind(stage ir.ShaderStage) module.ShaderKind {
+	switch stage {
+	case ir.StageVertex:
+		return module.VertexShader
+	case ir.StageFragment:
+		return module.PixelShader
+	case ir.StageCompute:
+		return module.ComputeShader
+	default:
+		return module.VertexShader
+	}
+}
+
+// shaderKindString returns the DXIL shader model prefix for metadata.
+func shaderKindString(kind module.ShaderKind) string {
+	switch kind {
+	case module.VertexShader:
+		return "vs"
+	case module.PixelShader:
+		return "ps"
+	case module.ComputeShader:
+		return "cs"
+	case module.GeometryShader:
+		return "gs"
+	case module.HullShader:
+		return "hs"
+	case module.DomainShader:
+		return "ds"
+	default:
+		return "vs"
+	}
+}
+
+// emitEntryPoint emits a single entry point function.
+func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
+	voidTy := e.mod.GetVoidType()
+	funcTy := e.mod.GetFunctionType(voidTy, nil)
+
+	mainFn := e.mod.AddFunction("main", funcTy, false)
+	bb := mainFn.AddBasicBlock("entry")
+	e.currentBB = bb
+	e.exprValues = make(map[ir.ExpressionHandle]int)
+	e.exprComponents = make(map[ir.ExpressionHandle][]int)
+
+	fn := &ep.Function
+
+	// Emit I/O: load inputs into value map, then emit function body,
+	// then store outputs. At this point we use temporary IDs starting
+	// from 0. These will be adjusted in finalize().
+	e.nextValue = 0
+	if err := e.emitInputLoads(fn, ep.Stage); err != nil {
+		return fmt.Errorf("input loads: %w", err)
+	}
+
+	if err := e.emitFunctionBody(fn); err != nil {
+		return fmt.Errorf("function body: %w", err)
+	}
+
+	// Add void return at the end.
+	bb = e.currentBB
+	bb.AddInstruction(module.NewRetVoidInstr())
+
+	// Emit metadata BEFORE finalize so all constants are known.
+	e.emitMetadata(ep, stageToShaderKind(ep.Stage))
+
+	// Finalize: assign proper value IDs that match serializer's numbering.
+	e.finalize(mainFn)
+
+	return nil
+}
+
+// finalize remaps the emitter's internal value IDs to match the
+// serializer's global value numbering.
+//
+// The serializer assigns value IDs in this order:
+//  1. Global vars: 0..gv_count-1
+//  2. Functions: gv_count..gv_count+fn_count-1
+//  3. Constants: in mod.Constants order (insertion order)
+//  4. Instruction results: sequentially after constants
+//
+// This method builds a mapping from emitter IDs to global IDs and
+// rewrites all instruction operands and value IDs.
+//
+//nolint:gocognit // value ID remapping requires iterating multiple data structures
+func (e *Emitter) finalize(mainFn *module.Function) {
+	// Build the ID mapping table: emitterID -> globalID
+	idMap := make(map[int]int)
+
+	nextGlobalID := 0
+
+	// Global vars.
+	for _, gv := range e.mod.GlobalVars {
+		gv.ValueID = nextGlobalID
+		nextGlobalID++
+	}
+
+	// Functions get sequential IDs.
+	for _, fn := range e.mod.Functions {
+		fn.ValueID = nextGlobalID
+		nextGlobalID++
+	}
+
+	// Constants: assign IDs in mod.Constants order (which matches
+	// the serializer's order). Build a reverse lookup from
+	// *module.Constant to emitter ID to find the mapping.
+	constToEmitterID := make(map[*module.Constant]int)
+	for emitterID, c := range e.constMap {
+		constToEmitterID[c] = emitterID
+	}
+	for _, c := range e.mod.Constants {
+		c.ValueID = nextGlobalID
+		if emitterID, ok := constToEmitterID[c]; ok {
+			idMap[emitterID] = nextGlobalID
+		}
+		nextGlobalID++
+	}
+
+	// Instruction results: process in order, assigning sequential IDs.
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.HasValue {
+				oldID := instr.ValueID
+				if _, isConst := e.constMap[oldID]; !isConst {
+					idMap[oldID] = nextGlobalID
+					instr.ValueID = nextGlobalID
+					nextGlobalID++
+				}
+			}
+		}
+	}
+
+	// Rewrite all operand references.
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			for i, op := range instr.Operands {
+				if newID, ok := idMap[op]; ok {
+					instr.Operands[i] = newID
+				}
+			}
+			if instr.Kind == module.InstrRet && instr.ReturnValue >= 0 {
+				if newID, ok := idMap[instr.ReturnValue]; ok {
+					instr.ReturnValue = newID
+				}
+			}
+		}
+	}
+
+	// Also rewrite component tracking IDs.
+	for handle, comps := range e.exprComponents {
+		for i, id := range comps {
+			if newID, ok := idMap[id]; ok {
+				e.exprComponents[handle][i] = newID
+			}
+		}
+	}
+}
+
+// emitMetadata writes the required DXIL metadata nodes.
+func (e *Emitter) emitMetadata(_ *ir.EntryPoint, kind module.ShaderKind) {
+	i32Ty := e.mod.GetIntType(32)
+
+	// dx.version = !{i32 1, i32 MINOR}
+	mdMajor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(1))
+	mdMinor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(e.opts.ShaderModelMinor)))
+	mdVersion := e.mod.AddMetadataTuple([]*module.MetadataNode{mdMajor, mdMinor})
+	e.mod.AddNamedMetadata("dx.version", []*module.MetadataNode{mdVersion})
+
+	// dx.valver = !{i32 1, i32 7}
+	mdValMajor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(1))
+	mdValMinor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(7))
+	mdValVer := e.mod.AddMetadataTuple([]*module.MetadataNode{mdValMajor, mdValMinor})
+	e.mod.AddNamedMetadata("dx.valver", []*module.MetadataNode{mdValVer})
+
+	// dx.shaderModel = !{!"vs", i32 6, i32 MINOR}
+	mdKind := e.mod.AddMetadataString(shaderKindString(kind))
+	mdSMMajor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(6))
+	mdSMMinor := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(e.opts.ShaderModelMinor)))
+	mdSM := e.mod.AddMetadataTuple([]*module.MetadataNode{mdKind, mdSMMajor, mdSMMinor})
+	e.mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
+
+	// dx.entryPoints = !{!{null, !"main", null, null, null}}
+	mdName := e.mod.AddMetadataString("main")
+	mdEntry := e.mod.AddMetadataTuple([]*module.MetadataNode{
+		nil,    // function ref (simplified)
+		mdName, // entry point name
+		nil,    // signatures
+		nil,    // resources
+		nil,    // properties
+	})
+	e.mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
+
+	// llvm.ident = !{!"dxil-go-naga"}
+	mdIdent := e.mod.AddMetadataString("dxil-go-naga")
+	mdIdentTuple := e.mod.AddMetadataTuple([]*module.MetadataNode{mdIdent})
+	e.mod.AddNamedMetadata("llvm.ident", []*module.MetadataNode{mdIdentTuple})
+}
+
+// getIntConstID returns the emitter value ID for a cached i32 constant.
+func (e *Emitter) getIntConstID(v int64) int {
+	if id, ok := e.intConsts[v]; ok {
+		return id
+	}
+	c := e.mod.AddIntConst(e.mod.GetIntType(32), v)
+	id := e.allocValue()
+	e.intConsts[v] = id
+	e.constMap[id] = c
+	return id
+}
+
+// getI8ConstID returns the emitter value ID for a cached i8 constant.
+// Used for dx.op call arguments that require i8 type (e.g., col index).
+func (e *Emitter) getI8ConstID(v int64) int {
+	// Use a distinct cache key to avoid colliding with i32 constants.
+	key := v + (1 << 40) // offset to distinguish from i32
+	if id, ok := e.intConsts[key]; ok {
+		return id
+	}
+	c := e.mod.AddIntConst(e.mod.GetIntType(8), v)
+	id := e.allocValue()
+	e.intConsts[key] = id
+	e.constMap[id] = c
+	return id
+}
+
+// getFloatConstID returns the emitter value ID for a cached f32 constant.
+func (e *Emitter) getFloatConstID(v float64) int {
+	bits := math.Float64bits(v)
+	if id, ok := e.floatConsts[bits]; ok {
+		return id
+	}
+	c := e.addFloatConst(e.mod.GetFloatType(32), v)
+	id := e.allocValue()
+	e.floatConsts[bits] = id
+	e.constMap[id] = c
+	return id
+}
+
+// addFloatConstID adds a floating-point constant and returns its emitter value ID.
+func (e *Emitter) addFloatConstID(ty *module.Type, v float64) int {
+	c := e.addFloatConst(ty, v)
+	id := e.allocValue()
+	e.constMap[id] = c
+	return id
+}
+
+// addFloatConst adds a floating-point constant to the module.
+func (e *Emitter) addFloatConst(ty *module.Type, v float64) *module.Constant {
+	c := &module.Constant{
+		ConstType:  ty,
+		FloatValue: v,
+	}
+	e.mod.Constants = append(e.mod.Constants, c)
+	return c
+}
+
+// getUndefConstID returns the emitter value ID for an undef i32 constant.
+func (e *Emitter) getUndefConstID() int {
+	if e.undefID >= 0 {
+		return e.undefID
+	}
+	c := &module.Constant{
+		ConstType: e.mod.GetIntType(32),
+		IsUndef:   true,
+	}
+	e.mod.Constants = append(e.mod.Constants, c)
+	id := e.allocValue()
+	e.undefID = id
+	e.constMap[id] = c
+	return id
+}
+
+// getIntConst is a compatibility helper that returns the module constant.
+// Used only for metadata emission where we need the *module.Constant.
+func (e *Emitter) getIntConst(v int64) *module.Constant {
+	// Check if already created.
+	if id, ok := e.intConsts[v]; ok {
+		return e.constMap[id]
+	}
+	c := e.mod.AddIntConst(e.mod.GetIntType(32), v)
+	id := e.allocValue()
+	e.intConsts[v] = id
+	e.constMap[id] = c
+	return c
+}
+
+// getComponentID returns the value ID for a specific component of a
+// vector expression. If per-component tracking exists, uses that.
+// Otherwise falls back to baseID + component (legacy behavior).
+func (e *Emitter) getComponentID(handle ir.ExpressionHandle, comp int) int {
+	if comps, ok := e.exprComponents[handle]; ok && comp < len(comps) {
+		return comps[comp]
+	}
+	// Fallback: assume sequential IDs from base.
+	if base, ok := e.exprValues[handle]; ok {
+		return base + comp
+	}
+	return 0
+}
+
+// allocValue assigns the next value ID and returns it.
+func (e *Emitter) allocValue() int {
+	v := e.nextValue
+	e.nextValue++
+	return v
+}
+
+// addCallInstr adds a call instruction to the current basic block and
+// returns the assigned value ID.
+func (e *Emitter) addCallInstr(fn *module.Function, resultTy *module.Type, operands []int) int {
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrCall,
+		HasValue:   resultTy.Kind != module.TypeVoid,
+		ResultType: resultTy,
+		CalledFunc: fn,
+		Operands:   operands,
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID
+}
+
+// addBinOpInstr adds a binary operation instruction.
+func (e *Emitter) addBinOpInstr(resultTy *module.Type, op BinOpKind, lhs, rhs int) int {
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrBinOp,
+		HasValue:   true,
+		ResultType: resultTy,
+		Operands:   []int{lhs, rhs, int(op)},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID
+}
+
+// addCmpInstr adds a comparison instruction.
+func (e *Emitter) addCmpInstr(pred CmpPredicate, lhs, rhs int) int {
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrCmp,
+		HasValue:   true,
+		ResultType: e.mod.GetIntType(1),
+		Operands:   []int{lhs, rhs, int(pred)},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID
+}
+
+// getDxOpStoreFunc creates a dx.op.storeOutput function declaration.
+// storeOutput: void @dx.op.storeOutput.TYPE(i32 opcode, i32 outputID, i32 row, i8 col, TYPE value)
+func (e *Emitter) getDxOpStoreFunc(ol overloadType) *module.Function {
+	name := "dx.op.storeOutput"
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	voidTy := e.mod.GetVoidType()
+	i32Ty := e.mod.GetIntType(32)
+	i8Ty := e.mod.GetIntType(8)
+	valueTy := e.overloadReturnType(ol)
+
+	fullName := name
+	switch ol {
+	case overloadF32:
+		fullName += suffixF32
+	case overloadI32:
+		fullName += suffixI32
+	case overloadF64:
+		fullName += suffixF64
+	}
+
+	params := []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, valueTy}
+	funcTy := e.mod.GetFunctionType(voidTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpLoadFunc creates a dx.op.loadInput function declaration.
+// loadInput: TYPE @dx.op.loadInput.TYPE(i32 opcode, i32 inputID, i32 row, i8 col, i32 vertexID)
+func (e *Emitter) getDxOpLoadFunc(ol overloadType) *module.Function {
+	name := "dx.op.loadInput"
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	retTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+	i8Ty := e.mod.GetIntType(8)
+
+	fullName := name
+	switch ol {
+	case overloadF32:
+		fullName += suffixF32
+	case overloadI32:
+		fullName += suffixI32
+	case overloadF64:
+		fullName += suffixF64
+	}
+
+	params := []*module.Type{i32Ty, i32Ty, i32Ty, i8Ty, i32Ty}
+	funcTy := e.mod.GetFunctionType(retTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpUnaryFunc creates a dx.op unary function declaration.
+// Signature: TYPE @dx.op.NAME.TYPE(i32 opcode, TYPE value)
+func (e *Emitter) getDxOpUnaryFunc(name string, ol overloadType) *module.Function {
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	retTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+
+	fullName := name
+	switch ol {
+	case overloadF32:
+		fullName += suffixF32
+	case overloadI32:
+		fullName += suffixI32
+	}
+
+	params := []*module.Type{i32Ty, retTy}
+	funcTy := e.mod.GetFunctionType(retTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// overloadReturnType returns the DXIL type for the given overload.
+func (e *Emitter) overloadReturnType(ol overloadType) *module.Type {
+	switch ol {
+	case overloadVoid:
+		return e.mod.GetVoidType()
+	case overloadI1:
+		return e.mod.GetIntType(1)
+	case overloadI16:
+		return e.mod.GetIntType(16)
+	case overloadI32:
+		return e.mod.GetIntType(32)
+	case overloadI64:
+		return e.mod.GetIntType(64)
+	case overloadF16:
+		return e.mod.GetFloatType(16)
+	case overloadF32:
+		return e.mod.GetFloatType(32)
+	case overloadF64:
+		return e.mod.GetFloatType(64)
+	default:
+		return e.mod.GetIntType(32)
+	}
+}
+
+// overloadForScalar picks the overload type matching a naga scalar.
+func overloadForScalar(s ir.ScalarType) overloadType {
+	switch s.Kind {
+	case ir.ScalarFloat:
+		switch s.Width {
+		case 2:
+			return overloadF16
+		case 8:
+			return overloadF64
+		default:
+			return overloadF32
+		}
+	case ir.ScalarSint, ir.ScalarUint:
+		switch s.Width {
+		case 2:
+			return overloadI16
+		case 8:
+			return overloadI64
+		default:
+			return overloadI32
+		}
+	case ir.ScalarBool:
+		return overloadI1
+	default:
+		return overloadI32
+	}
+}

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -49,6 +49,13 @@ type Emitter struct {
 	// pendingComponents holds per-component IDs from the last
 	// emitCompose call. Used by emitExpression to store in exprComponents.
 	pendingComponents []int
+
+	// Resource bindings: analyzed from GlobalVariables.
+	resources       []resourceInfo
+	resourceHandles map[ir.GlobalVariableHandle]int // global var handle -> index in resources
+
+	// Cached DXIL resource types (lazily created).
+	dxHandleType *module.Type
 }
 
 // loopContext holds the branch targets for the innermost loop,
@@ -108,15 +115,16 @@ func Emit(irMod *ir.Module, opts EmitOptions) (*module.Module, error) {
 	mod.MinorVersion = opts.ShaderModelMinor
 
 	e := &Emitter{
-		ir:          irMod,
-		mod:         mod,
-		opts:        opts,
-		exprValues:  make(map[ir.ExpressionHandle]int),
-		dxOpFuncs:   make(map[dxOpKey]*module.Function),
-		intConsts:   make(map[int64]int),
-		floatConsts: make(map[uint64]int),
-		undefID:     -1,
-		constMap:    make(map[int]*module.Constant),
+		ir:              irMod,
+		mod:             mod,
+		opts:            opts,
+		exprValues:      make(map[ir.ExpressionHandle]int),
+		dxOpFuncs:       make(map[dxOpKey]*module.Function),
+		intConsts:       make(map[int64]int),
+		floatConsts:     make(map[uint64]int),
+		undefID:         -1,
+		constMap:        make(map[int]*module.Constant),
+		resourceHandles: make(map[ir.GlobalVariableHandle]int),
 	}
 
 	if err := e.emitEntryPoint(ep); err != nil {
@@ -176,10 +184,16 @@ func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
 
 	fn := &ep.Function
 
+	// Analyze and create resource bindings before function body emission.
+	e.analyzeResources()
+
 	// Emit I/O: load inputs into value map, then emit function body,
 	// then store outputs. At this point we use temporary IDs starting
 	// from 0. These will be adjusted in finalize().
 	e.nextValue = 0
+
+	e.emitResourceHandles()
+
 	if err := e.emitInputLoads(fn, ep.Stage); err != nil {
 		return fmt.Errorf("input loads: %w", err)
 	}
@@ -310,14 +324,17 @@ func (e *Emitter) emitMetadata(_ *ir.EntryPoint, kind module.ShaderKind) {
 	mdSM := e.mod.AddMetadataTuple([]*module.MetadataNode{mdKind, mdSMMajor, mdSMMinor})
 	e.mod.AddNamedMetadata("dx.shaderModel", []*module.MetadataNode{mdSM})
 
-	// dx.entryPoints = !{!{null, !"main", null, null, null}}
+	// Emit resource metadata if we have any resources.
+	mdResources := e.emitResourceMetadata()
+
+	// dx.entryPoints = !{!{null, !"main", null, !resources, null}}
 	mdName := e.mod.AddMetadataString("main")
 	mdEntry := e.mod.AddMetadataTuple([]*module.MetadataNode{
-		nil,    // function ref (simplified)
-		mdName, // entry point name
-		nil,    // signatures
-		nil,    // resources
-		nil,    // properties
+		nil,         // function ref (simplified)
+		mdName,      // entry point name
+		nil,         // signatures
+		mdResources, // resources (nil if none)
+		nil,         // properties
 	})
 	e.mod.AddNamedMetadata("dx.entryPoints", []*module.MetadataNode{mdEntry})
 

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -524,6 +524,28 @@ func (e *Emitter) getDxOpLoadFunc(ol overloadType) *module.Function {
 	return fn
 }
 
+// overloadSuffix returns the type suffix string for a given overload.
+func overloadSuffix(ol overloadType) string {
+	switch ol {
+	case overloadF16:
+		return ".f16"
+	case overloadF32:
+		return suffixF32
+	case overloadF64:
+		return suffixF64
+	case overloadI16:
+		return ".i16"
+	case overloadI32:
+		return suffixI32
+	case overloadI64:
+		return ".i64"
+	case overloadI1:
+		return ".i1"
+	default:
+		return ""
+	}
+}
+
 // getDxOpUnaryFunc creates a dx.op unary function declaration.
 // Signature: TYPE @dx.op.NAME.TYPE(i32 opcode, TYPE value)
 func (e *Emitter) getDxOpUnaryFunc(name string, ol overloadType) *module.Function {
@@ -535,15 +557,77 @@ func (e *Emitter) getDxOpUnaryFunc(name string, ol overloadType) *module.Functio
 	retTy := e.overloadReturnType(ol)
 	i32Ty := e.mod.GetIntType(32)
 
-	fullName := name
-	switch ol {
-	case overloadF32:
-		fullName += suffixF32
-	case overloadI32:
-		fullName += suffixI32
-	}
+	fullName := name + overloadSuffix(ol)
 
 	params := []*module.Type{i32Ty, retTy}
+	funcTy := e.mod.GetFunctionType(retTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpBinaryFunc creates a dx.op binary function declaration.
+// Signature: TYPE @dx.op.NAME.TYPE(i32 opcode, TYPE a, TYPE b)
+func (e *Emitter) getDxOpBinaryFunc(name string, ol overloadType) *module.Function {
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	retTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+
+	fullName := name + overloadSuffix(ol)
+
+	params := []*module.Type{i32Ty, retTy, retTy}
+	funcTy := e.mod.GetFunctionType(retTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpTernaryFunc creates a dx.op ternary function declaration.
+// Signature: TYPE @dx.op.NAME.TYPE(i32 opcode, TYPE a, TYPE b, TYPE c)
+func (e *Emitter) getDxOpTernaryFunc(name string, ol overloadType) *module.Function {
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	retTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+
+	fullName := name + overloadSuffix(ol)
+
+	params := []*module.Type{i32Ty, retTy, retTy, retTy}
+	funcTy := e.mod.GetFunctionType(retTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpDotFunc creates a dx.op dot product function declaration.
+// Dot products take 2*size scalar params and return a scalar.
+// Signature: float @dx.op.dotN.f32(i32 opcode, float ax, float ay, ..., float bx, float by, ...)
+func (e *Emitter) getDxOpDotFunc(size int, ol overloadType) *module.Function {
+	name := fmt.Sprintf("dx.op.dot%d", size)
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	retTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+
+	fullName := name + overloadSuffix(ol)
+
+	// params: i32 opcode, then 2*size scalar values
+	params := make([]*module.Type, 1+2*size)
+	params[0] = i32Ty
+	for i := 1; i < len(params); i++ {
+		params[i] = retTy
+	}
+
 	funcTy := e.mod.GetFunctionType(retTy, params)
 	fn := e.mod.AddFunction(fullName, funcTy, true)
 	e.dxOpFuncs[key] = fn

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -28,6 +28,9 @@ type Emitter struct {
 	mainFn    *module.Function // the current function definition (for adding BBs)
 	nextValue int              // next value ID to assign within a function
 
+	// Maps local variable index to its alloca value ID (pointer).
+	localVarPtrs map[uint32]int
+
 	// Loop context stack for break/continue targets.
 	loopStack []loopContext
 
@@ -168,6 +171,7 @@ func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
 	e.currentBB = bb
 	e.exprValues = make(map[ir.ExpressionHandle]int)
 	e.exprComponents = make(map[ir.ExpressionHandle][]int)
+	e.localVarPtrs = make(map[uint32]int)
 	e.loopStack = e.loopStack[:0]
 
 	fn := &ep.Function

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -1,0 +1,580 @@
+package emit
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
+// emitExpression evaluates a single expression and returns its DXIL value ID.
+// For vector types, returns the ID of the first component.
+//
+// Reference: Mesa nir_to_dxil.c emit_alu()
+func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (int, error) {
+	// Check if already emitted.
+	if v, ok := e.exprValues[handle]; ok {
+		return v, nil
+	}
+
+	expr := fn.Expressions[handle]
+	var valueID int
+	var err error
+
+	switch ek := expr.Kind.(type) {
+	case ir.Literal:
+		valueID, err = e.emitLiteral(ek)
+
+	case ir.ExprFunctionArgument:
+		// Should have been set up by emitInputLoads.
+		return 0, fmt.Errorf("function argument %d not in value map", ek.Index)
+
+	case ir.ExprCompose:
+		valueID, err = e.emitCompose(fn, ek)
+
+	case ir.ExprAccessIndex:
+		valueID, err = e.emitAccessIndex(fn, ek)
+
+	case ir.ExprSplat:
+		valueID, err = e.emitSplat(fn, ek)
+
+	case ir.ExprBinary:
+		valueID, err = e.emitBinary(fn, ek)
+
+	case ir.ExprUnary:
+		valueID, err = e.emitUnary(fn, ek)
+
+	case ir.ExprMath:
+		valueID, err = e.emitMath(fn, ek)
+
+	case ir.ExprSelect:
+		valueID, err = e.emitSelect(fn, ek)
+
+	case ir.ExprLoad:
+		valueID, err = e.emitLoad(fn, ek)
+
+	case ir.ExprLocalVariable:
+		// Pointer to local variable. For now, treat as the value itself.
+		valueID = e.allocValue()
+
+	case ir.ExprGlobalVariable:
+		// Global variable reference. For now, treat as a constant.
+		valueID = e.allocValue()
+
+	case ir.ExprZeroValue:
+		valueID, err = e.emitZeroValue(ek)
+
+	case ir.ExprConstant:
+		valueID, err = e.emitConstant(ek)
+
+	case ir.ExprAs:
+		valueID, err = e.emitAs(fn, ek)
+
+	default:
+		// Unsupported expression kind — allocate a placeholder value.
+		valueID = e.allocValue()
+	}
+
+	if err != nil {
+		return 0, fmt.Errorf("expression [%d]: %w", handle, err)
+	}
+
+	e.exprValues[handle] = valueID
+
+	// If compose produced per-component IDs, store them.
+	if e.pendingComponents != nil {
+		e.exprComponents[handle] = e.pendingComponents
+		e.pendingComponents = nil
+	}
+
+	return valueID, nil
+}
+
+// emitLiteral emits a constant value and returns its value ID.
+func (e *Emitter) emitLiteral(lit ir.Literal) (int, error) {
+	switch v := lit.Value.(type) {
+	case ir.LiteralF32:
+		return e.getFloatConstID(float64(v)), nil
+
+	case ir.LiteralF64:
+		return e.addFloatConstID(e.mod.GetFloatType(64), float64(v)), nil
+
+	case ir.LiteralI32:
+		return e.getIntConstID(int64(v)), nil
+
+	case ir.LiteralU32:
+		return e.getIntConstID(int64(v)), nil
+
+	case ir.LiteralI64:
+		c := e.mod.AddIntConst(e.mod.GetIntType(64), int64(v))
+		id := e.allocValue()
+		e.constMap[id] = c
+		return id, nil
+
+	case ir.LiteralU64:
+		c := e.mod.AddIntConst(e.mod.GetIntType(64), int64(v)) //nolint:gosec // value may exceed int64 range
+		id := e.allocValue()
+		e.constMap[id] = c
+		return id, nil
+
+	case ir.LiteralBool:
+		val := int64(0)
+		if bool(v) {
+			val = 1
+		}
+		c := e.mod.AddIntConst(e.mod.GetIntType(1), val)
+		id := e.allocValue()
+		e.constMap[id] = c
+		return id, nil
+
+	case ir.LiteralF16:
+		return e.addFloatConstID(e.mod.GetFloatType(16), float64(v)), nil
+
+	default:
+		return e.getIntConstID(0), nil
+	}
+}
+
+// emitCompose builds a composite value from components.
+// In DXIL, composites are scalarized — each component is a separate value.
+// Returns the value ID of the first component. Also tracks per-component
+// IDs for correct access later.
+func (e *Emitter) emitCompose(fn *ir.Function, comp ir.ExprCompose) (int, error) {
+	if len(comp.Components) == 0 {
+		return e.getIntConstID(0), nil
+	}
+
+	componentIDs := make([]int, len(comp.Components))
+	firstID := -1
+	for i, ch := range comp.Components {
+		v, err := e.emitExpression(fn, ch)
+		if err != nil {
+			return 0, err
+		}
+		componentIDs[i] = v
+		if firstID < 0 {
+			firstID = v
+		}
+	}
+
+	// Store per-component IDs so getComponentID can resolve them.
+	// The compose expression handle will be set by the caller
+	// (emitExpression stores in exprValues).
+	e.pendingComponents = componentIDs
+
+	return firstID, nil
+}
+
+// emitAccessIndex extracts a component from a composite by constant index.
+func (e *Emitter) emitAccessIndex(fn *ir.Function, ai ir.ExprAccessIndex) (int, error) {
+	_, err := e.emitExpression(fn, ai.Base)
+	if err != nil {
+		return 0, err
+	}
+
+	// Use per-component tracking for correct ID resolution.
+	return e.getComponentID(ai.Base, int(ai.Index)), nil
+}
+
+// emitSplat broadcasts a scalar to all components of a vector.
+func (e *Emitter) emitSplat(fn *ir.Function, sp ir.ExprSplat) (int, error) {
+	v, err := e.emitExpression(fn, sp.Value)
+	if err != nil {
+		return 0, err
+	}
+	// In DXIL, all components share the same value — just return it.
+	return v, nil
+}
+
+// emitBinary emits a binary operation.
+//
+//nolint:gocognit,gocyclo,cyclop,funlen // binary op dispatch requires many cases
+func (e *Emitter) emitBinary(fn *ir.Function, bin ir.ExprBinary) (int, error) {
+	lhs, err := e.emitExpression(fn, bin.Left)
+	if err != nil {
+		return 0, err
+	}
+	rhs, err := e.emitExpression(fn, bin.Right)
+	if err != nil {
+		return 0, err
+	}
+
+	// Determine result type from left operand.
+	leftType := e.resolveExprType(fn, bin.Left)
+	isFloat := isFloatType(leftType)
+	isSigned := isSignedInt(leftType)
+	resultTy, _ := typeToDXIL(e.mod, e.ir, leftType)
+
+	switch bin.Op {
+	case ir.BinaryAdd:
+		if isFloat {
+			return e.addBinOpInstr(resultTy, BinOpFAdd, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpAdd, lhs, rhs), nil
+
+	case ir.BinarySubtract:
+		if isFloat {
+			return e.addBinOpInstr(resultTy, BinOpFSub, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpSub, lhs, rhs), nil
+
+	case ir.BinaryMultiply:
+		if isFloat {
+			return e.addBinOpInstr(resultTy, BinOpFMul, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpMul, lhs, rhs), nil
+
+	case ir.BinaryDivide:
+		if isFloat {
+			return e.addBinOpInstr(resultTy, BinOpFDiv, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addBinOpInstr(resultTy, BinOpSDiv, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpUDiv, lhs, rhs), nil
+
+	case ir.BinaryModulo:
+		if isFloat {
+			return e.addBinOpInstr(resultTy, BinOpFRem, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addBinOpInstr(resultTy, BinOpSRem, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpURem, lhs, rhs), nil
+
+	case ir.BinaryAnd:
+		return e.addBinOpInstr(resultTy, BinOpAnd, lhs, rhs), nil
+	case ir.BinaryExclusiveOr:
+		return e.addBinOpInstr(resultTy, BinOpXor, lhs, rhs), nil
+	case ir.BinaryInclusiveOr:
+		return e.addBinOpInstr(resultTy, BinOpOr, lhs, rhs), nil
+
+	case ir.BinaryShiftLeft:
+		return e.addBinOpInstr(resultTy, BinOpShl, lhs, rhs), nil
+	case ir.BinaryShiftRight:
+		if isSigned {
+			return e.addBinOpInstr(resultTy, BinOpAShr, lhs, rhs), nil
+		}
+		return e.addBinOpInstr(resultTy, BinOpLShr, lhs, rhs), nil
+
+	// Comparison operations.
+	case ir.BinaryEqual:
+		if isFloat {
+			return e.addCmpInstr(FCmpOEQ, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpEQ, lhs, rhs), nil
+
+	case ir.BinaryNotEqual:
+		if isFloat {
+			return e.addCmpInstr(FCmpONE, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpNE, lhs, rhs), nil
+
+	case ir.BinaryLess:
+		if isFloat {
+			return e.addCmpInstr(FCmpOLT, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addCmpInstr(ICmpSLT, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpULT, lhs, rhs), nil
+
+	case ir.BinaryLessEqual:
+		if isFloat {
+			return e.addCmpInstr(FCmpOLE, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addCmpInstr(ICmpSLE, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpULE, lhs, rhs), nil
+
+	case ir.BinaryGreater:
+		if isFloat {
+			return e.addCmpInstr(FCmpOGT, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addCmpInstr(ICmpSGT, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpUGT, lhs, rhs), nil
+
+	case ir.BinaryGreaterEqual:
+		if isFloat {
+			return e.addCmpInstr(FCmpOGE, lhs, rhs), nil
+		}
+		if isSigned {
+			return e.addCmpInstr(ICmpSGE, lhs, rhs), nil
+		}
+		return e.addCmpInstr(ICmpUGE, lhs, rhs), nil
+
+	case ir.BinaryLogicalAnd:
+		return e.addBinOpInstr(e.mod.GetIntType(1), BinOpAnd, lhs, rhs), nil
+	case ir.BinaryLogicalOr:
+		return e.addBinOpInstr(e.mod.GetIntType(1), BinOpOr, lhs, rhs), nil
+
+	default:
+		return 0, fmt.Errorf("unsupported binary operator: %d", bin.Op)
+	}
+}
+
+// emitUnary emits a unary operation.
+func (e *Emitter) emitUnary(fn *ir.Function, un ir.ExprUnary) (int, error) {
+	operand, err := e.emitExpression(fn, un.Expr)
+	if err != nil {
+		return 0, err
+	}
+
+	exprType := e.resolveExprType(fn, un.Expr)
+	isFloat := isFloatType(exprType)
+	resultTy, _ := typeToDXIL(e.mod, e.ir, exprType)
+
+	switch un.Op {
+	case ir.UnaryNegate:
+		if isFloat {
+			// fneg = fsub -0.0, operand
+			zeroID := e.getFloatConstID(0.0)
+			return e.addBinOpInstr(resultTy, BinOpFSub, zeroID, operand), nil
+		}
+		// neg = sub 0, operand
+		zeroID := e.getIntConstID(0)
+		return e.addBinOpInstr(resultTy, BinOpSub, zeroID, operand), nil
+
+	case ir.UnaryBitwiseNot:
+		// not = xor operand, -1
+		allOnesID := e.getIntConstID(-1)
+		return e.addBinOpInstr(resultTy, BinOpXor, operand, allOnesID), nil
+
+	case ir.UnaryLogicalNot:
+		// not = xor operand, true
+		c := e.mod.AddIntConst(e.mod.GetIntType(1), 1)
+		trueID := e.allocValue()
+		e.constMap[trueID] = c
+		return e.addBinOpInstr(e.mod.GetIntType(1), BinOpXor, operand, trueID), nil
+
+	default:
+		return 0, fmt.Errorf("unsupported unary operator: %d", un.Op)
+	}
+}
+
+// emitMath emits a math intrinsic as a dx.op call.
+func (e *Emitter) emitMath(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	arg, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+
+	opcode, opName, err := mathToDxOp(mathExpr.Fun)
+	if err != nil {
+		return 0, err
+	}
+
+	dxFn := e.getDxOpUnaryFunc(opName, ol)
+	opcodeVal := e.getIntConstID(int64(opcode))
+
+	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg}), nil
+}
+
+// mathToDxOp maps naga MathFunction to dx.op opcode and name.
+//
+//nolint:gocyclo,cyclop // math function mapping requires many cases
+func mathToDxOp(mf ir.MathFunction) (DXILOpcode, string, error) {
+	switch mf {
+	case ir.MathSin:
+		return OpSin, "dx.op.sin", nil
+	case ir.MathCos:
+		return OpCos, "dx.op.cos", nil
+	case ir.MathTan:
+		return OpTan, "dx.op.tan", nil
+	case ir.MathAsin:
+		return OpAsin, "dx.op.asin", nil
+	case ir.MathAcos:
+		return OpAcos, "dx.op.acos", nil
+	case ir.MathAtan:
+		return OpAtan, "dx.op.atan", nil
+	case ir.MathSinh:
+		return OpHSin, "dx.op.hsin", nil
+	case ir.MathCosh:
+		return OpHCos, "dx.op.hcos", nil
+	case ir.MathTanh:
+		return OpHTan, "dx.op.htan", nil
+	case ir.MathExp2:
+		return OpExp, "dx.op.exp", nil
+	case ir.MathLog2:
+		return OpLog, "dx.op.log", nil
+	case ir.MathSqrt:
+		return OpSqrt, "dx.op.sqrt", nil
+	case ir.MathInverseSqrt:
+		return OpRsqrt, "dx.op.rsqrt", nil
+	case ir.MathAbs:
+		return OpFAbs, "dx.op.fabs", nil
+	case ir.MathSaturate:
+		return OpSaturate, "dx.op.saturate", nil
+	case ir.MathFloor:
+		return OpRoundNI, "dx.op.round_ni", nil
+	case ir.MathCeil:
+		return OpRoundPI, "dx.op.round_pi", nil
+	case ir.MathTrunc:
+		return OpRoundZ, "dx.op.round_z", nil
+	case ir.MathRound:
+		return OpRoundNE, "dx.op.round_ne", nil
+	case ir.MathFract:
+		return OpFrc, "dx.op.frc", nil
+	case ir.MathReverseBits:
+		return OpReverseBits, "dx.op.reverseBits", nil
+	case ir.MathCountOneBits:
+		return OpCountBits, "dx.op.countBits", nil
+	case ir.MathFirstTrailingBit:
+		return OpFirstbitLo, "dx.op.firstbitLo", nil
+	case ir.MathFirstLeadingBit:
+		return OpFirstbitHi, "dx.op.firstbitHi", nil
+	default:
+		return 0, "", fmt.Errorf("unsupported math function: %d", mf)
+	}
+}
+
+// emitSelect emits a select (ternary) instruction.
+func (e *Emitter) emitSelect(fn *ir.Function, sel ir.ExprSelect) (int, error) {
+	cond, err := e.emitExpression(fn, sel.Condition)
+	if err != nil {
+		return 0, err
+	}
+	accept, err := e.emitExpression(fn, sel.Accept)
+	if err != nil {
+		return 0, err
+	}
+	reject, err := e.emitExpression(fn, sel.Reject)
+	if err != nil {
+		return 0, err
+	}
+
+	acceptType := e.resolveExprType(fn, sel.Accept)
+	resultTy, _ := typeToDXIL(e.mod, e.ir, acceptType)
+
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrSelect,
+		HasValue:   true,
+		ResultType: resultTy,
+		Operands:   []int{cond, accept, reject},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID, nil
+}
+
+// emitLoad emits a load through a pointer.
+func (e *Emitter) emitLoad(fn *ir.Function, load ir.ExprLoad) (int, error) {
+	ptr, err := e.emitExpression(fn, load.Pointer)
+	if err != nil {
+		return 0, err
+	}
+	// In the simplified model, just return the pointer value.
+	return ptr, nil
+}
+
+// emitZeroValue emits a zero-initialized constant.
+func (e *Emitter) emitZeroValue(zv ir.ExprZeroValue) (int, error) { //nolint:unparam // error return for interface consistency
+	ty := e.ir.Types[zv.Type]
+	inner := ty.Inner
+
+	switch inner.(type) {
+	case ir.ScalarType:
+		s := inner.(ir.ScalarType)
+		if s.Kind == ir.ScalarFloat {
+			return e.getFloatConstID(0.0), nil
+		}
+		return e.getIntConstID(0), nil
+	case ir.VectorType:
+		vt := inner.(ir.VectorType)
+		if vt.Scalar.Kind == ir.ScalarFloat {
+			return e.getFloatConstID(0.0), nil
+		}
+		return e.getIntConstID(0), nil
+	default:
+		return e.getIntConstID(0), nil
+	}
+}
+
+// emitConstant emits a reference to a module-scope constant.
+func (e *Emitter) emitConstant(ec ir.ExprConstant) (int, error) {
+	c := &e.ir.Constants[ec.Constant]
+
+	// Look at the init expression in GlobalExpressions.
+	if int(c.Init) < len(e.ir.GlobalExpressions) {
+		globalExpr := e.ir.GlobalExpressions[c.Init]
+		if lit, ok := globalExpr.Kind.(ir.Literal); ok {
+			return e.emitLiteral(lit)
+		}
+	}
+
+	// Fallback: zero value.
+	return e.getIntConstID(0), nil
+}
+
+// emitAs emits a type cast expression.
+func (e *Emitter) emitAs(fn *ir.Function, as ir.ExprAs) (int, error) {
+	src, err := e.emitExpression(fn, as.Expr)
+	if err != nil {
+		return 0, err
+	}
+	// Simplified: for now just pass through (proper casts need LLVM cast instructions).
+	return src, nil
+}
+
+// resolveExprType returns the TypeInner for an expression.
+func (e *Emitter) resolveExprType(fn *ir.Function, handle ir.ExpressionHandle) ir.TypeInner {
+	if int(handle) < len(fn.ExpressionTypes) {
+		tr := fn.ExpressionTypes[handle]
+		if tr.Handle != nil {
+			return e.ir.Types[*tr.Handle].Inner
+		}
+		if tr.Value != nil {
+			return tr.Value
+		}
+	}
+
+	// Fallback: try to infer from the expression itself.
+	if int(handle) < len(fn.Expressions) {
+		expr := fn.Expressions[handle]
+		switch ek := expr.Kind.(type) {
+		case ir.Literal:
+			return literalType(ek)
+		case ir.ExprFunctionArgument:
+			if int(ek.Index) < len(fn.Arguments) {
+				return e.ir.Types[fn.Arguments[ek.Index].Type].Inner
+			}
+		}
+	}
+
+	return ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+}
+
+// literalType returns the TypeInner for a literal expression.
+func literalType(lit ir.Literal) ir.TypeInner {
+	switch lit.Value.(type) {
+	case ir.LiteralF32:
+		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	case ir.LiteralF64:
+		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 8}
+	case ir.LiteralI32:
+		return ir.ScalarType{Kind: ir.ScalarSint, Width: 4}
+	case ir.LiteralU32:
+		return ir.ScalarType{Kind: ir.ScalarUint, Width: 4}
+	case ir.LiteralI64:
+		return ir.ScalarType{Kind: ir.ScalarSint, Width: 8}
+	case ir.LiteralU64:
+		return ir.ScalarType{Kind: ir.ScalarUint, Width: 8}
+	case ir.LiteralBool:
+		return ir.ScalarType{Kind: ir.ScalarBool, Width: 1}
+	case ir.LiteralF16:
+		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 2}
+	default:
+		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+}

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -59,8 +59,16 @@ func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (i
 		valueID, err = e.emitLocalVariable(fn, ek)
 
 	case ir.ExprGlobalVariable:
-		// Global variable reference. For now, treat as a constant.
-		valueID = e.allocValue()
+		// If this is a resource binding, return the pre-created handle ID.
+		if handleID, found := e.getResourceHandleID(ek.Variable); found {
+			valueID = handleID
+		} else {
+			// Non-resource global variable — allocate a placeholder value.
+			valueID = e.allocValue()
+		}
+
+	case ir.ExprImageSample:
+		valueID, err = e.emitImageSample(fn, ek)
 
 	case ir.ExprZeroValue:
 		valueID, err = e.emitZeroValue(ek)

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -54,8 +54,7 @@ func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (i
 		valueID, err = e.emitLoad(fn, ek)
 
 	case ir.ExprLocalVariable:
-		// Pointer to local variable. For now, treat as the value itself.
-		valueID = e.allocValue()
+		valueID, err = e.emitLocalVariable(fn, ek)
 
 	case ir.ExprGlobalVariable:
 		// Global variable reference. For now, treat as a constant.
@@ -999,8 +998,162 @@ func (e *Emitter) emitLoad(fn *ir.Function, load ir.ExprLoad) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	// In the simplified model, just return the pointer value.
-	return ptr, nil
+
+	// Resolve the loaded type from the pointer's target type.
+	loadedTy, err := e.resolveLoadType(fn, load.Pointer)
+	if err != nil {
+		return 0, fmt.Errorf("load type resolution: %w", err)
+	}
+
+	// Emit LLVM load instruction: %val = load TYPE, TYPE* %ptr, align N
+	valueID := e.allocValue()
+	align := e.alignForType(loadedTy)
+	instr := &module.Instruction{
+		Kind:       module.InstrLoad,
+		HasValue:   true,
+		ResultType: loadedTy,
+		Operands:   []int{ptr, loadedTy.ID, align, 0}, // ptr, typeID, align, isVolatile
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID, nil
+}
+
+// emitLocalVariable emits an alloca for the local variable (on first use)
+// and returns the pointer value ID.
+//
+// DXIL uses the standard LLVM stack allocation pattern:
+//
+//	%ptr = alloca TYPE, i32 1, align N
+//
+// Reference: Mesa nir_to_dxil.c emit_scratch() — dxil_emit_alloca(mod, type, 1, 16)
+func (e *Emitter) emitLocalVariable(fn *ir.Function, lv ir.ExprLocalVariable) (int, error) {
+	// Return cached alloca pointer if already emitted.
+	if ptr, ok := e.localVarPtrs[lv.Variable]; ok {
+		return ptr, nil
+	}
+
+	if int(lv.Variable) >= len(fn.LocalVars) {
+		return 0, fmt.Errorf("local variable index %d out of range (function has %d vars)", lv.Variable, len(fn.LocalVars))
+	}
+
+	localVar := &fn.LocalVars[lv.Variable]
+	irType := e.ir.Types[localVar.Type]
+
+	// Resolve the DXIL element type for the allocation.
+	elemTy, err := typeToDXIL(e.mod, e.ir, irType.Inner)
+	if err != nil {
+		return 0, fmt.Errorf("local var %q type: %w", localVar.Name, err)
+	}
+
+	// Create pointer type for the result.
+	ptrTy := e.mod.GetPointerType(elemTy)
+
+	// Size operand: i32 constant 1 (allocate a single element).
+	sizeID := e.getIntConstID(1)
+
+	// Alignment: log2(align) + 1, with bit 6 set (Mesa convention).
+	// Mesa uses 16-byte alignment for scratch variables.
+	align := e.alignForType(elemTy)
+	alignFlags := align | (1 << 6) // bit 6 = InAlloca flag in LLVM encoding
+
+	valueID := e.allocValue()
+	i32Ty := e.mod.GetIntType(32)
+	instr := &module.Instruction{
+		Kind:       module.InstrAlloca,
+		HasValue:   true,
+		ResultType: ptrTy,
+		Operands:   []int{elemTy.ID, i32Ty.ID, sizeID, alignFlags},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+
+	e.localVarPtrs[lv.Variable] = valueID
+	return valueID, nil
+}
+
+// resolveLoadType determines the DXIL type produced by loading from the given
+// pointer expression. It examines the pointer expression kind (local variable
+// or global variable) to find the element type.
+func (e *Emitter) resolveLoadType(fn *ir.Function, ptrHandle ir.ExpressionHandle) (*module.Type, error) {
+	expr := fn.Expressions[ptrHandle]
+	switch pk := expr.Kind.(type) {
+	case ir.ExprLocalVariable:
+		if int(pk.Variable) >= len(fn.LocalVars) {
+			return nil, fmt.Errorf("local variable %d out of range", pk.Variable)
+		}
+		lv := &fn.LocalVars[pk.Variable]
+		irType := e.ir.Types[lv.Type]
+		return typeToDXIL(e.mod, e.ir, irType.Inner)
+
+	case ir.ExprGlobalVariable:
+		if int(pk.Variable) >= len(e.ir.GlobalVariables) {
+			return nil, fmt.Errorf("global variable %d out of range", pk.Variable)
+		}
+		gv := &e.ir.GlobalVariables[pk.Variable]
+		irType := e.ir.Types[gv.Type]
+		return typeToDXIL(e.mod, e.ir, irType.Inner)
+
+	default:
+		return e.resolveLoadTypeFromExpressionInfo(fn, ptrHandle)
+	}
+}
+
+// resolveLoadTypeFromExpressionInfo resolves the loaded type by examining
+// the ExpressionTypes metadata for the pointer expression.
+func (e *Emitter) resolveLoadTypeFromExpressionInfo(fn *ir.Function, ptrHandle ir.ExpressionHandle) (*module.Type, error) {
+	if int(ptrHandle) >= len(fn.ExpressionTypes) {
+		return e.mod.GetIntType(32), nil
+	}
+	res := fn.ExpressionTypes[ptrHandle]
+
+	if res.Handle != nil && int(*res.Handle) < len(e.ir.Types) {
+		irType := e.ir.Types[*res.Handle]
+		if pt, ok := irType.Inner.(ir.PointerType); ok {
+			baseType := e.ir.Types[pt.Base]
+			return typeToDXIL(e.mod, e.ir, baseType.Inner)
+		}
+		return typeToDXIL(e.mod, e.ir, irType.Inner)
+	}
+
+	if res.Value != nil {
+		if pt, ok := res.Value.(ir.PointerType); ok {
+			baseType := e.ir.Types[pt.Base]
+			return typeToDXIL(e.mod, e.ir, baseType.Inner)
+		}
+	}
+
+	return e.mod.GetIntType(32), nil
+}
+
+// alignForType returns the alignment value for a DXIL type.
+// For alloca this is encoded as log2(bytes)+1, for load/store it's log2(bytes).
+// Uses the natural alignment of the type.
+func (e *Emitter) alignForType(ty *module.Type) int {
+	switch ty.Kind {
+	case module.TypeFloat:
+		switch ty.FloatBits {
+		case 16:
+			return 1 // log2(2) = 1
+		case 64:
+			return 3 // log2(8) = 3
+		default:
+			return 2 // log2(4) = 2 for f32
+		}
+	case module.TypeInteger:
+		switch ty.IntBits {
+		case 1, 8:
+			return 0 // log2(1) = 0
+		case 16:
+			return 1 // log2(2) = 1
+		case 64:
+			return 3 // log2(8) = 3
+		default:
+			return 2 // log2(4) = 2 for i32
+		}
+	default:
+		return 2 // default 4-byte alignment
+	}
 }
 
 // emitZeroValue emits a zero-initialized constant.

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -11,6 +11,8 @@ import (
 // For vector types, returns the ID of the first component.
 //
 // Reference: Mesa nir_to_dxil.c emit_alu()
+//
+//nolint:gocyclo,cyclop // expression dispatch requires handling all expression kinds
 func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (int, error) {
 	// Check if already emitted.
 	if v, ok := e.exprValues[handle]; ok {
@@ -69,9 +71,20 @@ func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (i
 	case ir.ExprAs:
 		valueID, err = e.emitAs(fn, ek)
 
+	case ir.ExprSwizzle:
+		valueID, err = e.emitSwizzle(fn, ek)
+
+	case ir.ExprDerivative:
+		valueID, err = e.emitDerivative(fn, ek)
+
+	case ir.ExprRelational:
+		valueID, err = e.emitRelational(fn, ek)
+
+	case ir.ExprArrayLength:
+		return 0, fmt.Errorf("ExprArrayLength not yet implemented in DXIL backend")
+
 	default:
-		// Unsupported expression kind — allocate a placeholder value.
-		valueID = e.allocValue()
+		return 0, fmt.Errorf("unsupported expression kind: %T", expr.Kind)
 	}
 
 	if err != nil {
@@ -1440,5 +1453,145 @@ func literalType(lit ir.Literal) ir.TypeInner {
 		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 2}
 	default:
 		return ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+}
+
+// emitSwizzle reorders or duplicates vector components.
+// In DXIL (scalarized), this remaps component IDs from the source vector.
+func (e *Emitter) emitSwizzle(fn *ir.Function, sw ir.ExprSwizzle) (int, error) {
+	// Ensure the source vector is emitted.
+	if _, err := e.emitExpression(fn, sw.Vector); err != nil {
+		return 0, err
+	}
+
+	size := int(sw.Size)
+	comps := make([]int, size)
+	for i := 0; i < size; i++ {
+		srcComp := int(sw.Pattern[i]) // 0=X, 1=Y, 2=Z, 3=W
+		comps[i] = e.getComponentID(sw.Vector, srcComp)
+	}
+
+	e.pendingComponents = comps
+	return comps[0], nil
+}
+
+// emitDerivative emits a fragment shader derivative as a dx.op call.
+//
+// Maps naga DerivativeAxis + DerivativeControl to dx.op opcodes:
+//
+//	X + Coarse → dx.op.derivCoarseX (83)
+//	Y + Coarse → dx.op.derivCoarseY (84)
+//	X + Fine   → dx.op.derivFineX   (85)
+//	Y + Fine   → dx.op.derivFineY   (86)
+//	Width      → derivCoarseX + derivCoarseY (abs sum, fwidth)
+func (e *Emitter) emitDerivative(fn *ir.Function, deriv ir.ExprDerivative) (int, error) {
+	arg, err := e.emitExpression(fn, deriv.Expr)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, deriv.Expr)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+
+	// fwidth = abs(dFdx) + abs(dFdy) — needs decomposition.
+	if deriv.Axis == ir.DerivativeWidth {
+		return e.emitDerivativeWidth(arg, ol)
+	}
+
+	opcode, opName := derivativeOp(deriv.Axis, deriv.Control)
+	dxFn := e.getDxOpUnaryFunc(opName, ol)
+	opcodeVal := e.getIntConstID(int64(opcode))
+	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg}), nil
+}
+
+// emitDerivativeWidth emits fwidth(v) = abs(dFdx(v)) + abs(dFdy(v)).
+func (e *Emitter) emitDerivativeWidth(arg int, ol overloadType) (int, error) {
+	resultTy := e.overloadReturnType(ol)
+
+	// dFdx
+	dxFnX := e.getDxOpUnaryFunc("dx.op.derivCoarseX", ol)
+	opcodeX := e.getIntConstID(int64(OpDerivCoarseX))
+	dfdx := e.addCallInstr(dxFnX, dxFnX.FuncType.RetType, []int{opcodeX, arg})
+
+	// dFdy
+	dxFnY := e.getDxOpUnaryFunc("dx.op.derivCoarseY", ol)
+	opcodeY := e.getIntConstID(int64(OpDerivCoarseY))
+	dfdy := e.addCallInstr(dxFnY, dxFnY.FuncType.RetType, []int{opcodeY, arg})
+
+	// abs(dFdx)
+	absFn := e.getDxOpUnaryFunc("dx.op.fabs", ol)
+	absOp := e.getIntConstID(int64(OpFAbs))
+	absDx := e.addCallInstr(absFn, absFn.FuncType.RetType, []int{absOp, dfdx})
+
+	// abs(dFdy)
+	absDy := e.addCallInstr(absFn, absFn.FuncType.RetType, []int{absOp, dfdy})
+
+	// abs(dFdx) + abs(dFdy)
+	return e.addBinOpInstr(resultTy, BinOpFAdd, absDx, absDy), nil
+}
+
+// derivativeOp returns the dx.op opcode and name for a derivative axis + control.
+func derivativeOp(axis ir.DerivativeAxis, control ir.DerivativeControl) (DXILOpcode, string) {
+	switch {
+	case axis == ir.DerivativeX && control == ir.DerivativeFine:
+		return OpDerivFineX, "dx.op.derivFineX"
+	case axis == ir.DerivativeY && control == ir.DerivativeFine:
+		return OpDerivFineY, "dx.op.derivFineY"
+	case axis == ir.DerivativeX: // Coarse or None
+		return OpDerivCoarseX, "dx.op.derivCoarseX"
+	case axis == ir.DerivativeY: // Coarse or None
+		return OpDerivCoarseY, "dx.op.derivCoarseY"
+	default:
+		return OpDerivCoarseX, "dx.op.derivCoarseX"
+	}
+}
+
+// emitRelational emits a relational test function as a dx.op call.
+//
+// Maps naga RelationalFunction to dx.op:
+//
+//	IsNan → dx.op.isNaN (8)
+//	IsInf → dx.op.isInf (9)
+//
+// All/Any are boolean vector reductions (not dx.op intrinsics).
+func (e *Emitter) emitRelational(fn *ir.Function, rel ir.ExprRelational) (int, error) {
+	arg, err := e.emitExpression(fn, rel.Argument)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, rel.Argument)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+
+	switch rel.Fun {
+	case ir.RelationalIsNan:
+		ol := overloadForScalar(scalar)
+		dxFn := e.getDxOpUnaryFunc("dx.op.isNaN", ol)
+		opcodeVal := e.getIntConstID(int64(OpIsNaN))
+		return e.addCallInstr(dxFn, e.mod.GetIntType(1), []int{opcodeVal, arg}), nil
+
+	case ir.RelationalIsInf:
+		ol := overloadForScalar(scalar)
+		dxFn := e.getDxOpUnaryFunc("dx.op.isInf", ol)
+		opcodeVal := e.getIntConstID(int64(OpIsInf))
+		return e.addCallInstr(dxFn, e.mod.GetIntType(1), []int{opcodeVal, arg}), nil
+
+	case ir.RelationalAll:
+		// All components are true: for scalar bool, just return the value.
+		return arg, nil
+
+	case ir.RelationalAny:
+		// Any component is true: for scalar bool, just return the value.
+		return arg, nil
+
+	default:
+		return 0, fmt.Errorf("unsupported relational function: %d", rel.Fun)
 	}
 }

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -356,7 +356,32 @@ func (e *Emitter) emitUnary(fn *ir.Function, un ir.ExprUnary) (int, error) {
 }
 
 // emitMath emits a math intrinsic as a dx.op call.
+// Dispatches based on argument count and special-case operations.
 func (e *Emitter) emitMath(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	// Special vector operations that need scalarized handling.
+	switch mathExpr.Fun {
+	case ir.MathDot:
+		return e.emitMathDot(fn, mathExpr)
+	case ir.MathCross:
+		return e.emitMathCross(fn, mathExpr)
+	case ir.MathLength:
+		return e.emitMathLength(fn, mathExpr)
+	case ir.MathDistance:
+		return e.emitMathDistance(fn, mathExpr)
+	case ir.MathNormalize:
+		return e.emitMathNormalize(fn, mathExpr)
+	}
+
+	// Composite operations without direct dx.op.
+	switch mathExpr.Fun {
+	case ir.MathPow:
+		return e.emitMathPow(fn, mathExpr)
+	case ir.MathStep:
+		return e.emitMathStep(fn, mathExpr)
+	case ir.MathSmoothStep:
+		return e.emitMathSmoothStep(fn, mathExpr)
+	}
+
 	arg, err := e.emitExpression(fn, mathExpr.Arg)
 	if err != nil {
 		return 0, err
@@ -368,8 +393,33 @@ func (e *Emitter) emitMath(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
 		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
 	}
 	ol := overloadForScalar(scalar)
+	isFloat := scalar.Kind == ir.ScalarFloat
+	isSigned := scalar.Kind == ir.ScalarSint
 
-	opcode, opName, err := mathToDxOp(mathExpr.Fun)
+	// Ternary: 3 args (Arg + Arg1 + Arg2).
+	if mathExpr.Arg1 != nil && mathExpr.Arg2 != nil {
+		arg1, err2 := e.emitExpression(fn, *mathExpr.Arg1)
+		if err2 != nil {
+			return 0, err2
+		}
+		arg2, err2 := e.emitExpression(fn, *mathExpr.Arg2)
+		if err2 != nil {
+			return 0, err2
+		}
+		return e.emitMathTernary(mathExpr.Fun, ol, isFloat, isSigned, arg, arg1, arg2)
+	}
+
+	// Binary: 2 args (Arg + Arg1).
+	if mathExpr.Arg1 != nil {
+		arg1, err2 := e.emitExpression(fn, *mathExpr.Arg1)
+		if err2 != nil {
+			return 0, err2
+		}
+		return e.emitMathBinary(mathExpr.Fun, ol, isFloat, isSigned, arg, arg1)
+	}
+
+	// Unary: 1 arg.
+	opcode, opName, err := mathToDxOpUnary(mathExpr.Fun)
 	if err != nil {
 		return 0, err
 	}
@@ -380,10 +430,485 @@ func (e *Emitter) emitMath(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
 	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg}), nil
 }
 
-// mathToDxOp maps naga MathFunction to dx.op opcode and name.
+// emitMathBinary emits a binary math dx.op call (min, max, atan2).
+func (e *Emitter) emitMathBinary(mf ir.MathFunction, ol overloadType, isFloat, isSigned bool, arg, arg1 int) (int, error) {
+	var opcode DXILOpcode
+	var opName string
+
+	switch mf {
+	case ir.MathMin:
+		if isFloat {
+			opcode, opName = OpFMin, "dx.op.fmin"
+		} else if isSigned {
+			opcode, opName = OpIMin, "dx.op.imin"
+		} else {
+			opcode, opName = OpUMin, "dx.op.umin"
+		}
+	case ir.MathMax:
+		if isFloat {
+			opcode, opName = OpFMax, "dx.op.fmax"
+		} else if isSigned {
+			opcode, opName = OpIMax, "dx.op.imax"
+		} else {
+			opcode, opName = OpUMax, "dx.op.umax"
+		}
+	case ir.MathAtan2:
+		// DXIL has no atan2 dx.op. Approximate as atan(y/x).
+		// This is a simplification; proper atan2 needs quadrant correction.
+		resultTy := e.overloadReturnType(ol)
+		div := e.addBinOpInstr(resultTy, BinOpFDiv, arg, arg1)
+		dxFn := e.getDxOpUnaryFunc("dx.op.atan", ol)
+		opcodeVal := e.getIntConstID(int64(OpAtan))
+		return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, div}), nil
+	default:
+		return 0, fmt.Errorf("unsupported binary math function: %d", mf)
+	}
+
+	dxFn := e.getDxOpBinaryFunc(opName, ol)
+	opcodeVal := e.getIntConstID(int64(opcode))
+	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg, arg1}), nil
+}
+
+// emitMathTernary emits a ternary math dx.op call (clamp, mix, fma).
+func (e *Emitter) emitMathTernary(mf ir.MathFunction, ol overloadType, isFloat, isSigned bool, arg, arg1, arg2 int) (int, error) {
+	switch mf {
+	case ir.MathClamp:
+		// clamp(x, lo, hi) = min(max(x, lo), hi)
+		return e.emitClamp(ol, isFloat, isSigned, arg, arg1, arg2)
+	case ir.MathMix:
+		// mix(a, b, t) = a + t*(b-a) = fmad(t, b-a, a)
+		if isFloat {
+			resultTy := e.overloadReturnType(ol)
+			bMinusA := e.addBinOpInstr(resultTy, BinOpFSub, arg1, arg)
+			dxFn := e.getDxOpTernaryFunc("dx.op.fmad", ol)
+			opcodeVal := e.getIntConstID(int64(OpFMad))
+			return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg2, bMinusA, arg}), nil
+		}
+		return 0, fmt.Errorf("mix not supported for non-float types")
+	case ir.MathFma:
+		if isFloat {
+			dxFn := e.getDxOpTernaryFunc("dx.op.fma", ol)
+			opcodeVal := e.getIntConstID(int64(OpFma))
+			return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg, arg1, arg2}), nil
+		}
+		return 0, fmt.Errorf("fma not supported for non-float types")
+	default:
+		return 0, fmt.Errorf("unsupported ternary math function: %d", mf)
+	}
+}
+
+// emitClamp emits clamp(x, lo, hi) = min(max(x, lo), hi).
+func (e *Emitter) emitClamp(ol overloadType, isFloat, isSigned bool, x, lo, hi int) (int, error) {
+	var maxOp, minOp DXILOpcode
+	var maxName, minName string
+	if isFloat {
+		maxOp, maxName = OpFMax, "dx.op.fmax"
+		minOp, minName = OpFMin, "dx.op.fmin"
+	} else if isSigned {
+		maxOp, maxName = OpIMax, "dx.op.imax"
+		minOp, minName = OpIMin, "dx.op.imin"
+	} else {
+		maxOp, maxName = OpUMax, "dx.op.umax"
+		minOp, minName = OpUMin, "dx.op.umin"
+	}
+
+	maxFn := e.getDxOpBinaryFunc(maxName, ol)
+	maxOpcodeVal := e.getIntConstID(int64(maxOp))
+	maxResult := e.addCallInstr(maxFn, maxFn.FuncType.RetType, []int{maxOpcodeVal, x, lo})
+
+	minFn := e.getDxOpBinaryFunc(minName, ol)
+	minOpcodeVal := e.getIntConstID(int64(minOp))
+	return e.addCallInstr(minFn, minFn.FuncType.RetType, []int{minOpcodeVal, maxResult, hi}), nil
+}
+
+// emitMathPow emits pow(base, exp) = exp2(log2(base) * exp).
+// DXIL has no pow dx.op; decompose into log2 + fmul + exp2.
+func (e *Emitter) emitMathPow(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	base, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	exp, err := e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+	resultTy := e.overloadReturnType(ol)
+
+	// log2(base)
+	logFn := e.getDxOpUnaryFunc("dx.op.log", ol)
+	logOp := e.getIntConstID(int64(OpLog))
+	logResult := e.addCallInstr(logFn, logFn.FuncType.RetType, []int{logOp, base})
+
+	// log2(base) * exp
+	mulResult := e.addBinOpInstr(resultTy, BinOpFMul, logResult, exp)
+
+	// exp2(log2(base) * exp)
+	expFn := e.getDxOpUnaryFunc("dx.op.exp", ol)
+	expOp := e.getIntConstID(int64(OpExp))
+	return e.addCallInstr(expFn, expFn.FuncType.RetType, []int{expOp, mulResult}), nil
+}
+
+// emitMathStep emits step(edge, x) = select(x >= edge, 1.0, 0.0).
+func (e *Emitter) emitMathStep(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	edge, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	x, err := e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+	resultTy := e.overloadReturnType(ol)
+
+	// x >= edge
+	cmp := e.addCmpInstr(FCmpOGE, x, edge)
+
+	// select(cmp, 1.0, 0.0)
+	oneID := e.getFloatConstID(1.0)
+	zeroID := e.getFloatConstID(0.0)
+
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrSelect,
+		HasValue:   true,
+		ResultType: resultTy,
+		Operands:   []int{cmp, oneID, zeroID},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID, nil
+}
+
+// emitMathSmoothStep emits smoothstep(edge0, edge1, x).
+// t = clamp((x - edge0) / (edge1 - edge0), 0.0, 1.0)
+// result = t * t * (3.0 - 2.0 * t)
+func (e *Emitter) emitMathSmoothStep(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	edge0, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	edge1, err := e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+	x, err := e.emitExpression(fn, *mathExpr.Arg2)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+	resultTy := e.overloadReturnType(ol)
+
+	// x - edge0
+	xMinusE0 := e.addBinOpInstr(resultTy, BinOpFSub, x, edge0)
+	// edge1 - edge0
+	e1MinusE0 := e.addBinOpInstr(resultTy, BinOpFSub, edge1, edge0)
+	// (x - edge0) / (edge1 - edge0)
+	ratio := e.addBinOpInstr(resultTy, BinOpFDiv, xMinusE0, e1MinusE0)
+
+	// clamp(ratio, 0.0, 1.0)
+	zeroID := e.getFloatConstID(0.0)
+	oneID := e.getFloatConstID(1.0)
+	t, err := e.emitClamp(ol, true, false, ratio, zeroID, oneID)
+	if err != nil {
+		return 0, err
+	}
+
+	// t * t
+	tSquared := e.addBinOpInstr(resultTy, BinOpFMul, t, t)
+	// 2.0 * t
+	twoID := e.getFloatConstID(2.0)
+	twoT := e.addBinOpInstr(resultTy, BinOpFMul, twoID, t)
+	// 3.0 - 2.0 * t
+	threeID := e.getFloatConstID(3.0)
+	threeMinusTwoT := e.addBinOpInstr(resultTy, BinOpFSub, threeID, twoT)
+	// t * t * (3.0 - 2.0 * t)
+	return e.addBinOpInstr(resultTy, BinOpFMul, tSquared, threeMinusTwoT), nil
+}
+
+// emitMathDot emits a dot product using dx.op.dot2/dot3/dot4.
+// Takes two vectors, extracts components, calls the appropriate dot intrinsic.
+func (e *Emitter) emitMathDot(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	_, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	_, err = e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	size := componentCount(argType)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+
+	var opcode DXILOpcode
+	switch size {
+	case 2:
+		opcode = OpDot2
+	case 3:
+		opcode = OpDot3
+	case 4:
+		opcode = OpDot4
+	default:
+		return 0, fmt.Errorf("unsupported dot product vector size: %d", size)
+	}
+
+	dxFn := e.getDxOpDotFunc(size, ol)
+	opcodeVal := e.getIntConstID(int64(opcode))
+
+	// Build operands: opcode, a.x, a.y, ..., b.x, b.y, ...
+	operands := make([]int, 1+2*size)
+	operands[0] = opcodeVal
+	for i := 0; i < size; i++ {
+		operands[1+i] = e.getComponentID(mathExpr.Arg, i)
+	}
+	for i := 0; i < size; i++ {
+		operands[1+size+i] = e.getComponentID(*mathExpr.Arg1, i)
+	}
+
+	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, operands), nil
+}
+
+// emitMathCross emits cross(a, b) = vec3(a.y*b.z - a.z*b.y, a.z*b.x - a.x*b.z, a.x*b.y - a.y*b.x).
+// No dx.op for cross — decompose into 6 fmul + 3 fsub.
+func (e *Emitter) emitMathCross(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	_, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	_, err = e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	resultTy := e.overloadReturnType(overloadForScalar(scalar))
+
+	ax := e.getComponentID(mathExpr.Arg, 0)
+	ay := e.getComponentID(mathExpr.Arg, 1)
+	az := e.getComponentID(mathExpr.Arg, 2)
+	bx := e.getComponentID(*mathExpr.Arg1, 0)
+	by := e.getComponentID(*mathExpr.Arg1, 1)
+	bz := e.getComponentID(*mathExpr.Arg1, 2)
+
+	// x = a.y*b.z - a.z*b.y
+	ayBz := e.addBinOpInstr(resultTy, BinOpFMul, ay, bz)
+	azBy := e.addBinOpInstr(resultTy, BinOpFMul, az, by)
+	cx := e.addBinOpInstr(resultTy, BinOpFSub, ayBz, azBy)
+
+	// y = a.z*b.x - a.x*b.z
+	azBx := e.addBinOpInstr(resultTy, BinOpFMul, az, bx)
+	axBz := e.addBinOpInstr(resultTy, BinOpFMul, ax, bz)
+	cy := e.addBinOpInstr(resultTy, BinOpFSub, azBx, axBz)
+
+	// z = a.x*b.y - a.y*b.x
+	axBy := e.addBinOpInstr(resultTy, BinOpFMul, ax, by)
+	ayBx := e.addBinOpInstr(resultTy, BinOpFMul, ay, bx)
+	cz := e.addBinOpInstr(resultTy, BinOpFSub, axBy, ayBx)
+
+	e.pendingComponents = []int{cx, cy, cz}
+	return cx, nil
+}
+
+// emitDotForVector emits a dot product of a vector expression with itself.
+// Helper used by length and normalize.
+func (e *Emitter) emitDotForVector(handle ir.ExpressionHandle, size int, ol overloadType) (int, error) {
+	var opcode DXILOpcode
+	switch size {
+	case 2:
+		opcode = OpDot2
+	case 3:
+		opcode = OpDot3
+	case 4:
+		opcode = OpDot4
+	default:
+		return 0, fmt.Errorf("unsupported vector size for dot: %d", size)
+	}
+
+	dxFn := e.getDxOpDotFunc(size, ol)
+	opcodeVal := e.getIntConstID(int64(opcode))
+
+	operands := make([]int, 1+2*size)
+	operands[0] = opcodeVal
+	for i := 0; i < size; i++ {
+		c := e.getComponentID(handle, i)
+		operands[1+i] = c
+		operands[1+size+i] = c
+	}
+
+	return e.addCallInstr(dxFn, dxFn.FuncType.RetType, operands), nil
+}
+
+// emitMathLength emits length(v) = sqrt(dot(v, v)).
+func (e *Emitter) emitMathLength(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	_, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	size := componentCount(argType)
+
+	// Scalar length = abs(x).
+	if size == 1 {
+		scalar, ok := scalarOfType(argType)
+		if !ok {
+			scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+		}
+		ol := overloadForScalar(scalar)
+		arg, _ := e.emitExpression(fn, mathExpr.Arg)
+		dxFn := e.getDxOpUnaryFunc("dx.op.fabs", ol)
+		opcodeVal := e.getIntConstID(int64(OpFAbs))
+		return e.addCallInstr(dxFn, dxFn.FuncType.RetType, []int{opcodeVal, arg}), nil
+	}
+
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+
+	// dot(v, v)
+	dotResult, err := e.emitDotForVector(mathExpr.Arg, size, ol)
+	if err != nil {
+		return 0, err
+	}
+
+	// sqrt(dot(v, v))
+	sqrtFn := e.getDxOpUnaryFunc("dx.op.sqrt", ol)
+	sqrtOp := e.getIntConstID(int64(OpSqrt))
+	return e.addCallInstr(sqrtFn, sqrtFn.FuncType.RetType, []int{sqrtOp, dotResult}), nil
+}
+
+// emitMathDistance emits distance(a, b) = length(a - b).
+func (e *Emitter) emitMathDistance(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	_, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+	_, err = e.emitExpression(fn, *mathExpr.Arg1)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	size := componentCount(argType)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+	resultTy := e.overloadReturnType(ol)
+
+	// Compute per-component (a - b) and store as a synthetic expression.
+	diffHandle := ir.ExpressionHandle(uint32(len(fn.Expressions)) + 1000) //nolint:gosec // synthetic handle, no overflow risk
+	diffComps := make([]int, size)
+	var firstID int
+	for i := 0; i < size; i++ {
+		ai := e.getComponentID(mathExpr.Arg, i)
+		bi := e.getComponentID(*mathExpr.Arg1, i)
+		diffComps[i] = e.addBinOpInstr(resultTy, BinOpFSub, ai, bi)
+		if i == 0 {
+			firstID = diffComps[i]
+		}
+	}
+	e.exprValues[diffHandle] = firstID
+	e.exprComponents[diffHandle] = diffComps
+
+	// dot(diff, diff)
+	dotResult, err := e.emitDotForVector(diffHandle, size, ol)
+	if err != nil {
+		return 0, err
+	}
+
+	// sqrt(dot)
+	sqrtFn := e.getDxOpUnaryFunc("dx.op.sqrt", ol)
+	sqrtOp := e.getIntConstID(int64(OpSqrt))
+	return e.addCallInstr(sqrtFn, sqrtFn.FuncType.RetType, []int{sqrtOp, dotResult}), nil
+}
+
+// emitMathNormalize emits normalize(v) = v * rsqrt(dot(v, v)).
+// Each component is multiplied by rsqrt(dot(v,v)), producing a vector result.
+func (e *Emitter) emitMathNormalize(fn *ir.Function, mathExpr ir.ExprMath) (int, error) {
+	_, err := e.emitExpression(fn, mathExpr.Arg)
+	if err != nil {
+		return 0, err
+	}
+
+	argType := e.resolveExprType(fn, mathExpr.Arg)
+	size := componentCount(argType)
+	scalar, ok := scalarOfType(argType)
+	if !ok {
+		scalar = ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}
+	}
+	ol := overloadForScalar(scalar)
+	resultTy := e.overloadReturnType(ol)
+
+	// Scalar normalize = sign(x): 1.0 for x>0, -1.0 for x<0, 0 for 0.
+	if size == 1 {
+		// Simplified: rsqrt(x*x) * x. For proper sign handling this works for nonzero.
+		arg, _ := e.emitExpression(fn, mathExpr.Arg)
+		mulSelf := e.addBinOpInstr(resultTy, BinOpFMul, arg, arg)
+		rsqrtFn := e.getDxOpUnaryFunc("dx.op.rsqrt", ol)
+		rsqrtOp := e.getIntConstID(int64(OpRsqrt))
+		rsqrt := e.addCallInstr(rsqrtFn, rsqrtFn.FuncType.RetType, []int{rsqrtOp, mulSelf})
+		return e.addBinOpInstr(resultTy, BinOpFMul, arg, rsqrt), nil
+	}
+
+	// dot(v, v)
+	dotResult, err := e.emitDotForVector(mathExpr.Arg, size, ol)
+	if err != nil {
+		return 0, err
+	}
+
+	// rsqrt(dot(v, v))
+	rsqrtFn := e.getDxOpUnaryFunc("dx.op.rsqrt", ol)
+	rsqrtOp := e.getIntConstID(int64(OpRsqrt))
+	invLen := e.addCallInstr(rsqrtFn, rsqrtFn.FuncType.RetType, []int{rsqrtOp, dotResult})
+
+	// v[i] * invLen for each component
+	comps := make([]int, size)
+	for i := 0; i < size; i++ {
+		vi := e.getComponentID(mathExpr.Arg, i)
+		comps[i] = e.addBinOpInstr(resultTy, BinOpFMul, vi, invLen)
+	}
+
+	e.pendingComponents = comps
+	return comps[0], nil
+}
+
+// mathToDxOpUnary maps naga MathFunction to dx.op opcode and name for unary functions.
 //
 //nolint:gocyclo,cyclop // math function mapping requires many cases
-func mathToDxOp(mf ir.MathFunction) (DXILOpcode, string, error) {
+func mathToDxOpUnary(mf ir.MathFunction) (DXILOpcode, string, error) {
 	switch mf {
 	case ir.MathSin:
 		return OpSin, "dx.op.sin", nil
@@ -434,7 +959,7 @@ func mathToDxOp(mf ir.MathFunction) (DXILOpcode, string, error) {
 	case ir.MathFirstLeadingBit:
 		return OpFirstbitHi, "dx.op.firstbitHi", nil
 	default:
-		return 0, "", fmt.Errorf("unsupported math function: %d", mf)
+		return 0, "", fmt.Errorf("unsupported unary math function: %d", mf)
 	}
 }
 
@@ -517,14 +1042,200 @@ func (e *Emitter) emitConstant(ec ir.ExprConstant) (int, error) {
 	return e.getIntConstID(0), nil
 }
 
-// emitAs emits a type cast expression.
+// emitAs emits a type cast expression using LLVM cast instructions.
+//
+// Reference: Mesa nir_to_dxil.c emit_cast(), SPIR-V backend emitAs().
 func (e *Emitter) emitAs(fn *ir.Function, as ir.ExprAs) (int, error) {
 	src, err := e.emitExpression(fn, as.Expr)
 	if err != nil {
 		return 0, err
 	}
-	// Simplified: for now just pass through (proper casts need LLVM cast instructions).
-	return src, nil
+
+	// Resolve source type.
+	srcInner := e.resolveExprType(fn, as.Expr)
+	srcScalar, ok := scalarOfType(srcInner)
+	if !ok {
+		// Non-scalar/vector/matrix source — pass through.
+		return src, nil
+	}
+
+	// Determine target scalar.
+	var dstScalar ir.ScalarType
+	if as.Convert == nil {
+		// Bitcast: same width, different interpretation.
+		dstScalar = ir.ScalarType{Kind: as.Kind, Width: srcScalar.Width}
+	} else {
+		dstScalar = ir.ScalarType{Kind: as.Kind, Width: *as.Convert}
+	}
+
+	// Identity: same kind and width — no-op.
+	if srcScalar.Kind == dstScalar.Kind && srcScalar.Width == dstScalar.Width {
+		return src, nil
+	}
+
+	// Check for vector type — need per-component cast.
+	if vec, ok := srcInner.(ir.VectorType); ok {
+		return e.emitVectorCast(fn, as.Expr, vec, srcScalar, dstScalar, as.Convert == nil)
+	}
+
+	// Scalar cast.
+	return e.emitScalarCast(src, srcScalar, dstScalar, as.Convert == nil)
+}
+
+// emitScalarCast emits a single scalar cast instruction.
+func (e *Emitter) emitScalarCast(src int, srcScalar, dstScalar ir.ScalarType, isBitcast bool) (int, error) {
+	if isBitcast {
+		destTy := scalarToDXIL(e.mod, dstScalar)
+		return e.addCastInstr(destTy, CastBitcast, src), nil
+	}
+
+	// Bool source: bool → numeric requires special handling.
+	if srcScalar.Kind == ir.ScalarBool {
+		return e.emitBoolToNumericDXIL(src, dstScalar)
+	}
+
+	// Bool target: numeric → bool requires comparison with zero.
+	if dstScalar.Kind == ir.ScalarBool {
+		return e.emitNumericToBoolDXIL(src, srcScalar)
+	}
+
+	op, err := selectDXILCastOp(srcScalar, dstScalar)
+	if err != nil {
+		return 0, err
+	}
+
+	destTy := scalarToDXIL(e.mod, dstScalar)
+	return e.addCastInstr(destTy, op, src), nil
+}
+
+// emitVectorCast emits per-component casts for a vector expression.
+func (e *Emitter) emitVectorCast(_ *ir.Function, handle ir.ExpressionHandle, vec ir.VectorType, srcScalar, dstScalar ir.ScalarType, isBitcast bool) (int, error) {
+	size := int(vec.Size)
+	componentIDs := make([]int, size)
+
+	for i := range size {
+		compSrc := e.getComponentID(handle, i)
+		compDst, err := e.emitScalarCast(compSrc, srcScalar, dstScalar, isBitcast)
+		if err != nil {
+			return 0, fmt.Errorf("vector component %d: %w", i, err)
+		}
+		componentIDs[i] = compDst
+	}
+
+	e.pendingComponents = componentIDs
+	return componentIDs[0], nil
+}
+
+// emitBoolToNumericDXIL converts a bool (i1) to a numeric type.
+// bool → int:   ZExt i1 → i32 (produces 0 or 1)
+// bool → float: ZExt i1 → i32, then UIToFP i32 → float
+func (e *Emitter) emitBoolToNumericDXIL(src int, dstScalar ir.ScalarType) (int, error) {
+	switch dstScalar.Kind {
+	case ir.ScalarSint, ir.ScalarUint:
+		destTy := scalarToDXIL(e.mod, dstScalar)
+		return e.addCastInstr(destTy, CastZExt, src), nil
+	case ir.ScalarFloat:
+		// Two-step: i1 → i32 → float
+		i32Ty := e.mod.GetIntType(32)
+		intVal := e.addCastInstr(i32Ty, CastZExt, src)
+		destTy := scalarToDXIL(e.mod, dstScalar)
+		return e.addCastInstr(destTy, CastUIToFP, intVal), nil
+	default:
+		return 0, fmt.Errorf("bool to %v: unsupported", dstScalar.Kind)
+	}
+}
+
+// emitNumericToBoolDXIL converts a numeric type to bool (i1) via comparison with zero.
+// int → bool:   ICmp NE val, 0
+// float → bool: FCmp ONE val, 0.0
+func (e *Emitter) emitNumericToBoolDXIL(src int, srcScalar ir.ScalarType) (int, error) {
+	switch srcScalar.Kind {
+	case ir.ScalarSint, ir.ScalarUint:
+		zero := e.getIntConstID(0)
+		return e.addCmpInstr(ICmpNE, src, zero), nil
+	case ir.ScalarFloat:
+		zero := e.getFloatConstID(0.0)
+		return e.addCmpInstr(FCmpONE, src, zero), nil
+	default:
+		return 0, fmt.Errorf("%v to bool: unsupported", srcScalar.Kind)
+	}
+}
+
+// selectDXILCastOp selects the LLVM cast opcode for a scalar conversion.
+// This does NOT handle bool conversions (caller must check).
+//
+//nolint:gocyclo,cyclop // type cast dispatch requires handling many src/dst kind combinations
+func selectDXILCastOp(src, dst ir.ScalarType) (CastOpKind, error) {
+	srcBits := uint(src.Width) * 8
+	dstBits := uint(dst.Width) * 8
+
+	switch {
+	// Float → Int
+	case src.Kind == ir.ScalarFloat && dst.Kind == ir.ScalarSint:
+		return CastFPToSI, nil
+	case src.Kind == ir.ScalarFloat && dst.Kind == ir.ScalarUint:
+		return CastFPToUI, nil
+
+	// Int → Float
+	case src.Kind == ir.ScalarSint && dst.Kind == ir.ScalarFloat:
+		return CastSIToFP, nil
+	case src.Kind == ir.ScalarUint && dst.Kind == ir.ScalarFloat:
+		return CastUIToFP, nil
+
+	// Float → Float (different width)
+	case src.Kind == ir.ScalarFloat && dst.Kind == ir.ScalarFloat:
+		if dstBits < srcBits {
+			return CastFPTrunc, nil
+		}
+		return CastFPExt, nil
+
+	// Int → Int (same signedness, different width)
+	case src.Kind == ir.ScalarSint && dst.Kind == ir.ScalarSint:
+		if dstBits < srcBits {
+			return CastTrunc, nil
+		}
+		return CastSExt, nil
+	case src.Kind == ir.ScalarUint && dst.Kind == ir.ScalarUint:
+		if dstBits < srcBits {
+			return CastTrunc, nil
+		}
+		return CastZExt, nil
+
+	// Int → Int (different signedness)
+	case src.Kind == ir.ScalarSint && dst.Kind == ir.ScalarUint:
+		if srcBits != dstBits {
+			if dstBits < srcBits {
+				return CastTrunc, nil
+			}
+			return CastZExt, nil
+		}
+		return CastBitcast, nil
+	case src.Kind == ir.ScalarUint && dst.Kind == ir.ScalarSint:
+		if srcBits != dstBits {
+			if dstBits < srcBits {
+				return CastTrunc, nil
+			}
+			return CastSExt, nil
+		}
+		return CastBitcast, nil
+
+	default:
+		return 0, fmt.Errorf("unsupported cast: %v(%d) → %v(%d)", src.Kind, src.Width, dst.Kind, dst.Width)
+	}
+}
+
+// addCastInstr adds a cast instruction to the current basic block.
+func (e *Emitter) addCastInstr(destTy *module.Type, op CastOpKind, src int) int {
+	valueID := e.allocValue()
+	instr := &module.Instruction{
+		Kind:       module.InstrCast,
+		HasValue:   true,
+		ResultType: destTy,
+		Operands:   []int{src, int(op)},
+		ValueID:    valueID,
+	}
+	e.currentBB.AddInstruction(instr)
+	return valueID
 }
 
 // resolveExprType returns the TypeInner for an expression.

--- a/dxil/internal/emit/io.go
+++ b/dxil/internal/emit/io.go
@@ -1,0 +1,166 @@
+package emit
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/ir"
+)
+
+// emitInputLoads emits dx.op.loadInput calls for each entry point argument.
+// Each vector component becomes a separate loadInput call.
+//
+// Reference: Mesa nir_to_dxil.c emit_load_input_via_intrinsic()
+func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
+	for argIdx, arg := range fn.Arguments {
+		if arg.Binding == nil {
+			continue
+		}
+
+		// Resolve the type of this argument.
+		argType := e.ir.Types[arg.Type]
+		scalar, ok := scalarOfType(argType.Inner)
+		if !ok {
+			// For struct inputs, we need to iterate over members.
+			if st, isSt := argType.Inner.(ir.StructType); isSt {
+				if err := e.emitStructInputLoads(fn, argIdx, &st, stage); err != nil {
+					return err
+				}
+				continue
+			}
+			return fmt.Errorf("unsupported input type for argument %d", argIdx)
+		}
+
+		numComps := componentCount(argType.Inner)
+		ol := overloadForScalar(scalar)
+		loadFn := e.getDxOpLoadFunc(ol)
+
+		inputID := e.locationFromBinding(*arg.Binding)
+
+		// Emit one loadInput per component.
+		// dx.op.loadInput signature: TYPE(i32 opcode, i32 inputID, i32 row, i8 col, i32 vertexID)
+		for comp := 0; comp < numComps; comp++ {
+			opcodeVal := e.getIntConstID(int64(OpLoadInput))
+			inputIDVal := e.getIntConstID(int64(inputID))
+			rowVal := e.getIntConstID(0)
+			colVal := e.getI8ConstID(int64(comp)) // col is i8
+
+			vertexIDVal := e.getUndefConstID()
+
+			valueID := e.addCallInstr(loadFn, loadFn.FuncType.RetType,
+				[]int{opcodeVal, inputIDVal, rowVal, colVal, vertexIDVal})
+
+			// Track the expression handle for this function argument.
+			exprHandle := e.findArgExprHandle(fn, argIdx)
+			if comp == 0 {
+				e.exprValues[exprHandle] = valueID
+				if numComps > 1 {
+					comps := make([]int, numComps)
+					comps[0] = valueID
+					e.exprComponents[exprHandle] = comps
+				}
+			} else if comps, ok := e.exprComponents[exprHandle]; ok && comp < len(comps) {
+				comps[comp] = valueID
+			}
+		}
+	}
+	return nil
+}
+
+// emitStructInputLoads handles struct-typed inputs (e.g., vertex input structs).
+func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.StructType, _ ir.ShaderStage) error {
+	for _, member := range st.Members {
+		if member.Binding == nil {
+			continue
+		}
+
+		memberType := e.ir.Types[member.Type]
+		scalar, ok := scalarOfType(memberType.Inner)
+		if !ok {
+			continue
+		}
+
+		numComps := componentCount(memberType.Inner)
+		ol := overloadForScalar(scalar)
+		loadFn := e.getDxOpLoadFunc(ol)
+		inputID := e.locationFromBinding(*member.Binding)
+
+		for comp := 0; comp < numComps; comp++ {
+			opcodeVal := e.getIntConstID(int64(OpLoadInput))
+			inputIDVal := e.getIntConstID(int64(inputID))
+			rowVal := e.getIntConstID(0)
+			colVal := e.getI8ConstID(int64(comp)) // col is i8
+			vertexIDVal := e.getUndefConstID()
+
+			_ = e.addCallInstr(loadFn, loadFn.FuncType.RetType,
+				[]int{opcodeVal, inputIDVal, rowVal, colVal, vertexIDVal})
+		}
+	}
+
+	// Also record the argument expression.
+	for exprIdx := range fn.Expressions {
+		if fa, ok := fn.Expressions[exprIdx].Kind.(ir.ExprFunctionArgument); ok {
+			if int(fa.Index) == argIdx {
+				// For struct args, the value ID is approximate.
+				// Real struct handling would track per-member.
+				e.exprValues[ir.ExpressionHandle(exprIdx)] = e.nextValue - 1
+				break
+			}
+		}
+	}
+	return nil
+}
+
+// emitOutputStore emits a dx.op.storeOutput call for a single output.
+func (e *Emitter) emitOutputStore(outputID int, comp int, valueID int, ol overloadType) {
+	storeFn := e.getDxOpStoreFunc(ol)
+	opcodeVal := e.getIntConstID(int64(OpStoreOutput))
+	outputIDVal := e.getIntConstID(int64(outputID))
+	rowVal := e.getIntConstID(0)
+	colVal := e.getI8ConstID(int64(comp)) // col is i8
+
+	e.addCallInstr(storeFn, e.mod.GetVoidType(),
+		[]int{opcodeVal, outputIDVal, rowVal, colVal, valueID})
+}
+
+// findArgExprHandle finds the ExpressionHandle for a FunctionArgument with the given index.
+func (e *Emitter) findArgExprHandle(fn *ir.Function, argIdx int) ir.ExpressionHandle {
+	for exprIdx := range fn.Expressions {
+		if fa, ok := fn.Expressions[exprIdx].Kind.(ir.ExprFunctionArgument); ok {
+			if int(fa.Index) == argIdx {
+				return ir.ExpressionHandle(exprIdx)
+			}
+		}
+	}
+	return 0
+}
+
+// locationFromBinding extracts the location index from a Binding.
+func (e *Emitter) locationFromBinding(b ir.Binding) int {
+	switch bb := b.(type) {
+	case ir.LocationBinding:
+		return int(bb.Location)
+	case ir.BuiltinBinding:
+		return builtinSemanticIndex(bb.Builtin)
+	default:
+		return 0
+	}
+}
+
+// builtinSemanticIndex maps naga builtins to DXIL semantic indices.
+// For vertex shaders, SV_Position is output index 0.
+func builtinSemanticIndex(b ir.BuiltinValue) int {
+	switch b {
+	case ir.BuiltinPosition:
+		return 0
+	case ir.BuiltinVertexIndex:
+		return 1
+	case ir.BuiltinInstanceIndex:
+		return 2
+	case ir.BuiltinFrontFacing:
+		return 0
+	case ir.BuiltinFragDepth:
+		return 0
+	default:
+		return 0
+	}
+}

--- a/dxil/internal/emit/opcodes.go
+++ b/dxil/internal/emit/opcodes.go
@@ -1,0 +1,175 @@
+// Package emit implements naga IR to DXIL module lowering.
+//
+// This package translates naga IR types, expressions, and statements into
+// DXIL module constructs (LLVM 3.7 IR with dx.op intrinsics). The output
+// is a module.Module that can be serialized to bitcode and wrapped in a
+// DXBC container.
+//
+// Reference: Mesa's src/microsoft/compiler/nir_to_dxil.c
+package emit
+
+// DXILOpcode represents a dx.op intrinsic opcode number.
+type DXILOpcode uint32
+
+// dx.op opcode values from the DXIL specification.
+// Reference: DXC's hctdb.py and DxilConstants.h
+const (
+	// I/O operations.
+	OpLoadInput   DXILOpcode = 4
+	OpStoreOutput DXILOpcode = 5
+
+	// Unary float operations.
+	OpFAbs        DXILOpcode = 6
+	OpSaturate    DXILOpcode = 7
+	OpIsNaN       DXILOpcode = 8
+	OpIsInf       DXILOpcode = 9
+	OpIsFinite    DXILOpcode = 10
+	OpIsNormal    DXILOpcode = 11
+	OpCos         DXILOpcode = 12
+	OpSin         DXILOpcode = 13
+	OpTan         DXILOpcode = 14
+	OpAcos        DXILOpcode = 15
+	OpAsin        DXILOpcode = 16
+	OpAtan        DXILOpcode = 17
+	OpHCos        DXILOpcode = 18
+	OpHSin        DXILOpcode = 19
+	OpHTan        DXILOpcode = 20
+	OpExp         DXILOpcode = 21
+	OpFrc         DXILOpcode = 22
+	OpLog         DXILOpcode = 23
+	OpSqrt        DXILOpcode = 24
+	OpRsqrt       DXILOpcode = 25
+	OpRoundNE     DXILOpcode = 26
+	OpRoundNI     DXILOpcode = 27
+	OpRoundPI     DXILOpcode = 28
+	OpRoundZ      DXILOpcode = 29
+	OpReverseBits DXILOpcode = 30
+	OpCountBits   DXILOpcode = 31
+	OpFirstbitLo  DXILOpcode = 32
+	OpFirstbitHi  DXILOpcode = 33
+
+	// Binary float/int operations.
+	OpFMax DXILOpcode = 35
+	OpFMin DXILOpcode = 36
+	OpIMax DXILOpcode = 37
+	OpIMin DXILOpcode = 38
+	OpUMax DXILOpcode = 39
+	OpUMin DXILOpcode = 40
+
+	// Ternary operations.
+	OpFMad DXILOpcode = 46
+	OpFma  DXILOpcode = 47
+	OpIMad DXILOpcode = 48
+	OpUMad DXILOpcode = 49
+
+	// Dot product operations.
+	OpDot2 DXILOpcode = 54
+	OpDot3 DXILOpcode = 55
+	OpDot4 DXILOpcode = 56
+
+	// Resource operations.
+	OpCreateHandle       DXILOpcode = 57
+	OpCBufferLoadLegacy  DXILOpcode = 59
+	OpSample             DXILOpcode = 60
+	OpSampleBias         DXILOpcode = 61
+	OpSampleLevel        DXILOpcode = 62
+	OpSampleGrad         DXILOpcode = 63
+	OpSampleCmp          DXILOpcode = 64
+	OpSampleCmpLevelZero DXILOpcode = 65
+	OpTextureLoad        DXILOpcode = 66
+	OpTextureStore       DXILOpcode = 67
+	OpBufferLoad         DXILOpcode = 68
+	OpBufferStore        DXILOpcode = 69
+
+	// Derivative operations.
+	OpDerivCoarseX DXILOpcode = 83
+	OpDerivCoarseY DXILOpcode = 84
+	OpDerivFineX   DXILOpcode = 85
+	OpDerivFineY   DXILOpcode = 86
+
+	// Thread/dispatch ID operations.
+	OpThreadID            DXILOpcode = 93
+	OpGroupID             DXILOpcode = 94
+	OpThreadIDInGroup     DXILOpcode = 95
+	OpFlattenedTIDInGroup DXILOpcode = 96
+)
+
+// BinOpKind represents LLVM binary operation opcodes for DXIL.
+// These are used in the FUNC_CODE_INST_BINOP record.
+type BinOpKind uint32
+
+// LLVM 3.7 binary operation codes.
+const (
+	BinOpAdd  BinOpKind = 0  // integer add
+	BinOpFAdd BinOpKind = 1  // float add (not used directly; mapped to fadd)
+	BinOpSub  BinOpKind = 2  // integer sub
+	BinOpFSub BinOpKind = 3  // float sub
+	BinOpMul  BinOpKind = 4  // integer mul
+	BinOpFMul BinOpKind = 5  // float mul
+	BinOpUDiv BinOpKind = 6  // unsigned div
+	BinOpSDiv BinOpKind = 7  // signed div
+	BinOpFDiv BinOpKind = 8  // float div
+	BinOpURem BinOpKind = 9  // unsigned remainder
+	BinOpSRem BinOpKind = 10 // signed remainder
+	BinOpFRem BinOpKind = 11 // float remainder
+	BinOpShl  BinOpKind = 12 // shift left
+	BinOpLShr BinOpKind = 13 // logical shift right
+	BinOpAShr BinOpKind = 14 // arithmetic shift right
+	BinOpAnd  BinOpKind = 15 // bitwise and
+	BinOpOr   BinOpKind = 16 // bitwise or
+	BinOpXor  BinOpKind = 17 // bitwise xor
+)
+
+// CmpPredicate represents LLVM comparison predicates.
+type CmpPredicate uint32
+
+// LLVM 3.7 floating-point comparison predicates (FCMP).
+const (
+	FCmpFalse CmpPredicate = 0  // Always false
+	FCmpOEQ   CmpPredicate = 1  // Ordered and equal
+	FCmpOGT   CmpPredicate = 2  // Ordered and greater than
+	FCmpOGE   CmpPredicate = 3  // Ordered and greater/equal
+	FCmpOLT   CmpPredicate = 4  // Ordered and less than
+	FCmpOLE   CmpPredicate = 5  // Ordered and less/equal
+	FCmpONE   CmpPredicate = 6  // Ordered and not equal
+	FCmpORD   CmpPredicate = 7  // Ordered (no NaNs)
+	FCmpUNO   CmpPredicate = 8  // Unordered (at least one NaN)
+	FCmpUEQ   CmpPredicate = 9  // Unordered or equal
+	FCmpUGT   CmpPredicate = 10 // Unordered or greater than
+	FCmpUGE   CmpPredicate = 11 // Unordered or greater/equal
+	FCmpULT   CmpPredicate = 12 // Unordered or less than
+	FCmpULE   CmpPredicate = 13 // Unordered or less/equal
+	FCmpUNE   CmpPredicate = 14 // Unordered or not equal
+	FCmpTrue  CmpPredicate = 15 // Always true
+)
+
+// LLVM 3.7 integer comparison predicates (ICMP).
+const (
+	ICmpEQ  CmpPredicate = 32 // Equal
+	ICmpNE  CmpPredicate = 33 // Not equal
+	ICmpUGT CmpPredicate = 34 // Unsigned greater than
+	ICmpUGE CmpPredicate = 35 // Unsigned greater/equal
+	ICmpULT CmpPredicate = 36 // Unsigned less than
+	ICmpULE CmpPredicate = 37 // Unsigned less/equal
+	ICmpSGT CmpPredicate = 38 // Signed greater than
+	ICmpSGE CmpPredicate = 39 // Signed greater/equal
+	ICmpSLT CmpPredicate = 40 // Signed less than
+	ICmpSLE CmpPredicate = 41 // Signed less/equal
+)
+
+// CastOpKind represents LLVM cast operation codes.
+type CastOpKind uint32
+
+// LLVM 3.7 cast operation codes.
+const (
+	CastTrunc   CastOpKind = 0  // Truncate integers
+	CastZExt    CastOpKind = 1  // Zero-extend integers
+	CastSExt    CastOpKind = 2  // Sign-extend integers
+	CastFPToUI  CastOpKind = 3  // Float to unsigned integer
+	CastFPToSI  CastOpKind = 4  // Float to signed integer
+	CastUIToFP  CastOpKind = 5  // Unsigned integer to float
+	CastSIToFP  CastOpKind = 6  // Signed integer to float
+	CastFPTrunc CastOpKind = 7  // Truncate float (e.g., double→float)
+	CastFPExt   CastOpKind = 8  // Extend float (e.g., float→double)
+	CastBitcast CastOpKind = 11 // Bitcast (same size, different type)
+)

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -1,21 +1,423 @@
 package emit
 
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
 // Resource handling for DXIL emission.
 //
 // This file handles CBV (constant buffer views), SRV (shader resource views),
-// and sampler bindings via dx.op intrinsics.
+// sampler bindings, and UAV stubs via dx.op intrinsics.
 //
-// Phase 1 scope: CBV via dx.op.createHandle + dx.op.cbufferLoadLegacy.
-// Texture sampling and UAVs are deferred to Phase 2.
+// Reference: Mesa nir_to_dxil.c emit_resources(), emit_createhandle_call_pre_6_6()
+
+// DXIL resource classes (matches DXIL spec D3D12_SHADER_INPUT_BIND_DESC).
+const (
+	resourceClassSRV     uint8 = 0
+	resourceClassUAV     uint8 = 1
+	resourceClassCBV     uint8 = 2
+	resourceClassSampler uint8 = 3
+)
+
+// resourceInfo describes a single resource binding discovered during analysis.
+type resourceInfo struct {
+	varHandle  ir.GlobalVariableHandle
+	name       string
+	class      uint8 // resourceClassSRV, resourceClassUAV, resourceClassCBV, resourceClassSampler
+	rangeID    int
+	group      uint32
+	binding    uint32
+	typeHandle ir.TypeHandle
+	handleID   int // emitter value ID of the created handle (-1 if not yet created)
+}
+
+// analyzeResources scans the module's global variables and classifies them
+// into resource categories. Must be called before emitting function bodies.
+func (e *Emitter) analyzeResources() {
+	e.resources = nil
+	e.resourceHandles = make(map[ir.GlobalVariableHandle]int)
+
+	// Track per-class range IDs.
+	rangeCounters := [4]int{} // SRV, UAV, CBV, Sampler
+
+	for i := range e.ir.GlobalVariables {
+		gv := &e.ir.GlobalVariables[i]
+		if gv.Binding == nil {
+			continue
+		}
+
+		class, ok := e.classifyGlobalVariable(gv)
+		if !ok {
+			continue
+		}
+
+		rangeID := rangeCounters[class]
+		rangeCounters[class]++
+
+		info := resourceInfo{
+			varHandle:  ir.GlobalVariableHandle(uint32(i)),
+			name:       gv.Name,
+			class:      class,
+			rangeID:    rangeID,
+			group:      gv.Binding.Group,
+			binding:    gv.Binding.Binding,
+			typeHandle: gv.Type,
+			handleID:   -1,
+		}
+
+		e.resourceHandles[info.varHandle] = len(e.resources)
+		e.resources = append(e.resources, info)
+	}
+}
+
+// classifyGlobalVariable determines the resource class of a global variable.
+// Returns the class and true if it is a resource; false if it is not.
+func (e *Emitter) classifyGlobalVariable(gv *ir.GlobalVariable) (uint8, bool) {
+	switch gv.Space {
+	case ir.SpaceUniform:
+		return resourceClassCBV, true
+
+	case ir.SpaceStorage:
+		return resourceClassUAV, true
+
+	case ir.SpaceHandle:
+		// Handle space: classify by the pointed-to type.
+		if int(gv.Type) < len(e.ir.Types) {
+			inner := e.ir.Types[gv.Type].Inner
+			switch inner.(type) {
+			case ir.ImageType:
+				return resourceClassSRV, true
+			case ir.SamplerType:
+				return resourceClassSampler, true
+			}
+		}
+		return 0, false
+
+	default:
+		return 0, false
+	}
+}
+
+// emitResourceHandles creates dx.op.createHandle calls for all analyzed resources.
+// Must be called at function entry before any resource accesses.
 //
-// Reference: Mesa nir_to_dxil.c emit_resources()
+// dx.op.createHandle(i32 57, i8 class, i32 rangeID, i32 index, i1 false)
+func (e *Emitter) emitResourceHandles() {
+	if len(e.resources) == 0 {
+		return
+	}
+
+	handleTy := e.getDxHandleType()
+	createFn := e.getDxOpCreateHandleFunc()
+
+	for i := range e.resources {
+		res := &e.resources[i]
+
+		opcodeVal := e.getIntConstID(int64(OpCreateHandle))
+		classVal := e.getI8ConstID(int64(res.class))
+		rangeIDVal := e.getIntConstID(int64(res.rangeID))
+		indexVal := e.getIntConstID(int64(res.binding))
+		nonUniformVal := e.getI1ConstID(0) // false
+
+		handleID := e.addCallInstr(createFn, handleTy,
+			[]int{opcodeVal, classVal, rangeIDVal, indexVal, nonUniformVal})
+
+		res.handleID = handleID
+	}
+}
+
+// getResourceHandleID returns the emitter value ID of the handle for a
+// given global variable, or -1 if not a resource.
+func (e *Emitter) getResourceHandleID(varHandle ir.GlobalVariableHandle) (int, bool) {
+	idx, ok := e.resourceHandles[varHandle]
+	if !ok {
+		return -1, false
+	}
+	return e.resources[idx].handleID, true
+}
+
+// --- Texture sampling ---
+
+// emitImageSample emits a dx.op.sample call for texture sampling.
+func (e *Emitter) emitImageSample(fn *ir.Function, sample ir.ExprImageSample) (int, error) {
+	// Resolve image and sampler handles.
+	imageHandleID, err := e.resolveResourceHandle(fn, sample.Image)
+	if err != nil {
+		return 0, fmt.Errorf("image handle: %w", err)
+	}
+	samplerHandleID, err := e.resolveResourceHandle(fn, sample.Sampler)
+	if err != nil {
+		return 0, fmt.Errorf("sampler handle: %w", err)
+	}
+
+	// Emit coordinate expression.
+	if _, err := e.emitExpression(fn, sample.Coordinate); err != nil {
+		return 0, fmt.Errorf("coordinate: %w", err)
+	}
+
+	// Determine coordinate dimensionality.
+	coordType := e.resolveExprType(fn, sample.Coordinate)
+	coordComps := componentCount(coordType)
+
+	// Determine the overload from the image type.
+	ol := overloadF32 // textures almost always return f32
+
+	resRetTy := e.getDxResRetType(ol)
+	sampleFn := e.getDxOpSampleFunc(ol)
+
+	// Build operands: opcode, texHandle, samplerHandle, coord0..3, offset0..2, clamp, undef
+	// Total 12 operands for sample.
+	undefVal := e.getUndefConstID()
+	zeroF := e.getFloatConstID(0.0)
+
+	opcodeVal := e.getIntConstID(int64(OpSample))
+
+	// Scalarize coordinates into coord0..coord3.
+	coords := [4]int{zeroF, zeroF, zeroF, zeroF}
+	for i := 0; i < 4 && i < coordComps; i++ {
+		coords[i] = e.getComponentID(sample.Coordinate, i)
+	}
+
+	operands := []int{
+		opcodeVal,                                  // i32 opcode
+		imageHandleID,                              // %handle texture
+		samplerHandleID,                            // %handle sampler
+		coords[0], coords[1], coords[2], coords[3], // coord0..3
+		zeroF, zeroF, zeroF, // offset0..2
+		zeroF,    // clamp
+		undefVal, // undef
+	}
+
+	retID := e.addCallInstr(sampleFn, resRetTy, operands)
+
+	// Extract 4 components from the result and store as pending components.
+	scalarTy := e.overloadReturnType(ol)
+	comps := make([]int, 4)
+	for i := 0; i < 4; i++ {
+		extractID := e.allocValue()
+		instr := &module.Instruction{
+			Kind:       module.InstrExtractVal,
+			HasValue:   true,
+			ResultType: scalarTy,
+			Operands:   []int{retID, i},
+			ValueID:    extractID,
+		}
+		e.currentBB.AddInstruction(instr)
+		comps[i] = extractID
+	}
+	e.pendingComponents = comps
+
+	return comps[0], nil
+}
+
+// resolveResourceHandle evaluates the expression and returns the resource
+// handle value ID. The expression must be an ExprGlobalVariable that was
+// classified as a resource.
+func (e *Emitter) resolveResourceHandle(fn *ir.Function, exprHandle ir.ExpressionHandle) (int, error) {
+	expr := fn.Expressions[exprHandle]
+	if gv, ok := expr.Kind.(ir.ExprGlobalVariable); ok {
+		if handleID, found := e.getResourceHandleID(gv.Variable); found {
+			return handleID, nil
+		}
+		return 0, fmt.Errorf("global variable %d is not a resource", gv.Variable)
+	}
+	// Fallback: emit the expression and hope it resolves.
+	return e.emitExpression(fn, exprHandle)
+}
+
+// --- dx.op function declarations and DXIL types ---
+
+// getDxHandleType returns the %dx.types.Handle opaque struct type.
+func (e *Emitter) getDxHandleType() *module.Type {
+	if e.dxHandleType != nil {
+		return e.dxHandleType
+	}
+	// %dx.types.Handle = type { i8* }
+	i8PtrTy := e.mod.GetPointerType(e.mod.GetIntType(8))
+	e.dxHandleType = e.mod.GetStructType("dx.types.Handle", []*module.Type{i8PtrTy})
+	return e.dxHandleType
+}
+
+// getDxResRetType returns the %dx.types.ResRet.XX struct type.
+func (e *Emitter) getDxResRetType(ol overloadType) *module.Type {
+	scalarTy := e.overloadReturnType(ol)
+	i32Ty := e.mod.GetIntType(32)
+	name := "dx.types.ResRet" + overloadSuffix(ol)
+	// ResRet has 4 scalar components + 1 i32 status.
+	return e.mod.GetStructType(name, []*module.Type{scalarTy, scalarTy, scalarTy, scalarTy, i32Ty})
+}
+
+// getDxOpCreateHandleFunc creates the dx.op.createHandle function declaration.
+// Signature: %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1)
+func (e *Emitter) getDxOpCreateHandleFunc() *module.Function {
+	name := "dx.op.createHandle"
+	key := dxOpKey{name: name, overload: overloadVoid}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	handleTy := e.getDxHandleType()
+	i32Ty := e.mod.GetIntType(32)
+	i8Ty := e.mod.GetIntType(8)
+	i1Ty := e.mod.GetIntType(1)
+
+	params := []*module.Type{i32Ty, i8Ty, i32Ty, i32Ty, i1Ty}
+	funcTy := e.mod.GetFunctionType(handleTy, params)
+	fn := e.mod.AddFunction(name, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getDxOpSampleFunc creates the dx.op.sample function declaration.
+// Signature: %dx.types.ResRet.XX @dx.op.sample.XX(
 //
-// NOTE: This file is a placeholder for Phase 1.5/2. The current
-// implementation handles the case where shaders have NO resource
-// bindings (pure vertex transform + fragment color output).
-// When resource bindings are needed (uniform buffers, textures),
-// this will be extended with:
-//   - dx.op.createHandle(57) for binding resources
-//   - dx.op.cbufferLoadLegacy(59) for reading uniform buffers
-//   - dx.op.sample(60) for texture sampling
-//   - !dx.resources metadata for resource declarations
+//	i32 opcode, %handle tex, %handle sampler,
+//	float coord0..3, float offset0..2, float clamp, i32 undef)
+func (e *Emitter) getDxOpSampleFunc(ol overloadType) *module.Function {
+	name := "dx.op.sample"
+	key := dxOpKey{name: name, overload: ol}
+	if fn, ok := e.dxOpFuncs[key]; ok {
+		return fn
+	}
+
+	resRetTy := e.getDxResRetType(ol)
+	handleTy := e.getDxHandleType()
+	i32Ty := e.mod.GetIntType(32)
+	f32Ty := e.mod.GetFloatType(32)
+
+	fullName := name + overloadSuffix(ol)
+	params := []*module.Type{
+		i32Ty,                      // opcode
+		handleTy,                   // texture handle
+		handleTy,                   // sampler handle
+		f32Ty, f32Ty, f32Ty, f32Ty, // coord0..3
+		f32Ty, f32Ty, f32Ty, // offset0..2
+		f32Ty, // clamp
+		i32Ty, // undef
+	}
+	funcTy := e.mod.GetFunctionType(resRetTy, params)
+	fn := e.mod.AddFunction(fullName, funcTy, true)
+	e.dxOpFuncs[key] = fn
+	return fn
+}
+
+// getI1ConstID returns the emitter value ID for a cached i1 constant.
+func (e *Emitter) getI1ConstID(v int64) int {
+	key := v + (1 << 41) // offset to distinguish from i32 and i8
+	if id, ok := e.intConsts[key]; ok {
+		return id
+	}
+	c := e.mod.AddIntConst(e.mod.GetIntType(1), v)
+	id := e.allocValue()
+	e.intConsts[key] = id
+	e.constMap[id] = c
+	return id
+}
+
+// --- dx.resources metadata ---
+
+// emitResourceMetadata emits the !dx.resources named metadata node.
+// Called from emitMetadata when resources are present.
+//
+// Format: !dx.resources = !{!srvs, !uavs, !cbvs, !samplers}
+// Each list contains entries: !{i32 rangeID, null, !"name", i32 space, i32 lower, i32 upper, i32 kind, null}
+func (e *Emitter) emitResourceMetadata() *module.MetadataNode {
+	if len(e.resources) == 0 {
+		return nil
+	}
+
+	i32Ty := e.mod.GetIntType(32)
+
+	// Group resources by class.
+	var srvs, uavs, cbvs, samplers []*module.MetadataNode
+
+	for i := range e.resources {
+		res := &e.resources[i]
+		entry := e.buildResourceMetadataEntry(res, i32Ty)
+
+		switch res.class {
+		case resourceClassSRV:
+			srvs = append(srvs, entry)
+		case resourceClassUAV:
+			uavs = append(uavs, entry)
+		case resourceClassCBV:
+			cbvs = append(cbvs, entry)
+		case resourceClassSampler:
+			samplers = append(samplers, entry)
+		}
+	}
+
+	// Build the 4-element tuple: !{!srvs, !uavs, !cbvs, !samplers}
+	// Each element is either a tuple of entries or null.
+	elements := [4][]*module.MetadataNode{srvs, uavs, cbvs, samplers}
+	mdParts := make([]*module.MetadataNode, 4)
+	for i, list := range elements {
+		if len(list) > 0 {
+			mdParts[i] = e.mod.AddMetadataTuple(list)
+		}
+		// nil represents null in metadata
+	}
+
+	mdResources := e.mod.AddMetadataTuple(mdParts)
+	e.mod.AddNamedMetadata("dx.resources", []*module.MetadataNode{mdResources})
+
+	return mdResources
+}
+
+// buildResourceMetadataEntry builds a single resource metadata entry.
+// Format: !{i32 rangeID, null, !"name", i32 space, i32 lowerBound, i32 upperBound, i32 kind, null}
+func (e *Emitter) buildResourceMetadataEntry(res *resourceInfo, i32Ty *module.Type) *module.MetadataNode {
+	mdRangeID := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(res.rangeID)))
+	mdName := e.mod.AddMetadataString(res.name)
+	mdSpace := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(res.group)))
+	mdLower := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(res.binding)))
+	mdUpper := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(res.binding)+1))
+	mdKind := e.mod.AddMetadataValue(i32Ty, e.getIntConst(int64(e.resourceKind(res))))
+
+	return e.mod.AddMetadataTuple([]*module.MetadataNode{
+		mdRangeID, // i32 rangeID
+		nil,       // null (global variable ref, simplified)
+		mdName,    // !"name"
+		mdSpace,   // i32 space
+		mdLower,   // i32 lowerBound
+		mdUpper,   // i32 upperBound
+		mdKind,    // i32 kind
+		nil,       // null (additional properties)
+	})
+}
+
+// resourceKind returns the DXIL resource kind integer for metadata.
+// Reference: D3D12_SRV_DIMENSION / DXIL resource kinds.
+func (e *Emitter) resourceKind(res *resourceInfo) int {
+	switch res.class {
+	case resourceClassCBV:
+		return 13 // CBuffer
+	case resourceClassSampler:
+		return 0 // Sampler (no dimension)
+	case resourceClassSRV:
+		// Determine from the image type.
+		if int(res.typeHandle) < len(e.ir.Types) {
+			inner := e.ir.Types[res.typeHandle].Inner
+			if img, ok := inner.(ir.ImageType); ok {
+				switch img.Dim {
+				case ir.Dim1D:
+					return 2 // Texture1D
+				case ir.Dim2D:
+					return 4 // Texture2D
+				case ir.Dim3D:
+					return 7 // Texture3D
+				case ir.DimCube:
+					return 9 // TextureCube
+				}
+			}
+		}
+		return 4 // default Texture2D
+	case resourceClassUAV:
+		return 4 // default Texture2D for UAV
+	default:
+		return 0
+	}
+}

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -1,0 +1,21 @@
+package emit
+
+// Resource handling for DXIL emission.
+//
+// This file handles CBV (constant buffer views), SRV (shader resource views),
+// and sampler bindings via dx.op intrinsics.
+//
+// Phase 1 scope: CBV via dx.op.createHandle + dx.op.cbufferLoadLegacy.
+// Texture sampling and UAVs are deferred to Phase 2.
+//
+// Reference: Mesa nir_to_dxil.c emit_resources()
+//
+// NOTE: This file is a placeholder for Phase 1.5/2. The current
+// implementation handles the case where shaders have NO resource
+// bindings (pure vertex transform + fragment color output).
+// When resource bindings are needed (uniform buffers, textures),
+// this will be extended with:
+//   - dx.op.createHandle(57) for binding resources
+//   - dx.op.cbufferLoadLegacy(59) for reading uniform buffers
+//   - dx.op.sample(60) for texture sampling
+//   - !dx.resources metadata for resource declarations

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -14,6 +14,9 @@ import (
 //
 // Reference: Mesa nir_to_dxil.c emit_resources(), emit_createhandle_call_pre_6_6()
 
+// dx.op function name for resource handle creation.
+const dxOpCreateHandleName = "dx.op.createHandle"
+
 // DXIL resource classes (matches DXIL spec D3D12_SHADER_INPUT_BIND_DESC).
 const (
 	resourceClassSRV     uint8 = 0
@@ -253,8 +256,7 @@ func (e *Emitter) getDxResRetType(ol overloadType) *module.Type {
 // getDxOpCreateHandleFunc creates the dx.op.createHandle function declaration.
 // Signature: %dx.types.Handle @dx.op.createHandle(i32, i8, i32, i32, i1)
 func (e *Emitter) getDxOpCreateHandleFunc() *module.Function {
-	name := "dx.op.createHandle"
-	key := dxOpKey{name: name, overload: overloadVoid}
+	key := dxOpKey{name: dxOpCreateHandleName, overload: overloadVoid}
 	if fn, ok := e.dxOpFuncs[key]; ok {
 		return fn
 	}
@@ -266,7 +268,7 @@ func (e *Emitter) getDxOpCreateHandleFunc() *module.Function {
 
 	params := []*module.Type{i32Ty, i8Ty, i32Ty, i32Ty, i1Ty}
 	funcTy := e.mod.GetFunctionType(handleTy, params)
-	fn := e.mod.AddFunction(name, funcTy, true)
+	fn := e.mod.AddFunction(dxOpCreateHandleName, funcTy, true)
 	e.dxOpFuncs[key] = fn
 	return fn
 }

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -160,20 +160,38 @@ func (e *Emitter) emitReturnComposite(fn *ir.Function, valueID int, inner ir.Typ
 }
 
 // emitStmtStore handles store statements.
+//
 // In naga IR, stores write a value through a pointer expression.
+// In DXIL, this emits an LLVM store instruction:
+//
+//	store TYPE %value, TYPE* %ptr, align N
+//
+// Reference: Mesa nir_to_dxil.c dxil_emit_store()
 func (e *Emitter) emitStmtStore(fn *ir.Function, store ir.StmtStore) error {
-	// Evaluate pointer and value.
-	_, err := e.emitExpression(fn, store.Pointer)
+	ptr, err := e.emitExpression(fn, store.Pointer)
 	if err != nil {
 		return fmt.Errorf("store pointer: %w", err)
 	}
-	_, err = e.emitExpression(fn, store.Value)
+	value, err := e.emitExpression(fn, store.Value)
 	if err != nil {
 		return fmt.Errorf("store value: %w", err)
 	}
-	// In the simplified model, stores through local variables are
-	// handled implicitly via value numbering. The pointer expression
-	// is mapped to the same value as the stored value.
+
+	// Resolve the stored value's type for alignment.
+	storedTy, err := e.resolveLoadType(fn, store.Pointer)
+	if err != nil {
+		return fmt.Errorf("store type resolution: %w", err)
+	}
+	align := e.alignForType(storedTy)
+
+	// Emit LLVM store instruction (no value produced).
+	instr := &module.Instruction{
+		Kind:        module.InstrStore,
+		HasValue:    false,
+		Operands:    []int{ptr, value, align, 0}, // ptr, value, align, isVolatile
+		ReturnValue: -1,
+	}
+	e.currentBB.AddInstruction(instr)
 	return nil
 }
 

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -1,0 +1,199 @@
+package emit
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/ir"
+)
+
+// emitFunctionBody emits the statements in the function body.
+//
+// This walks the naga IR statement tree and emits:
+// - StmtEmit: evaluates expressions in the emit range
+// - StmtReturn: stores outputs and returns
+// - StmtStore: stores values through pointers (simplified)
+// - StmtIf: conditional branching (not yet implemented)
+// - StmtLoop: loop constructs (not yet implemented)
+// - StmtBlock: nested statement blocks
+//
+// Reference: Mesa nir_to_dxil.c emit_module()
+func (e *Emitter) emitFunctionBody(fn *ir.Function) error {
+	return e.emitBlock(fn, fn.Body)
+}
+
+// emitBlock emits all statements in a block.
+func (e *Emitter) emitBlock(fn *ir.Function, block ir.Block) error {
+	for i := range block {
+		if err := e.emitStatement(fn, &block[i]); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// emitStatement emits a single statement.
+func (e *Emitter) emitStatement(fn *ir.Function, stmt *ir.Statement) error {
+	switch sk := stmt.Kind.(type) {
+	case ir.StmtEmit:
+		return e.emitStmtEmit(fn, sk)
+
+	case ir.StmtReturn:
+		return e.emitStmtReturn(fn, sk)
+
+	case ir.StmtStore:
+		return e.emitStmtStore(fn, sk)
+
+	case ir.StmtBlock:
+		return e.emitBlock(fn, sk.Block)
+
+	case ir.StmtIf:
+		// Simplified: emit both branches sequentially.
+		// Proper implementation needs basic block splitting.
+		// For MVP, we emit only the accept block (assumes simple cases).
+		return e.emitBlock(fn, sk.Accept)
+
+	case ir.StmtLoop:
+		// Simplified: emit loop body once.
+		// Proper loops need back-edge basic blocks.
+		return e.emitBlock(fn, sk.Body)
+
+	case ir.StmtBreak, ir.StmtContinue:
+		// Control flow stubs — handled by loop/switch structure.
+		return nil
+
+	case ir.StmtKill:
+		// Fragment shader discard — not yet implemented.
+		return nil
+
+	case ir.StmtCall:
+		// Function calls.
+		return e.emitStmtCall(fn, sk)
+
+	default:
+		// Unsupported statement kinds are silently skipped for MVP.
+		return nil
+	}
+}
+
+// emitStmtEmit evaluates expressions in the emit range.
+// In naga IR, StmtEmit marks when expressions should be materialized.
+func (e *Emitter) emitStmtEmit(fn *ir.Function, emit ir.StmtEmit) error {
+	for h := emit.Range.Start; h < emit.Range.End; h++ {
+		if _, err := e.emitExpression(fn, h); err != nil {
+			return fmt.Errorf("emit range [%d]: %w", h, err)
+		}
+	}
+	return nil
+}
+
+// emitStmtReturn handles the return statement.
+//
+// For entry point functions with a result binding, the return value is
+// stored via dx.op.storeOutput before the void return. This matches how
+// DXIL entry points work: they are void functions that store outputs
+// via intrinsics.
+func (e *Emitter) emitStmtReturn(fn *ir.Function, ret ir.StmtReturn) error {
+	if ret.Value == nil || fn.Result == nil {
+		return nil
+	}
+
+	// Evaluate the return value expression.
+	valueID, err := e.emitExpression(fn, *ret.Value)
+	if err != nil {
+		return fmt.Errorf("return value: %w", err)
+	}
+
+	// Store the return value as output(s).
+	resultType := e.ir.Types[fn.Result.Type]
+	scalar, ok := scalarOfType(resultType.Inner)
+	if !ok {
+		// Non-scalar result type — try to handle vector.
+		return e.emitReturnComposite(fn, valueID, resultType.Inner)
+	}
+
+	numComps := componentCount(resultType.Inner)
+	ol := overloadForScalar(scalar)
+	outputID := e.outputLocationFromBinding(fn.Result.Binding)
+
+	for comp := 0; comp < numComps; comp++ {
+		compValueID := e.getComponentID(*ret.Value, comp)
+		e.emitOutputStore(outputID, comp, compValueID, ol)
+	}
+
+	return nil
+}
+
+// emitReturnComposite handles returning composite types (vectors, structs).
+func (e *Emitter) emitReturnComposite(fn *ir.Function, valueID int, inner ir.TypeInner) error {
+	switch t := inner.(type) {
+	case ir.VectorType:
+		// This is called when scalarOfType fails on the result type,
+		// which shouldn't happen for VectorType. Just handle it.
+		ol := overloadForScalar(t.Scalar)
+		outputID := e.outputLocationFromBinding(fn.Result.Binding)
+		for comp := 0; comp < int(t.Size); comp++ {
+			e.emitOutputStore(outputID, comp, valueID+comp, ol)
+		}
+		return nil
+
+	case ir.StructType:
+		// Struct outputs: each member has its own binding.
+		for _, member := range t.Members {
+			if member.Binding == nil {
+				continue
+			}
+			memberType := e.ir.Types[member.Type]
+			scalar, ok := scalarOfType(memberType.Inner)
+			if !ok {
+				continue
+			}
+			numComps := componentCount(memberType.Inner)
+			ol := overloadForScalar(scalar)
+			outputID := e.locationFromBinding(*member.Binding)
+			for comp := 0; comp < numComps; comp++ {
+				e.emitOutputStore(outputID, comp, valueID+comp, ol)
+			}
+		}
+		return nil
+
+	default:
+		return fmt.Errorf("unsupported return type: %T", inner)
+	}
+}
+
+// emitStmtStore handles store statements.
+// In naga IR, stores write a value through a pointer expression.
+func (e *Emitter) emitStmtStore(fn *ir.Function, store ir.StmtStore) error {
+	// Evaluate pointer and value.
+	_, err := e.emitExpression(fn, store.Pointer)
+	if err != nil {
+		return fmt.Errorf("store pointer: %w", err)
+	}
+	_, err = e.emitExpression(fn, store.Value)
+	if err != nil {
+		return fmt.Errorf("store value: %w", err)
+	}
+	// In the simplified model, stores through local variables are
+	// handled implicitly via value numbering. The pointer expression
+	// is mapped to the same value as the stored value.
+	return nil
+}
+
+// emitStmtCall handles function call statements.
+func (e *Emitter) emitStmtCall(fn *ir.Function, call ir.StmtCall) error {
+	// Evaluate arguments.
+	for _, arg := range call.Arguments {
+		if _, err := e.emitExpression(fn, arg); err != nil {
+			return fmt.Errorf("call argument: %w", err)
+		}
+	}
+	return nil
+}
+
+// outputLocationFromBinding extracts the output location from a binding.
+func (e *Emitter) outputLocationFromBinding(b *ir.Binding) int {
+	if b == nil {
+		return 0
+	}
+	return e.locationFromBinding(*b)
+}

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -3,6 +3,7 @@ package emit
 import (
 	"fmt"
 
+	"github.com/gogpu/naga/dxil/internal/module"
 	"github.com/gogpu/naga/ir"
 )
 
@@ -47,19 +48,16 @@ func (e *Emitter) emitStatement(fn *ir.Function, stmt *ir.Statement) error {
 		return e.emitBlock(fn, sk.Block)
 
 	case ir.StmtIf:
-		// Simplified: emit both branches sequentially.
-		// Proper implementation needs basic block splitting.
-		// For MVP, we emit only the accept block (assumes simple cases).
-		return e.emitBlock(fn, sk.Accept)
+		return e.emitIfStatement(fn, sk)
 
 	case ir.StmtLoop:
-		// Simplified: emit loop body once.
-		// Proper loops need back-edge basic blocks.
-		return e.emitBlock(fn, sk.Body)
+		return e.emitLoopStatement(fn, sk)
 
-	case ir.StmtBreak, ir.StmtContinue:
-		// Control flow stubs — handled by loop/switch structure.
-		return nil
+	case ir.StmtBreak:
+		return e.emitBreak()
+
+	case ir.StmtContinue:
+		return e.emitContinue()
 
 	case ir.StmtKill:
 		// Fragment shader discard — not yet implemented.
@@ -188,6 +186,193 @@ func (e *Emitter) emitStmtCall(fn *ir.Function, call ir.StmtCall) error {
 		}
 	}
 	return nil
+}
+
+// emitIfStatement emits an if/else construct using LLVM basic blocks.
+//
+// DXIL uses basic block branching for control flow:
+//
+//	current_bb:
+//	  br i1 %cond, label %then, label %else_or_merge
+//	then_bb:
+//	  <accept block>
+//	  br label %merge
+//	else_bb: (only if reject block is non-empty)
+//	  <reject block>
+//	  br label %merge
+//	merge_bb:
+//	  <continues>
+//
+// Reference: Mesa nir_to_dxil.c emit_cf_list / emit_if
+func (e *Emitter) emitIfStatement(fn *ir.Function, stmt ir.StmtIf) error {
+	// Emit the condition expression.
+	condID, err := e.emitExpression(fn, stmt.Condition)
+	if err != nil {
+		return fmt.Errorf("if condition: %w", err)
+	}
+
+	hasReject := len(stmt.Reject) > 0
+
+	// Create basic blocks. We add them to mainFn now so we can
+	// reference their indices for branch instructions.
+	thenBB := e.mainFn.AddBasicBlock("if.then")
+	thenBBIndex := len(e.mainFn.BasicBlocks) - 1
+
+	var elseBBIndex int
+	if hasReject {
+		elseBB := e.mainFn.AddBasicBlock("if.else")
+		elseBBIndex = len(e.mainFn.BasicBlocks) - 1
+		_ = elseBB // used below via index
+	}
+
+	mergeBB := e.mainFn.AddBasicBlock("if.merge")
+	mergeBBIndex := len(e.mainFn.BasicBlocks) - 1
+
+	// Emit conditional branch from the current BB.
+	falseBBIndex := mergeBBIndex
+	if hasReject {
+		falseBBIndex = elseBBIndex
+	}
+	e.currentBB.AddInstruction(module.NewBrCondInstr(thenBBIndex, falseBBIndex, condID))
+
+	// Emit accept (then) block.
+	e.currentBB = thenBB
+	if err := e.emitBlock(fn, stmt.Accept); err != nil {
+		return fmt.Errorf("if accept: %w", err)
+	}
+	// Branch from then to merge (unless block already ends with a terminator).
+	if !e.blockHasTerminator(e.currentBB) {
+		e.currentBB.AddInstruction(module.NewBrInstr(mergeBBIndex))
+	}
+
+	// Emit reject (else) block if present.
+	if hasReject {
+		e.currentBB = e.mainFn.BasicBlocks[elseBBIndex]
+		if err := e.emitBlock(fn, stmt.Reject); err != nil {
+			return fmt.Errorf("if reject: %w", err)
+		}
+		if !e.blockHasTerminator(e.currentBB) {
+			e.currentBB.AddInstruction(module.NewBrInstr(mergeBBIndex))
+		}
+	}
+
+	// Continue emitting into the merge block.
+	e.currentBB = mergeBB
+	return nil
+}
+
+// emitLoopStatement emits a loop construct using LLVM basic blocks.
+//
+// DXIL loop structure:
+//
+//	current_bb:
+//	  br label %loop_header
+//	loop_header:
+//	  br label %loop_body
+//	loop_body:
+//	  <body statements>
+//	  br label %loop_continuing  (or break → br %loop_merge)
+//	loop_continuing:
+//	  <continuing statements>
+//	  br label %loop_header      (back edge)
+//	loop_merge:
+//	  <continues after loop>
+//
+// Reference: Mesa nir_to_dxil.c emit_cf_list / emit_loop
+func (e *Emitter) emitLoopStatement(fn *ir.Function, stmt ir.StmtLoop) error {
+	// Create basic blocks for the loop structure.
+	headerBB := e.mainFn.AddBasicBlock("loop.header")
+	headerBBIndex := len(e.mainFn.BasicBlocks) - 1
+
+	bodyBB := e.mainFn.AddBasicBlock("loop.body")
+	bodyBBIndex := len(e.mainFn.BasicBlocks) - 1
+	_ = bodyBBIndex // used implicitly via headerBB branch
+
+	continuingBB := e.mainFn.AddBasicBlock("loop.continuing")
+	continuingBBIndex := len(e.mainFn.BasicBlocks) - 1
+
+	mergeBB := e.mainFn.AddBasicBlock("loop.merge")
+	mergeBBIndex := len(e.mainFn.BasicBlocks) - 1
+
+	// Branch from current BB to loop header.
+	e.currentBB.AddInstruction(module.NewBrInstr(headerBBIndex))
+
+	// Header branches unconditionally to body.
+	headerBB.AddInstruction(module.NewBrInstr(bodyBBIndex))
+
+	// Push loop context for break/continue.
+	e.loopStack = append(e.loopStack, loopContext{
+		continuingBBIndex: continuingBBIndex,
+		mergeBBIndex:      mergeBBIndex,
+	})
+
+	// Emit body.
+	e.currentBB = bodyBB
+	if err := e.emitBlock(fn, stmt.Body); err != nil {
+		return fmt.Errorf("loop body: %w", err)
+	}
+	// After body, branch to continuing (unless terminated by break/continue/return).
+	if !e.blockHasTerminator(e.currentBB) {
+		e.currentBB.AddInstruction(module.NewBrInstr(continuingBBIndex))
+	}
+
+	// Emit continuing block.
+	e.currentBB = continuingBB
+	if len(stmt.Continuing) > 0 {
+		if err := e.emitBlock(fn, stmt.Continuing); err != nil {
+			return fmt.Errorf("loop continuing: %w", err)
+		}
+	}
+
+	// Handle break_if: conditional back-edge vs break.
+	if stmt.BreakIf != nil {
+		breakCondID, err := e.emitExpression(fn, *stmt.BreakIf)
+		if err != nil {
+			return fmt.Errorf("loop break_if: %w", err)
+		}
+		// If break condition is true, go to merge; otherwise loop back.
+		e.currentBB.AddInstruction(module.NewBrCondInstr(mergeBBIndex, headerBBIndex, breakCondID))
+	} else if !e.blockHasTerminator(e.currentBB) {
+		// Unconditional back edge.
+		e.currentBB.AddInstruction(module.NewBrInstr(headerBBIndex))
+	}
+
+	// Pop loop context.
+	e.loopStack = e.loopStack[:len(e.loopStack)-1]
+
+	// Continue emitting into merge block.
+	e.currentBB = mergeBB
+	return nil
+}
+
+// emitBreak emits a branch to the loop merge block (exits the loop).
+func (e *Emitter) emitBreak() error {
+	if len(e.loopStack) == 0 {
+		return fmt.Errorf("break outside of loop")
+	}
+	ctx := e.loopStack[len(e.loopStack)-1]
+	e.currentBB.AddInstruction(module.NewBrInstr(ctx.mergeBBIndex))
+	return nil
+}
+
+// emitContinue emits a branch to the loop continuing block.
+func (e *Emitter) emitContinue() error {
+	if len(e.loopStack) == 0 {
+		return fmt.Errorf("continue outside of loop")
+	}
+	ctx := e.loopStack[len(e.loopStack)-1]
+	e.currentBB.AddInstruction(module.NewBrInstr(ctx.continuingBBIndex))
+	return nil
+}
+
+// blockHasTerminator checks whether the basic block already ends with
+// a terminator instruction (return or branch).
+func (e *Emitter) blockHasTerminator(bb *module.BasicBlock) bool {
+	if len(bb.Instructions) == 0 {
+		return false
+	}
+	last := bb.Instructions[len(bb.Instructions)-1]
+	return last.Kind == module.InstrRet || last.Kind == module.InstrBr
 }
 
 // outputLocationFromBinding extracts the output location from a binding.

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -68,8 +68,7 @@ func (e *Emitter) emitStatement(fn *ir.Function, stmt *ir.Statement) error {
 		return e.emitStmtCall(fn, sk)
 
 	default:
-		// Unsupported statement kinds are silently skipped for MVP.
-		return nil
+		return fmt.Errorf("unsupported statement kind: %T", sk)
 	}
 }
 

--- a/dxil/internal/emit/types.go
+++ b/dxil/internal/emit/types.go
@@ -1,0 +1,129 @@
+package emit
+
+import (
+	"fmt"
+
+	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/ir"
+)
+
+// scalarToDXIL maps a naga ScalarType to a DXIL type.
+// DXIL types are always scalar — vectors are decomposed by the emitter.
+func scalarToDXIL(mod *module.Module, s ir.ScalarType) *module.Type {
+	switch s.Kind {
+	case ir.ScalarBool:
+		return mod.GetIntType(1)
+	case ir.ScalarSint:
+		return mod.GetIntType(uint(s.Width) * 8)
+	case ir.ScalarUint:
+		return mod.GetIntType(uint(s.Width) * 8)
+	case ir.ScalarFloat:
+		return mod.GetFloatType(uint(s.Width) * 8)
+	default:
+		// Abstract types should have been resolved before reaching the backend.
+		return mod.GetIntType(32)
+	}
+}
+
+// typeToDXIL maps a naga IR TypeInner to a DXIL type.
+// Vectors and matrices are scalarized — this returns the element type.
+// Callers must handle multi-component types by iterating over components.
+func typeToDXIL(mod *module.Module, irMod *ir.Module, inner ir.TypeInner) (*module.Type, error) {
+	switch t := inner.(type) {
+	case ir.ScalarType:
+		return scalarToDXIL(mod, t), nil
+
+	case ir.VectorType:
+		// DXIL has no native vectors. Return the scalar element type.
+		// The caller is responsible for creating N separate values.
+		return scalarToDXIL(mod, t.Scalar), nil
+
+	case ir.MatrixType:
+		// DXIL has no native matrices. Return the scalar element type.
+		// Matrices are fully scalarized: columns * rows separate values.
+		return scalarToDXIL(mod, t.Scalar), nil
+
+	case ir.ArrayType:
+		base := irMod.Types[t.Base]
+		elemTy, err := typeToDXIL(mod, irMod, base.Inner)
+		if err != nil {
+			return nil, fmt.Errorf("array element type: %w", err)
+		}
+		if t.Size.Constant != nil {
+			return mod.GetArrayType(elemTy, uint(*t.Size.Constant)), nil
+		}
+		// Runtime-sized array — use large count.
+		return mod.GetArrayType(elemTy, 0), nil
+
+	case ir.StructType:
+		elems := make([]*module.Type, len(t.Members))
+		for i, m := range t.Members {
+			memberTy := irMod.Types[m.Type]
+			var err error
+			elems[i], err = typeToDXIL(mod, irMod, memberTy.Inner)
+			if err != nil {
+				return nil, fmt.Errorf("struct member %d (%s): %w", i, m.Name, err)
+			}
+		}
+		return mod.GetStructType("", elems), nil
+
+	case ir.PointerType:
+		base := irMod.Types[t.Base]
+		elemTy, err := typeToDXIL(mod, irMod, base.Inner)
+		if err != nil {
+			return nil, fmt.Errorf("pointer element type: %w", err)
+		}
+		return mod.GetPointerType(elemTy), nil
+
+	default:
+		return mod.GetIntType(32), nil
+	}
+}
+
+// componentCount returns the number of scalar components for a type.
+func componentCount(inner ir.TypeInner) int {
+	switch t := inner.(type) {
+	case ir.ScalarType:
+		return 1
+	case ir.VectorType:
+		return int(t.Size)
+	case ir.MatrixType:
+		return int(t.Columns) * int(t.Rows)
+	default:
+		return 1
+	}
+}
+
+// scalarOfType returns the scalar type underlying any type.
+// For scalars, returns the scalar directly. For vectors/matrices,
+// returns the element scalar.
+func scalarOfType(inner ir.TypeInner) (ir.ScalarType, bool) {
+	switch t := inner.(type) {
+	case ir.ScalarType:
+		return t, true
+	case ir.VectorType:
+		return t.Scalar, true
+	case ir.MatrixType:
+		return t.Scalar, true
+	default:
+		return ir.ScalarType{}, false
+	}
+}
+
+// isFloatType returns true if the type is a floating-point type.
+func isFloatType(inner ir.TypeInner) bool {
+	s, ok := scalarOfType(inner)
+	if !ok {
+		return false
+	}
+	return s.Kind == ir.ScalarFloat
+}
+
+// isSignedInt returns true if the type is a signed integer type.
+func isSignedInt(inner ir.TypeInner) bool {
+	s, ok := scalarOfType(inner)
+	if !ok {
+		return false
+	}
+	return s.Kind == ir.ScalarSint
+}

--- a/dxil/internal/module/metadata.go
+++ b/dxil/internal/module/metadata.go
@@ -1,0 +1,81 @@
+package module
+
+// MetadataNodeKind identifies the type of a metadata node.
+type MetadataNodeKind int
+
+// Metadata node kinds matching LLVM 3.7 metadata system.
+const (
+	MDString MetadataNodeKind = iota // string value
+	MDValue                          // typed value reference
+	MDTuple                          // tuple of sub-nodes
+)
+
+// MetadataNode represents a single metadata node in the module.
+type MetadataNode struct {
+	Kind MetadataNodeKind
+
+	// ID is assigned during serialization.
+	ID int
+
+	// For MDString: the string value.
+	StringValue string
+
+	// For MDValue: the type and constant value.
+	ValueType  *Type
+	ValueConst *Constant
+
+	// For MDTuple: sub-nodes. A nil entry represents a null operand.
+	SubNodes []*MetadataNode
+}
+
+// NamedMetadataNode represents a named metadata entry (e.g., "dx.version").
+type NamedMetadataNode struct {
+	// Name is the metadata name (e.g., "dx.version", "dx.shaderModel").
+	Name string
+
+	// Operands are the metadata nodes referenced by this named entry.
+	Operands []*MetadataNode
+}
+
+// AddMetadataString creates a metadata string node and adds it to the module.
+func (m *Module) AddMetadataString(s string) *MetadataNode {
+	node := &MetadataNode{
+		Kind:        MDString,
+		ID:          len(m.Metadata),
+		StringValue: s,
+	}
+	m.Metadata = append(m.Metadata, node)
+	return node
+}
+
+// AddMetadataValue creates a metadata value node and adds it to the module.
+func (m *Module) AddMetadataValue(ty *Type, c *Constant) *MetadataNode {
+	node := &MetadataNode{
+		Kind:       MDValue,
+		ID:         len(m.Metadata),
+		ValueType:  ty,
+		ValueConst: c,
+	}
+	m.Metadata = append(m.Metadata, node)
+	return node
+}
+
+// AddMetadataTuple creates a metadata tuple node and adds it to the module.
+// Nil entries in subNodes represent null operands.
+func (m *Module) AddMetadataTuple(subNodes []*MetadataNode) *MetadataNode {
+	node := &MetadataNode{
+		Kind:     MDTuple,
+		ID:       len(m.Metadata),
+		SubNodes: subNodes,
+	}
+	m.Metadata = append(m.Metadata, node)
+	return node
+}
+
+// AddNamedMetadata adds a named metadata entry to the module.
+func (m *Module) AddNamedMetadata(name string, operands []*MetadataNode) {
+	m.NamedMetadata = append(m.NamedMetadata, &NamedMetadataNode{
+		Name:     name,
+		Operands: operands,
+	})
+}

--- a/dxil/internal/module/module.go
+++ b/dxil/internal/module/module.go
@@ -73,7 +73,7 @@ func NewModule(kind ShaderKind) *Module {
 		MajorVersion: 1,
 		MinorVersion: 0,
 		TargetTriple: "dxil-ms-dx",
-		DataLayout:   "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64",
+		DataLayout:   "e-m:e-p:32:32-i1:32-i8:32-i16:32-i32:32-i64:64-f16:32-f32:32-f64:64-n8:16:32:64",
 	}
 }
 

--- a/dxil/internal/module/module.go
+++ b/dxil/internal/module/module.go
@@ -1,0 +1,386 @@
+// Package module provides an in-memory representation of a DXIL module.
+//
+// DXIL modules are LLVM 3.7 IR modules with DXIL-specific metadata and
+// dx.op intrinsic calls. This package defines the types needed to build
+// a module in memory before serializing it to LLVM 3.7 bitcode.
+//
+// Reference: Mesa's dxil_internal.h and dxil_module.h
+package module
+
+// ShaderKind identifies the type of DXIL shader.
+type ShaderKind uint32
+
+// Shader kinds matching DXIL specification.
+const (
+	PixelShader    ShaderKind = 0
+	VertexShader   ShaderKind = 1
+	GeometryShader ShaderKind = 2
+	HullShader     ShaderKind = 3
+	DomainShader   ShaderKind = 4
+	ComputeShader  ShaderKind = 5
+)
+
+// Module represents a DXIL module (LLVM 3.7 IR with DXIL metadata).
+type Module struct {
+	// ShaderKind is the type of shader (vertex, pixel, compute, etc.).
+	ShaderKind ShaderKind
+
+	// MajorVersion and MinorVersion are the DXIL version numbers.
+	MajorVersion uint32
+	MinorVersion uint32
+
+	// TargetTriple is always "dxil-ms-dx" for DXIL.
+	TargetTriple string
+
+	// DataLayout is the LLVM data layout string.
+	DataLayout string
+
+	// Types contains all types used in the module.
+	Types []*Type
+
+	// Functions contains all function declarations and definitions.
+	Functions []*Function
+
+	// Constants contains all constant values.
+	Constants []*Constant
+
+	// GlobalVars contains global variable declarations.
+	GlobalVars []*GlobalVar
+
+	// NamedMetadata maps metadata names (e.g. "dx.version") to
+	// metadata node lists.
+	NamedMetadata []*NamedMetadataNode
+
+	// Metadata contains all metadata nodes referenced by the module.
+	Metadata []*MetadataNode
+
+	// cachedTypes provides deduplication for commonly used types.
+	voidType    *Type
+	int1Type    *Type
+	int8Type    *Type
+	int16Type   *Type
+	int32Type   *Type
+	int64Type   *Type
+	float16Type *Type
+	float32Type *Type
+	float64Type *Type
+}
+
+// NewModule creates a new empty DXIL module with the given shader kind.
+func NewModule(kind ShaderKind) *Module {
+	return &Module{
+		ShaderKind:   kind,
+		MajorVersion: 1,
+		MinorVersion: 0,
+		TargetTriple: "dxil-ms-dx",
+		DataLayout:   "e-m:e-p:32:32-i1:32-i8:8-i16:16-i32:32-i64:64-f16:16-f32:32-f64:64-n8:16:32:64",
+	}
+}
+
+// TypeKind identifies the category of a Type.
+type TypeKind int
+
+// Type kinds matching LLVM 3.7 type system subset used by DXIL.
+const (
+	TypeVoid     TypeKind = iota // void
+	TypeInteger                  // iN (i1, i8, i16, i32, i64)
+	TypeFloat                    // half, float, double
+	TypePointer                  // pointer to another type
+	TypeStruct                   // named or anonymous struct
+	TypeArray                    // array of elements
+	TypeVector                   // vector of elements
+	TypeFunction                 // function signature
+	TypeLabel                    // basic block label
+	TypeMetadata                 // metadata type
+)
+
+// Type represents an LLVM 3.7 type.
+type Type struct {
+	Kind TypeKind
+
+	// ID is the index of this type in the module's type table.
+	// Assigned during serialization.
+	ID int
+
+	// For TypeInteger: bit width (1, 8, 16, 32, 64).
+	IntBits uint
+
+	// For TypeFloat: bit width (16, 32, 64).
+	FloatBits uint
+
+	// For TypePointer: the element type pointed to.
+	PointerElem *Type
+
+	// For TypeStruct: name (empty for anonymous) and element types.
+	StructName  string
+	StructElems []*Type
+
+	// For TypeArray and TypeVector: element type and count.
+	ElemType  *Type
+	ElemCount uint
+
+	// For TypeFunction: return type and parameter types.
+	RetType    *Type
+	ParamTypes []*Type
+}
+
+// GetVoidType returns the void type, creating it if needed.
+func (m *Module) GetVoidType() *Type {
+	if m.voidType == nil {
+		m.voidType = m.addType(&Type{Kind: TypeVoid})
+	}
+	return m.voidType
+}
+
+// GetIntType returns an integer type with the given bit width.
+func (m *Module) GetIntType(bits uint) *Type {
+	switch bits {
+	case 1:
+		if m.int1Type == nil {
+			m.int1Type = m.addType(&Type{Kind: TypeInteger, IntBits: 1})
+		}
+		return m.int1Type
+	case 8:
+		if m.int8Type == nil {
+			m.int8Type = m.addType(&Type{Kind: TypeInteger, IntBits: 8})
+		}
+		return m.int8Type
+	case 16:
+		if m.int16Type == nil {
+			m.int16Type = m.addType(&Type{Kind: TypeInteger, IntBits: 16})
+		}
+		return m.int16Type
+	case 32:
+		if m.int32Type == nil {
+			m.int32Type = m.addType(&Type{Kind: TypeInteger, IntBits: 32})
+		}
+		return m.int32Type
+	case 64:
+		if m.int64Type == nil {
+			m.int64Type = m.addType(&Type{Kind: TypeInteger, IntBits: 64})
+		}
+		return m.int64Type
+	default:
+		return m.addType(&Type{Kind: TypeInteger, IntBits: bits})
+	}
+}
+
+// GetFloatType returns a floating-point type with the given bit width.
+func (m *Module) GetFloatType(bits uint) *Type {
+	switch bits {
+	case 16:
+		if m.float16Type == nil {
+			m.float16Type = m.addType(&Type{Kind: TypeFloat, FloatBits: 16})
+		}
+		return m.float16Type
+	case 32:
+		if m.float32Type == nil {
+			m.float32Type = m.addType(&Type{Kind: TypeFloat, FloatBits: 32})
+		}
+		return m.float32Type
+	case 64:
+		if m.float64Type == nil {
+			m.float64Type = m.addType(&Type{Kind: TypeFloat, FloatBits: 64})
+		}
+		return m.float64Type
+	default:
+		return m.addType(&Type{Kind: TypeFloat, FloatBits: bits})
+	}
+}
+
+// GetPointerType returns a pointer type to the given element type.
+func (m *Module) GetPointerType(elem *Type) *Type {
+	// Search for existing pointer type.
+	for _, ty := range m.Types {
+		if ty.Kind == TypePointer && ty.PointerElem == elem {
+			return ty
+		}
+	}
+	return m.addType(&Type{Kind: TypePointer, PointerElem: elem})
+}
+
+// GetFunctionType returns a function type with the given return and parameter types.
+func (m *Module) GetFunctionType(ret *Type, params []*Type) *Type {
+	return m.addType(&Type{
+		Kind:       TypeFunction,
+		RetType:    ret,
+		ParamTypes: params,
+	})
+}
+
+// GetStructType returns a named struct type.
+func (m *Module) GetStructType(name string, elems []*Type) *Type {
+	return m.addType(&Type{
+		Kind:        TypeStruct,
+		StructName:  name,
+		StructElems: elems,
+	})
+}
+
+// GetArrayType returns an array type.
+func (m *Module) GetArrayType(elem *Type, count uint) *Type {
+	return m.addType(&Type{
+		Kind:      TypeArray,
+		ElemType:  elem,
+		ElemCount: count,
+	})
+}
+
+// GetLabelType returns the label type used for basic block references.
+func (m *Module) GetLabelType() *Type {
+	return m.addType(&Type{Kind: TypeLabel})
+}
+
+// GetMetadataType returns the metadata type.
+func (m *Module) GetMetadataType() *Type {
+	return m.addType(&Type{Kind: TypeMetadata})
+}
+
+func (m *Module) addType(ty *Type) *Type {
+	ty.ID = len(m.Types)
+	m.Types = append(m.Types, ty)
+	return ty
+}
+
+// Function represents an LLVM function declaration or definition.
+type Function struct {
+	// Name is the function name (e.g., "main", "dx.op.loadInput.f32").
+	Name string
+
+	// FuncType is the function's type (TypeFunction).
+	FuncType *Type
+
+	// IsDeclaration is true for external declarations (no body).
+	IsDeclaration bool
+
+	// BasicBlocks contains the function body (nil for declarations).
+	BasicBlocks []*BasicBlock
+
+	// ValueID is assigned during serialization.
+	ValueID int
+}
+
+// AddFunction adds a function declaration or definition to the module.
+func (m *Module) AddFunction(name string, funcType *Type, isDecl bool) *Function {
+	f := &Function{
+		Name:          name,
+		FuncType:      funcType,
+		IsDeclaration: isDecl,
+	}
+	m.Functions = append(m.Functions, f)
+	return f
+}
+
+// AddBasicBlock adds a new basic block to the function.
+func (f *Function) AddBasicBlock(name string) *BasicBlock {
+	bb := &BasicBlock{
+		Name: name,
+	}
+	f.BasicBlocks = append(f.BasicBlocks, bb)
+	return bb
+}
+
+// BasicBlock represents a sequence of instructions with a single entry
+// and single exit.
+type BasicBlock struct {
+	// Name is an optional label for the basic block.
+	Name string
+
+	// Instructions contains the block's instruction sequence.
+	Instructions []*Instruction
+}
+
+// AddInstruction appends an instruction to the basic block.
+func (bb *BasicBlock) AddInstruction(instr *Instruction) {
+	bb.Instructions = append(bb.Instructions, instr)
+}
+
+// InstrKind identifies the type of an Instruction.
+type InstrKind int
+
+// Instruction kinds matching LLVM 3.7 instruction set subset used by DXIL.
+const (
+	InstrRet        InstrKind = iota // return
+	InstrBr                          // branch
+	InstrCall                        // function call
+	InstrBinOp                       // binary operation
+	InstrCmp                         // comparison
+	InstrCast                        // type cast
+	InstrSelect                      // select (ternary)
+	InstrExtractVal                  // extractvalue
+	InstrAlloca                      // stack allocation
+	InstrLoad                        // memory load
+	InstrStore                       // memory store
+	InstrGEP                         // getelementptr
+	InstrPhi                         // phi node
+)
+
+// Instruction represents a single LLVM IR instruction.
+type Instruction struct {
+	Kind InstrKind
+
+	// HasValue is true if this instruction produces a value.
+	HasValue bool
+
+	// ResultType is the type of the produced value (nil if HasValue is false).
+	ResultType *Type
+
+	// Operands are the instruction's input values (interpretation
+	// depends on Kind).
+	Operands []int // indices into value numbering
+
+	// For InstrRet: ReturnValue is the value to return (-1 for void).
+	ReturnValue int
+
+	// For InstrCall: the called function.
+	CalledFunc *Function
+
+	// ValueID is assigned during serialization.
+	ValueID int
+}
+
+// NewRetVoidInstr creates a void return instruction.
+func NewRetVoidInstr() *Instruction {
+	return &Instruction{
+		Kind:        InstrRet,
+		HasValue:    false,
+		ReturnValue: -1,
+	}
+}
+
+// Constant represents a constant value in the module.
+type Constant struct {
+	// ConstType is the type of this constant.
+	ConstType *Type
+
+	// IntValue is used for integer constants.
+	IntValue int64
+
+	// FloatValue is used for floating-point constants.
+	FloatValue float64
+
+	// IsUndef is true for undef values.
+	IsUndef bool
+
+	// ValueID is assigned during serialization.
+	ValueID int
+}
+
+// AddIntConst adds an integer constant to the module.
+func (m *Module) AddIntConst(ty *Type, value int64) *Constant {
+	c := &Constant{
+		ConstType: ty,
+		IntValue:  value,
+	}
+	m.Constants = append(m.Constants, c)
+	return c
+}
+
+// GlobalVar represents a global variable.
+type GlobalVar struct {
+	Name        string
+	VarType     *Type
+	IsConstant  bool
+	Initializer *Constant
+	ValueID     int
+}

--- a/dxil/internal/module/module.go
+++ b/dxil/internal/module/module.go
@@ -348,6 +348,30 @@ func NewRetVoidInstr() *Instruction {
 	}
 }
 
+// NewBrInstr creates an unconditional branch to the target basic block.
+// The operand is the basic block index within the parent function.
+func NewBrInstr(targetBBIndex int) *Instruction {
+	return &Instruction{
+		Kind:        InstrBr,
+		HasValue:    false,
+		Operands:    []int{targetBBIndex},
+		ReturnValue: -1,
+	}
+}
+
+// NewBrCondInstr creates a conditional branch.
+// If cond is true, branches to trueBBIndex; otherwise to falseBBIndex.
+// cond is an emitter value ID (i1 type). The BB indices are positions
+// within the parent function's BasicBlocks slice.
+func NewBrCondInstr(trueBBIndex, falseBBIndex, cond int) *Instruction {
+	return &Instruction{
+		Kind:        InstrBr,
+		HasValue:    false,
+		Operands:    []int{trueBBIndex, falseBBIndex, cond},
+		ReturnValue: -1,
+	}
+}
+
 // Constant represents a constant value in the module.
 type Constant struct {
 	// ConstType is the type of this constant.

--- a/dxil/internal/module/module_test.go
+++ b/dxil/internal/module/module_test.go
@@ -1,0 +1,384 @@
+package module
+
+import (
+	"encoding/binary"
+	"testing"
+)
+
+func TestNewModule(t *testing.T) {
+	mod := NewModule(VertexShader)
+	if mod.ShaderKind != VertexShader {
+		t.Errorf("ShaderKind: got %d, want %d", mod.ShaderKind, VertexShader)
+	}
+	if mod.TargetTriple != "dxil-ms-dx" {
+		t.Errorf("TargetTriple: got %q, want %q", mod.TargetTriple, "dxil-ms-dx")
+	}
+	if mod.MajorVersion != 1 || mod.MinorVersion != 0 {
+		t.Errorf("version: got %d.%d, want 1.0", mod.MajorVersion, mod.MinorVersion)
+	}
+}
+
+func TestShaderKindConstants(t *testing.T) {
+	// Verify shader kind values match DXIL spec.
+	tests := []struct {
+		name string
+		kind ShaderKind
+		want ShaderKind
+	}{
+		{"Pixel", PixelShader, 0},
+		{"Vertex", VertexShader, 1},
+		{"Geometry", GeometryShader, 2},
+		{"Hull", HullShader, 3},
+		{"Domain", DomainShader, 4},
+		{"Compute", ComputeShader, 5},
+	}
+	for _, tt := range tests {
+		if tt.kind != tt.want {
+			t.Errorf("%s: got %d, want %d", tt.name, tt.kind, tt.want)
+		}
+	}
+}
+
+func TestGetVoidType_Deduplication(t *testing.T) {
+	mod := NewModule(VertexShader)
+	v1 := mod.GetVoidType()
+	v2 := mod.GetVoidType()
+	if v1 != v2 {
+		t.Error("GetVoidType returned different pointers")
+	}
+	if v1.Kind != TypeVoid {
+		t.Errorf("void type kind: got %d, want %d", v1.Kind, TypeVoid)
+	}
+}
+
+func TestGetIntType_Deduplication(t *testing.T) {
+	mod := NewModule(VertexShader)
+	for _, bits := range []uint{1, 8, 16, 32, 64} {
+		t1 := mod.GetIntType(bits)
+		t2 := mod.GetIntType(bits)
+		if t1 != t2 {
+			t.Errorf("GetIntType(%d) not deduplicated", bits)
+		}
+		if t1.IntBits != bits {
+			t.Errorf("GetIntType(%d).IntBits = %d", bits, t1.IntBits)
+		}
+	}
+}
+
+func TestGetFloatType_Deduplication(t *testing.T) {
+	mod := NewModule(VertexShader)
+	for _, bits := range []uint{16, 32, 64} {
+		t1 := mod.GetFloatType(bits)
+		t2 := mod.GetFloatType(bits)
+		if t1 != t2 {
+			t.Errorf("GetFloatType(%d) not deduplicated", bits)
+		}
+		if t1.FloatBits != bits {
+			t.Errorf("GetFloatType(%d).FloatBits = %d", bits, t1.FloatBits)
+		}
+	}
+}
+
+func TestGetPointerType_Deduplication(t *testing.T) {
+	mod := NewModule(VertexShader)
+	i32 := mod.GetIntType(32)
+	p1 := mod.GetPointerType(i32)
+	p2 := mod.GetPointerType(i32)
+	if p1 != p2 {
+		t.Error("GetPointerType not deduplicated for same element type")
+	}
+	if p1.PointerElem != i32 {
+		t.Error("pointer element type mismatch")
+	}
+}
+
+func TestGetFunctionType(t *testing.T) {
+	mod := NewModule(VertexShader)
+	voidTy := mod.GetVoidType()
+	i32Ty := mod.GetIntType(32)
+	fty := mod.GetFunctionType(voidTy, []*Type{i32Ty, i32Ty})
+	if fty.Kind != TypeFunction {
+		t.Errorf("function type kind: got %d, want %d", fty.Kind, TypeFunction)
+	}
+	if fty.RetType != voidTy {
+		t.Error("function return type mismatch")
+	}
+	if len(fty.ParamTypes) != 2 {
+		t.Errorf("function param count: got %d, want 2", len(fty.ParamTypes))
+	}
+}
+
+func TestGetStructType(t *testing.T) {
+	mod := NewModule(VertexShader)
+	i32 := mod.GetIntType(32)
+	st := mod.GetStructType("test_struct", []*Type{i32, i32})
+	if st.Kind != TypeStruct {
+		t.Errorf("struct kind: got %d, want %d", st.Kind, TypeStruct)
+	}
+	if st.StructName != "test_struct" {
+		t.Errorf("struct name: got %q, want %q", st.StructName, "test_struct")
+	}
+	if len(st.StructElems) != 2 {
+		t.Errorf("struct elem count: got %d, want 2", len(st.StructElems))
+	}
+}
+
+func TestGetArrayType(t *testing.T) {
+	mod := NewModule(VertexShader)
+	f32 := mod.GetFloatType(32)
+	arr := mod.GetArrayType(f32, 4)
+	if arr.Kind != TypeArray {
+		t.Errorf("array kind: got %d, want %d", arr.Kind, TypeArray)
+	}
+	if arr.ElemCount != 4 {
+		t.Errorf("array count: got %d, want 4", arr.ElemCount)
+	}
+}
+
+func TestAddFunction(t *testing.T) {
+	mod := NewModule(VertexShader)
+	voidTy := mod.GetVoidType()
+	funcTy := mod.GetFunctionType(voidTy, nil)
+	fn := mod.AddFunction("main", funcTy, false)
+	if fn.Name != "main" {
+		t.Errorf("function name: got %q, want %q", fn.Name, "main")
+	}
+	if fn.IsDeclaration {
+		t.Error("expected non-declaration function")
+	}
+	if len(mod.Functions) != 1 {
+		t.Errorf("function count: got %d, want 1", len(mod.Functions))
+	}
+}
+
+func TestAddBasicBlock(t *testing.T) {
+	mod := NewModule(VertexShader)
+	voidTy := mod.GetVoidType()
+	funcTy := mod.GetFunctionType(voidTy, nil)
+	fn := mod.AddFunction("main", funcTy, false)
+	bb := fn.AddBasicBlock("entry")
+	if bb.Name != "entry" {
+		t.Errorf("bb name: got %q, want %q", bb.Name, "entry")
+	}
+	if len(fn.BasicBlocks) != 1 {
+		t.Errorf("bb count: got %d, want 1", len(fn.BasicBlocks))
+	}
+}
+
+func TestNewRetVoidInstr(t *testing.T) {
+	instr := NewRetVoidInstr()
+	if instr.Kind != InstrRet {
+		t.Errorf("kind: got %d, want %d", instr.Kind, InstrRet)
+	}
+	if instr.HasValue {
+		t.Error("void return should not have value")
+	}
+	if instr.ReturnValue != -1 {
+		t.Errorf("return value: got %d, want -1", instr.ReturnValue)
+	}
+}
+
+func TestAddIntConst(t *testing.T) {
+	mod := NewModule(VertexShader)
+	i32 := mod.GetIntType(32)
+	c := mod.AddIntConst(i32, 42)
+	if c.IntValue != 42 {
+		t.Errorf("const value: got %d, want 42", c.IntValue)
+	}
+	if c.ConstType != i32 {
+		t.Error("const type mismatch")
+	}
+}
+
+func TestMetadata(t *testing.T) {
+	mod := NewModule(VertexShader)
+	i32 := mod.GetIntType(32)
+	c := mod.AddIntConst(i32, 1)
+
+	mdStr := mod.AddMetadataString("hello")
+	if mdStr.Kind != MDString {
+		t.Errorf("md string kind: got %d, want %d", mdStr.Kind, MDString)
+	}
+	if mdStr.StringValue != "hello" {
+		t.Errorf("md string value: got %q, want %q", mdStr.StringValue, "hello")
+	}
+
+	mdVal := mod.AddMetadataValue(i32, c)
+	if mdVal.Kind != MDValue {
+		t.Errorf("md value kind: got %d, want %d", mdVal.Kind, MDValue)
+	}
+
+	mdTuple := mod.AddMetadataTuple([]*MetadataNode{mdStr, mdVal, nil})
+	if mdTuple.Kind != MDTuple {
+		t.Errorf("md tuple kind: got %d, want %d", mdTuple.Kind, MDTuple)
+	}
+	if len(mdTuple.SubNodes) != 3 {
+		t.Errorf("md tuple sub-nodes: got %d, want 3", len(mdTuple.SubNodes))
+	}
+	if mdTuple.SubNodes[2] != nil {
+		t.Error("expected nil sub-node at index 2")
+	}
+}
+
+func TestNamedMetadata(t *testing.T) {
+	mod := NewModule(VertexShader)
+	mdStr := mod.AddMetadataString("test")
+	mod.AddNamedMetadata("dx.version", []*MetadataNode{mdStr})
+
+	if len(mod.NamedMetadata) != 1 {
+		t.Fatalf("named metadata count: got %d, want 1", len(mod.NamedMetadata))
+	}
+	if mod.NamedMetadata[0].Name != "dx.version" {
+		t.Errorf("named md name: got %q, want %q", mod.NamedMetadata[0].Name, "dx.version")
+	}
+}
+
+func TestTypeIDAssignment(t *testing.T) {
+	mod := NewModule(VertexShader)
+	v := mod.GetVoidType()
+	i32 := mod.GetIntType(32)
+	f32 := mod.GetFloatType(32)
+
+	if v.ID != 0 {
+		t.Errorf("void ID: got %d, want 0", v.ID)
+	}
+	if i32.ID != 1 {
+		t.Errorf("i32 ID: got %d, want 1", i32.ID)
+	}
+	if f32.ID != 2 {
+		t.Errorf("f32 ID: got %d, want 2", f32.ID)
+	}
+}
+
+func TestSerialize_MinimalModule(t *testing.T) {
+	mod := NewModule(VertexShader)
+	voidTy := mod.GetVoidType()
+	funcTy := mod.GetFunctionType(voidTy, nil)
+	fn := mod.AddFunction("main", funcTy, false)
+	bb := fn.AddBasicBlock("entry")
+	bb.AddInstruction(NewRetVoidInstr())
+
+	data := Serialize(mod)
+	if len(data) == 0 {
+		t.Fatal("serialization produced empty output")
+	}
+
+	// Verify magic.
+	if data[0] != 'B' || data[1] != 'C' || data[2] != 0xC0 || data[3] != 0xDE {
+		t.Errorf("bad magic: %02X %02X %02X %02X", data[0], data[1], data[2], data[3])
+	}
+
+	// Verify 32-bit alignment.
+	if len(data)%4 != 0 {
+		t.Errorf("output not 32-bit aligned: %d bytes", len(data))
+	}
+
+	// Should be bigger than just magic (there's a module block with content).
+	if len(data) < 16 {
+		t.Errorf("output too small: %d bytes", len(data))
+	}
+}
+
+func TestSerialize_WithMetadata(t *testing.T) {
+	mod := NewModule(VertexShader)
+	voidTy := mod.GetVoidType()
+	i32 := mod.GetIntType(32)
+	funcTy := mod.GetFunctionType(voidTy, nil)
+	fn := mod.AddFunction("main", funcTy, false)
+	bb := fn.AddBasicBlock("entry")
+	bb.AddInstruction(NewRetVoidInstr())
+
+	c0 := mod.AddIntConst(i32, 0)
+	c1 := mod.AddIntConst(i32, 1)
+
+	md0 := mod.AddMetadataValue(i32, c0)
+	md1 := mod.AddMetadataValue(i32, c1)
+	mdTuple := mod.AddMetadataTuple([]*MetadataNode{md1, md0})
+	mod.AddNamedMetadata("dx.version", []*MetadataNode{mdTuple})
+
+	data := Serialize(mod)
+	if len(data) == 0 {
+		t.Fatal("serialization with metadata produced empty output")
+	}
+	if len(data)%4 != 0 {
+		t.Errorf("output not 32-bit aligned: %d bytes", len(data))
+	}
+}
+
+func TestEncodeSignRotated(t *testing.T) {
+	tests := []struct {
+		input int64
+		want  uint64
+	}{
+		{0, 0},
+		{1, 2},
+		{2, 4},
+		{-1, 1},
+		{-2, 3},
+		{100, 200},
+		{-100, 199},
+	}
+	for _, tt := range tests {
+		got := encodeSignRotated(tt.input)
+		if got != tt.want {
+			t.Errorf("encodeSignRotated(%d) = %d, want %d", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestSerialize_EmptyModule(t *testing.T) {
+	// Module with no functions, constants, or metadata.
+	mod := NewModule(ComputeShader)
+	data := Serialize(mod)
+	if len(data) == 0 {
+		t.Fatal("empty module serialization produced nothing")
+	}
+	if data[0] != 'B' || data[1] != 'C' {
+		t.Error("bad magic for empty module")
+	}
+
+	// Verify the first 32-bit word after magic is the ENTER_SUBBLOCK encoding.
+	if len(data) < 8 {
+		t.Fatalf("too small: %d bytes", len(data))
+	}
+	// After magic (4 bytes), the MODULE_BLOCK enters. We just verify alignment.
+	if len(data)%4 != 0 {
+		t.Errorf("not 32-bit aligned: %d bytes", len(data))
+	}
+}
+
+func TestSerialize_Deterministic(t *testing.T) {
+	// Verify that serializing the same module twice produces identical output.
+	build := func() []byte {
+		mod := NewModule(VertexShader)
+		voidTy := mod.GetVoidType()
+		i32 := mod.GetIntType(32)
+		funcTy := mod.GetFunctionType(voidTy, nil)
+		fn := mod.AddFunction("main", funcTy, false)
+		bb := fn.AddBasicBlock("entry")
+		bb.AddInstruction(NewRetVoidInstr())
+		c := mod.AddIntConst(i32, 42)
+		mdV := mod.AddMetadataValue(i32, c)
+		mdT := mod.AddMetadataTuple([]*MetadataNode{mdV})
+		mod.AddNamedMetadata("dx.test", []*MetadataNode{mdT})
+		return Serialize(mod)
+	}
+
+	data1 := build()
+	data2 := build()
+
+	if len(data1) != len(data2) {
+		t.Fatalf("different lengths: %d vs %d", len(data1), len(data2))
+	}
+
+	for i := range data1 {
+		if data1[i] != data2[i] {
+			// Find dword containing the difference.
+			dw := i / 4
+			d1 := binary.LittleEndian.Uint32(data1[dw*4:])
+			d2 := binary.LittleEndian.Uint32(data2[dw*4:])
+			t.Errorf("difference at byte %d (dword %d): 0x%08X vs 0x%08X", i, dw, d1, d2)
+			break
+		}
+	}
+}

--- a/dxil/internal/module/serialize.go
+++ b/dxil/internal/module/serialize.go
@@ -1,0 +1,515 @@
+package module
+
+import (
+	"github.com/gogpu/naga/dxil/internal/bitcode"
+)
+
+// uid converts a non-negative int (ID or index) to uint64.
+// All IDs in the module are non-negative by construction.
+func uid(v int) uint64 {
+	return uint64(v) //nolint:gosec // IDs are always non-negative
+}
+
+// LLVM 3.7 block IDs.
+const (
+	blockInfoID     = 0
+	firstAppBlockID = 8
+
+	moduleBlockID   = firstAppBlockID     // 8
+	paramAttrID     = firstAppBlockID + 1 // 9
+	paramAttrGrpID  = firstAppBlockID + 2 // 10
+	constBlockID    = firstAppBlockID + 3 // 11
+	functionBlockID = firstAppBlockID + 4 // 12
+	valueSymtabID   = firstAppBlockID + 6 // 14
+	metadataBlockID = firstAppBlockID + 7 // 15
+	typeBlockID     = firstAppBlockID + 9 // 17
+)
+
+// Module info record codes.
+const (
+	moduleCodeVersion    = 1
+	moduleCodeTriple     = 2
+	moduleCodeDataLayout = 3
+	moduleCodeGlobalVar  = 7
+	moduleCodeFunction   = 8
+)
+
+// Type table record codes.
+const (
+	typeCodeNumEntry    = 1
+	typeCodeVoid        = 2
+	typeCodeFloat       = 3
+	typeCodeDouble      = 4
+	typeCodeLabel       = 5
+	typeCodeInteger     = 7
+	typeCodePointer     = 8
+	typeCodeHalf        = 10
+	typeCodeArray       = 11
+	typeCodeVector      = 12
+	typeCodeMetadata    = 16
+	typeCodeStructAnon  = 18
+	typeCodeStructName  = 19
+	typeCodeStructNamed = 20
+	typeCodeFuncType    = 21 // LLVM TYPE_CODE_FUNCTION
+)
+
+// Constant record codes.
+const (
+	constCodeSetType   = 1
+	constCodeNull      = 2
+	constCodeUndef     = 3
+	constCodeInteger   = 4
+	constCodeFloat     = 6
+	constCodeAggregate = 7
+)
+
+// Function body record codes.
+const (
+	funcCodeDeclareBlocks = 1
+	funcCodeInstBinop     = 2
+	funcCodeInstCast      = 3
+	funcCodeInstRet       = 10
+	funcCodeInstBr        = 11
+	funcCodeInstCall      = 34
+)
+
+// Metadata record codes.
+const (
+	metadataString    = 1
+	metadataValue     = 2
+	metadataNode      = 3
+	metadataName      = 4
+	metadataNamedNode = 10
+)
+
+// Value symbol table record codes.
+const (
+	vstCodeEntry   = 1
+	vstCodeBBEntry = 2
+)
+
+// Serialize writes the Module to LLVM 3.7 bitcode format.
+//
+// The serialization order follows Mesa's dxil_emit_module():
+//  1. Bitcode magic: 'B','C', 0xC0, 0xDE
+//  2. MODULE_BLOCK (blockid=8, abbrevWidth=3)
+//  3. VERSION record (code=1, value=1 for LLVM 3.7)
+//  4. TRIPLE record
+//  5. DATALAYOUT record
+//  6. TYPE_BLOCK — all types
+//  7. Module info — function declarations
+//  8. CONSTANTS_BLOCK — constant values
+//  9. METADATA_BLOCK — metadata nodes and named metadata
+//  10. Function bodies
+//  11. VALUE_SYMTAB_BLOCK — symbol names
+//  12. Exit MODULE_BLOCK
+func Serialize(m *Module) []byte {
+	s := &serializer{
+		mod: m,
+		w:   bitcode.NewWriter(2),
+	}
+	s.assignIDs()
+	s.emitModule()
+	return s.w.Bytes()
+}
+
+type serializer struct {
+	mod *Module
+	w   *bitcode.Writer
+}
+
+// assignIDs assigns sequential value IDs to all global values.
+func (s *serializer) assignIDs() {
+	nextID := 0
+
+	// Assign type IDs.
+	for i, ty := range s.mod.Types {
+		ty.ID = i
+	}
+
+	// Global variables get value IDs first.
+	for _, gv := range s.mod.GlobalVars {
+		gv.ValueID = nextID
+		nextID++
+	}
+
+	// Then functions.
+	for _, fn := range s.mod.Functions {
+		fn.ValueID = nextID
+		nextID++
+	}
+
+	// Then constants.
+	for _, c := range s.mod.Constants {
+		c.ValueID = nextID
+		nextID++
+	}
+
+	// Metadata IDs (separate numbering).
+	for i, md := range s.mod.Metadata {
+		md.ID = i
+	}
+}
+
+// emitModule writes the complete bitcode module.
+func (s *serializer) emitModule() {
+	// Bitcode magic.
+	s.w.WriteBits('B', 8)
+	s.w.WriteBits('C', 8)
+	s.w.WriteBits(0xC0, 8)
+	s.w.WriteBits(0xDE, 8)
+
+	// MODULE_BLOCK.
+	s.w.EnterBlock(moduleBlockID, 3)
+
+	// VERSION record: value=1 means LLVM 3.7 bitcode.
+	s.w.EmitRecord(moduleCodeVersion, []uint64{1})
+
+	// TRIPLE record.
+	s.emitStringRecord(moduleCodeTriple, s.mod.TargetTriple)
+
+	// DATALAYOUT record.
+	if s.mod.DataLayout != "" {
+		s.emitStringRecord(moduleCodeDataLayout, s.mod.DataLayout)
+	}
+
+	// TYPE_BLOCK.
+	s.emitTypeTable()
+
+	// Module info: function declarations.
+	s.emitModuleInfo()
+
+	// CONSTANTS_BLOCK.
+	if len(s.mod.Constants) > 0 {
+		s.emitConstants()
+	}
+
+	// METADATA_BLOCK.
+	if len(s.mod.Metadata) > 0 || len(s.mod.NamedMetadata) > 0 {
+		s.emitMetadata()
+	}
+
+	// Function bodies.
+	for i := range s.mod.Functions {
+		fn := s.mod.Functions[i]
+		if !fn.IsDeclaration && len(fn.BasicBlocks) > 0 {
+			s.emitFunctionBody(fn)
+		}
+	}
+
+	// VALUE_SYMTAB_BLOCK.
+	s.emitValueSymtab()
+
+	s.w.ExitBlock() // MODULE_BLOCK
+}
+
+// emitStringRecord encodes a string as a sequence of byte values in a record.
+func (s *serializer) emitStringRecord(code uint, str string) {
+	vals := make([]uint64, len(str))
+	for i := 0; i < len(str); i++ {
+		vals[i] = uint64(str[i])
+	}
+	s.w.EmitRecord(code, vals)
+}
+
+// emitTypeTable writes the TYPE_BLOCK containing all module types.
+func (s *serializer) emitTypeTable() {
+	// The type count includes the metadata type which is always appended.
+	typeCount := len(s.mod.Types) + 1
+
+	s.w.EnterBlock(typeBlockID, 4)
+
+	// NUMENTRY record: total number of types.
+	s.w.EmitRecord(typeCodeNumEntry, []uint64{uint64(typeCount)})
+
+	for _, ty := range s.mod.Types {
+		s.emitType(ty)
+	}
+
+	// Metadata type is always appended last (Mesa: emit_metadata_type).
+	s.w.EmitRecord(typeCodeMetadata, nil)
+
+	s.w.ExitBlock()
+}
+
+// emitType writes a single type record.
+func (s *serializer) emitType(ty *Type) {
+	switch ty.Kind {
+	case TypeVoid:
+		s.w.EmitRecord(typeCodeVoid, nil)
+
+	case TypeInteger:
+		s.w.EmitRecord(typeCodeInteger, []uint64{uint64(ty.IntBits)})
+
+	case TypeFloat:
+		switch ty.FloatBits {
+		case 16:
+			s.w.EmitRecord(typeCodeHalf, nil)
+		case 32:
+			s.w.EmitRecord(typeCodeFloat, nil)
+		case 64:
+			s.w.EmitRecord(typeCodeDouble, nil)
+		}
+
+	case TypePointer:
+		// POINTER: [pointee type index, address space=0]
+		s.w.EmitRecord(typeCodePointer, []uint64{uid(ty.PointerElem.ID), 0})
+
+	case TypeStruct:
+		if ty.StructName != "" {
+			// Named struct: emit STRUCT_NAME first, then STRUCT_NAMED.
+			s.emitStringRecord(typeCodeStructName, ty.StructName)
+			data := make([]uint64, 1+len(ty.StructElems))
+			data[0] = 0 // packed = false
+			for i, elem := range ty.StructElems {
+				data[1+i] = uid(elem.ID)
+			}
+			s.w.EmitRecord(typeCodeStructNamed, data)
+		} else {
+			// Anonymous struct.
+			data := make([]uint64, 1+len(ty.StructElems))
+			data[0] = 0 // packed = false
+			for i, elem := range ty.StructElems {
+				data[1+i] = uid(elem.ID)
+			}
+			s.w.EmitRecord(typeCodeStructAnon, data)
+		}
+
+	case TypeArray:
+		// ARRAY: [numelems, eltty]
+		s.w.EmitRecord(typeCodeArray, []uint64{uint64(ty.ElemCount), uid(ty.ElemType.ID)})
+
+	case TypeVector:
+		// VECTOR: [numelems, eltty]
+		s.w.EmitRecord(typeCodeVector, []uint64{uint64(ty.ElemCount), uid(ty.ElemType.ID)})
+
+	case TypeFunction:
+		// FUNCTION: [vararg, retty, ...paramtys]
+		data := make([]uint64, 2+len(ty.ParamTypes))
+		data[0] = 0 // vararg = false
+		data[1] = uid(ty.RetType.ID)
+		for i, pt := range ty.ParamTypes {
+			data[2+i] = uid(pt.ID)
+		}
+		s.w.EmitRecord(typeCodeFuncType, data)
+
+	case TypeLabel:
+		s.w.EmitRecord(typeCodeLabel, nil)
+
+	case TypeMetadata:
+		s.w.EmitRecord(typeCodeMetadata, nil)
+	}
+}
+
+// emitModuleInfo writes global variable and function declaration records.
+func (s *serializer) emitModuleInfo() {
+	for i := range s.mod.Functions {
+		fn := s.mod.Functions[i]
+		s.emitFunctionDecl(fn)
+	}
+}
+
+// emitFunctionDecl writes a MODULE_CODE_FUNCTION record.
+func (s *serializer) emitFunctionDecl(fn *Function) {
+	isDecl := uint64(0)
+	if fn.IsDeclaration {
+		isDecl = 1
+	}
+	data := []uint64{
+		uid(fn.FuncType.ID), // type
+		0,                   // callingconv (default=0)
+		isDecl,              // isproto
+		0,                   // linkage (external=0)
+		0,                   // paramattr
+		0,                   // alignment
+		0,                   // section
+		0,                   // visibility
+		0,                   // gc
+		0,                   // unnamed_addr
+		0,                   // prologuedata
+		0,                   // dllstorageclass
+		0,                   // comdat
+		0,                   // prefixdata
+	}
+	s.w.EmitRecord(moduleCodeFunction, data)
+}
+
+// emitConstants writes the CONSTANTS_BLOCK.
+func (s *serializer) emitConstants() {
+	s.w.EnterBlock(constBlockID, 4)
+
+	var lastType *Type
+	for _, c := range s.mod.Constants {
+		// Emit SETTYPE if the type changes.
+		if c.ConstType != lastType {
+			s.w.EmitRecord(constCodeSetType, []uint64{uid(c.ConstType.ID)})
+			lastType = c.ConstType
+		}
+
+		if c.IsUndef {
+			s.w.EmitRecord(constCodeUndef, nil)
+		} else if c.ConstType.Kind == TypeInteger {
+			// Encode signed integers using the LLVM sign-rotating encoding:
+			// positive N → 2*N, negative N → 2*(-N)-1
+			encoded := encodeSignRotated(c.IntValue)
+			s.w.EmitRecord(constCodeInteger, []uint64{encoded})
+		} else {
+			// For now, emit as null for non-integer types.
+			s.w.EmitRecord(constCodeNull, nil)
+		}
+	}
+
+	s.w.ExitBlock()
+}
+
+// encodeSignRotated encodes a signed value using LLVM's sign-rotating
+// encoding: non-negative N maps to 2*N, negative N maps to 2*(-N)-1.
+func encodeSignRotated(v int64) uint64 {
+	if v >= 0 {
+		return uint64(v) << 1
+	}
+	return (uint64(-v) << 1) - 1
+}
+
+// emitMetadata writes the METADATA_BLOCK containing all metadata nodes
+// and named metadata entries.
+func (s *serializer) emitMetadata() {
+	s.w.EnterBlock(metadataBlockID, 3)
+
+	// Emit all metadata nodes.
+	for _, md := range s.mod.Metadata {
+		switch md.Kind {
+		case MDString:
+			s.emitMetadataString(md)
+		case MDValue:
+			s.emitMetadataValue(md)
+		case MDTuple:
+			s.emitMetadataTuple(md)
+		}
+	}
+
+	// Emit named metadata entries.
+	for _, named := range s.mod.NamedMetadata {
+		s.emitNamedMetadata(named)
+	}
+
+	s.w.ExitBlock()
+}
+
+// emitMetadataString writes a METADATA_STRING record.
+func (s *serializer) emitMetadataString(md *MetadataNode) {
+	vals := make([]uint64, len(md.StringValue))
+	for i := 0; i < len(md.StringValue); i++ {
+		vals[i] = uint64(md.StringValue[i])
+	}
+	s.w.EmitRecord(metadataString, vals)
+}
+
+// emitMetadataValue writes a METADATA_VALUE record: [type, value].
+func (s *serializer) emitMetadataValue(md *MetadataNode) {
+	typeID := uint64(0)
+	valueID := uint64(0)
+	if md.ValueType != nil {
+		typeID = uid(md.ValueType.ID)
+	}
+	if md.ValueConst != nil {
+		valueID = uid(md.ValueConst.ValueID)
+	}
+	s.w.EmitRecord(metadataValue, []uint64{typeID, valueID})
+}
+
+// emitMetadataTuple writes a METADATA_NODE record: [n x md_id].
+func (s *serializer) emitMetadataTuple(md *MetadataNode) {
+	vals := make([]uint64, len(md.SubNodes))
+	for i, sub := range md.SubNodes {
+		if sub != nil {
+			// Metadata IDs are offset by 1 (0 means null).
+			vals[i] = uid(sub.ID) + 1
+		}
+		// else: 0 means null operand
+	}
+	s.w.EmitRecord(metadataNode, vals)
+}
+
+// emitNamedMetadata writes METADATA_NAME + METADATA_NAMED_NODE records.
+func (s *serializer) emitNamedMetadata(named *NamedMetadataNode) {
+	// METADATA_NAME: the name as bytes.
+	nameVals := make([]uint64, len(named.Name))
+	for i := 0; i < len(named.Name); i++ {
+		nameVals[i] = uint64(named.Name[i])
+	}
+	s.w.EmitRecord(metadataName, nameVals)
+
+	// METADATA_NAMED_NODE: list of metadata IDs.
+	ids := make([]uint64, len(named.Operands))
+	for i, op := range named.Operands {
+		ids[i] = uid(op.ID)
+	}
+	s.w.EmitRecord(metadataNamedNode, ids)
+}
+
+// emitFunctionBody writes a FUNCTION_BLOCK for one function definition.
+func (s *serializer) emitFunctionBody(fn *Function) {
+	s.w.EnterBlock(functionBlockID, 4)
+
+	// DECLAREBLOCKS: number of basic blocks.
+	s.w.EmitRecord(funcCodeDeclareBlocks, []uint64{uint64(len(fn.BasicBlocks))})
+
+	for _, bb := range fn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			s.emitInstruction(instr)
+		}
+	}
+
+	s.w.ExitBlock()
+}
+
+// emitInstruction writes a single instruction record.
+func (s *serializer) emitInstruction(instr *Instruction) {
+	switch instr.Kind {
+	case InstrRet:
+		if instr.ReturnValue < 0 {
+			// void return: INST_RET with no operands
+			s.w.EmitRecord(funcCodeInstRet, nil)
+		} else {
+			s.w.EmitRecord(funcCodeInstRet, []uint64{uint64(instr.ReturnValue)})
+		}
+	default:
+		// Other instruction types will be implemented in Phase 1.
+		// For now, skip them.
+	}
+}
+
+// emitValueSymtab writes the VALUE_SYMTAB_BLOCK containing function names.
+func (s *serializer) emitValueSymtab() {
+	// Collect entries: we need names for all functions.
+	type entry struct {
+		valueID int
+		name    string
+	}
+	var entries []entry
+	for i := range s.mod.Functions {
+		fn := s.mod.Functions[i]
+		if fn.Name != "" {
+			entries = append(entries, entry{fn.ValueID, fn.Name})
+		}
+	}
+
+	if len(entries) == 0 {
+		return
+	}
+
+	s.w.EnterBlock(valueSymtabID, 4)
+
+	for _, e := range entries {
+		// VST_CODE_ENTRY: [valueid, ...namechar]
+		vals := make([]uint64, 1+len(e.name))
+		vals[0] = uid(e.valueID)
+		for i := 0; i < len(e.name); i++ {
+			vals[1+i] = uint64(e.name[i])
+		}
+		s.w.EmitRecord(vstCodeEntry, vals)
+	}
+
+	s.w.ExitBlock()
+}

--- a/dxil/internal/module/serialize.go
+++ b/dxil/internal/module/serialize.go
@@ -76,6 +76,9 @@ const (
 	funcCodeInstSelect    = 29 // FUNC_CODE_INST_VSELECT
 	funcCodeInstCmp2      = 28 // FUNC_CODE_INST_CMP2
 	funcCodeInstCall      = 34
+	funcCodeInstAlloca    = 19
+	funcCodeInstLoad      = 20
+	funcCodeInstStore     = 44
 )
 
 // Metadata record codes.
@@ -506,6 +509,8 @@ func (s *serializer) globalValueCount() int {
 // emitInstruction writes a single instruction record.
 //
 // Reference: Mesa dxil_module.c emit_instr()
+//
+//nolint:gocyclo,cyclop,funlen // instruction dispatch requires handling all LLVM instruction kinds
 func (s *serializer) emitInstruction(instr *Instruction, currentValueID int) {
 	switch instr.Kind {
 	case InstrRet:
@@ -593,6 +598,42 @@ func (s *serializer) emitInstruction(instr *Instruction, currentValueID int) {
 			opDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always positive
 			idx := uint64(instr.Operands[1])                      //nolint:gosec // index is small positive int
 			s.w.EmitRecord(26, []uint64{opDelta, idx})            // FUNC_CODE_INST_EXTRACTVAL = 26
+		}
+
+	case InstrAlloca:
+		// ALLOCA: [alloc_type_id, size_type_id, size_value_delta, align_flags]
+		// Operands: [allocTypeID, sizeTypeID, sizeValueID, alignFlags]
+		if len(instr.Operands) >= 4 {
+			allocTypeID := uint64(instr.Operands[0]) //nolint:gosec // type ID
+			sizeTypeID := uint64(instr.Operands[1])  //nolint:gosec // type ID
+			sizeID := uint64(instr.Operands[2])      //nolint:gosec // value ID (absolute, not delta)
+			alignFlags := uint64(instr.Operands[3])  //nolint:gosec // alignment flags
+			s.w.EmitRecord(funcCodeInstAlloca, []uint64{allocTypeID, sizeTypeID, sizeID, alignFlags})
+		}
+
+	case InstrLoad:
+		// LOAD: [ptr_delta, type_id, align, is_volatile]
+		// Operands: [ptrValueID, typeID, align, isVolatile]
+		if len(instr.Operands) >= 4 {
+			ptrDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always positive
+			typeID := uint64(instr.Operands[1])                    //nolint:gosec // type ID
+			align := uint64(instr.Operands[2])                     //nolint:gosec // alignment
+			isVolatile := uint64(instr.Operands[3])                //nolint:gosec // 0 or 1
+			s.w.EmitRecord(funcCodeInstLoad, []uint64{ptrDelta, typeID, align, isVolatile})
+		}
+
+	case InstrStore:
+		// STORE: [ptr_delta, value_delta, align, is_volatile]
+		// Operands: [ptrValueID, valueID, align, isVolatile]
+		// Store does not produce a value, but uses currentValueID for deltas.
+		// Mesa uses instr->value.id for delta computation even though store has no result.
+		// In our model, the "virtual" ID is currentValueID (next would-be value).
+		if len(instr.Operands) >= 4 {
+			ptrDelta := uint64(currentValueID - instr.Operands[0])   //nolint:gosec // delta always positive
+			valueDelta := uint64(currentValueID - instr.Operands[1]) //nolint:gosec // delta always positive
+			align := uint64(instr.Operands[2])                       //nolint:gosec // alignment
+			isVolatile := uint64(instr.Operands[3])                  //nolint:gosec // 0 or 1
+			s.w.EmitRecord(funcCodeInstStore, []uint64{ptrDelta, valueDelta, align, isVolatile})
 		}
 	}
 }

--- a/dxil/internal/module/serialize.go
+++ b/dxil/internal/module/serialize.go
@@ -1,6 +1,8 @@
 package module
 
 import (
+	"math"
+
 	"github.com/gogpu/naga/dxil/internal/bitcode"
 )
 
@@ -68,8 +70,11 @@ const (
 	funcCodeDeclareBlocks = 1
 	funcCodeInstBinop     = 2
 	funcCodeInstCast      = 3
+	funcCodeInstGEP       = 9
 	funcCodeInstRet       = 10
 	funcCodeInstBr        = 11
+	funcCodeInstSelect    = 29 // FUNC_CODE_INST_VSELECT
+	funcCodeInstCmp2      = 28 // FUNC_CODE_INST_CMP2
 	funcCodeInstCall      = 34
 )
 
@@ -162,7 +167,7 @@ func (s *serializer) emitModule() {
 	// MODULE_BLOCK.
 	s.w.EnterBlock(moduleBlockID, 3)
 
-	// VERSION record: value=1 means LLVM 3.7 bitcode.
+	// VERSION record: value=1 means relative IDs (LLVM 3.7 bitcode).
 	s.w.EmitRecord(moduleCodeVersion, []uint64{1})
 
 	// TRIPLE record.
@@ -353,8 +358,11 @@ func (s *serializer) emitConstants() {
 			// positive N → 2*N, negative N → 2*(-N)-1
 			encoded := encodeSignRotated(c.IntValue)
 			s.w.EmitRecord(constCodeInteger, []uint64{encoded})
+		} else if c.ConstType.Kind == TypeFloat {
+			// Float constants are stored as IEEE 754 bit patterns.
+			bits := floatBits(c)
+			s.w.EmitRecord(constCodeFloat, []uint64{bits})
 		} else {
-			// For now, emit as null for non-integer types.
 			s.w.EmitRecord(constCodeNull, nil)
 		}
 	}
@@ -369,6 +377,18 @@ func encodeSignRotated(v int64) uint64 {
 		return uint64(v) << 1
 	}
 	return (uint64(-v) << 1) - 1
+}
+
+// floatBits returns the IEEE 754 bit pattern for a float constant.
+// For f16 and f32, returns 32-bit pattern; for f64, returns 64-bit pattern.
+func floatBits(c *Constant) uint64 {
+	switch c.ConstType.FloatBits {
+	case 64:
+		return math.Float64bits(c.FloatValue)
+	default:
+		// f16 and f32 are stored as 32-bit float bit patterns.
+		return uint64(math.Float32bits(float32(c.FloatValue)))
+	}
 }
 
 // emitMetadata writes the METADATA_BLOCK containing all metadata nodes
@@ -449,34 +469,131 @@ func (s *serializer) emitNamedMetadata(named *NamedMetadataNode) {
 }
 
 // emitFunctionBody writes a FUNCTION_BLOCK for one function definition.
+//
+// Within a function body, value IDs are assigned sequentially starting
+// from the next ID after all global values (globals, functions, constants).
+// Operand references use relative encoding: current_value_id - operand_id.
+//
+// Reference: Mesa dxil_module.c emit_function()
 func (s *serializer) emitFunctionBody(fn *Function) {
 	s.w.EnterBlock(functionBlockID, 4)
 
 	// DECLAREBLOCKS: number of basic blocks.
 	s.w.EmitRecord(funcCodeDeclareBlocks, []uint64{uint64(len(fn.BasicBlocks))})
 
+	// The current value ID counter starts after all global values.
+	// Each instruction that produces a value increments this counter.
+	nextValueID := s.globalValueCount()
+
 	for _, bb := range fn.BasicBlocks {
 		for _, instr := range bb.Instructions {
-			s.emitInstruction(instr)
+			s.emitInstruction(instr, nextValueID)
+			if instr.HasValue {
+				nextValueID++
+			}
 		}
 	}
 
 	s.w.ExitBlock()
 }
 
+// globalValueCount returns the total number of global values
+// (global vars + functions + constants).
+func (s *serializer) globalValueCount() int {
+	return len(s.mod.GlobalVars) + len(s.mod.Functions) + len(s.mod.Constants)
+}
+
 // emitInstruction writes a single instruction record.
-func (s *serializer) emitInstruction(instr *Instruction) {
+//
+// Reference: Mesa dxil_module.c emit_instr()
+func (s *serializer) emitInstruction(instr *Instruction, currentValueID int) {
 	switch instr.Kind {
 	case InstrRet:
 		if instr.ReturnValue < 0 {
-			// void return: INST_RET with no operands
 			s.w.EmitRecord(funcCodeInstRet, nil)
 		} else {
-			s.w.EmitRecord(funcCodeInstRet, []uint64{uint64(instr.ReturnValue)})
+			// Relative encoding for return value.
+			s.w.EmitRecord(funcCodeInstRet, []uint64{uint64(currentValueID - instr.ReturnValue)}) //nolint:gosec // delta always positive
 		}
-	default:
-		// Other instruction types will be implemented in Phase 1.
-		// For now, skip them.
+
+	case InstrBinOp:
+		// BINOP: [opval_delta, opval_delta, opcode]
+		// Operands: [lhs, rhs, opcode_as_int]
+		if len(instr.Operands) >= 3 {
+			lhsDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always non-negative
+			rhsDelta := uint64(currentValueID - instr.Operands[1]) //nolint:gosec // delta always non-negative
+			opcode := uint64(instr.Operands[2])                    //nolint:gosec // opcode is small positive int
+			s.w.EmitRecord(funcCodeInstBinop, []uint64{lhsDelta, rhsDelta, opcode})
+		}
+
+	case InstrCmp:
+		// CMP2: [opval_delta, opval_delta, pred]
+		// Operands: [lhs, rhs, pred_as_int]
+		if len(instr.Operands) >= 3 {
+			lhsDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always non-negative
+			rhsDelta := uint64(currentValueID - instr.Operands[1]) //nolint:gosec // delta always non-negative
+			pred := uint64(instr.Operands[2])                      //nolint:gosec // predicate is small positive int
+			s.w.EmitRecord(funcCodeInstCmp2, []uint64{lhsDelta, rhsDelta, pred})
+		}
+
+	case InstrCall:
+		// CALL: [attr, cc, fnty, fn_delta, ...arg_deltas]
+		// With explicit function type (bit 15 set).
+		// Reference: Mesa emit_call(), LLVM 3.7 bitcode format.
+		if instr.CalledFunc != nil {
+			fnDelta := uint64(currentValueID - instr.CalledFunc.ValueID) //nolint:gosec // delta always positive
+
+			// Build record with explicit function type.
+			// cc: bit 15 = explicit function type present.
+			data := make([]uint64, 4, 4+len(instr.Operands))
+			data[0] = 0                                 // paramattr
+			data[1] = 1 << 15                           // calling convention (explicit fn type)
+			data[2] = uid(instr.CalledFunc.FuncType.ID) // function type
+			data[3] = fnDelta                           // callee value delta
+			for _, op := range instr.Operands {
+				data = append(data, uint64(currentValueID-op)) //nolint:gosec // delta always positive
+			}
+			s.w.EmitRecord(funcCodeInstCall, data)
+		}
+
+	case InstrSelect:
+		// VSELECT: [cond_delta, true_delta, false_delta]
+		// Operands: [cond, trueVal, falseVal]
+		if len(instr.Operands) >= 3 {
+			trueDelta := uint64(currentValueID - instr.Operands[1])  //nolint:gosec // delta always positive
+			falseDelta := uint64(currentValueID - instr.Operands[2]) //nolint:gosec // same
+			condDelta := uint64(currentValueID - instr.Operands[0])  //nolint:gosec // same
+			s.w.EmitRecord(funcCodeInstSelect, []uint64{trueDelta, falseDelta, condDelta})
+		}
+
+	case InstrCast:
+		// CAST: [opval_delta, destty, castopc]
+		if len(instr.Operands) >= 2 && instr.ResultType != nil {
+			opDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always positive
+			castOp := uint64(instr.Operands[1])                   //nolint:gosec // cast opcode is small positive int
+			s.w.EmitRecord(funcCodeInstCast, []uint64{opDelta, uid(instr.ResultType.ID), castOp})
+		}
+
+	case InstrBr:
+		// BR: [bb#] for unconditional, [bb#true, bb#false, cond_delta] for conditional
+		if len(instr.Operands) == 1 {
+			s.w.EmitRecord(funcCodeInstBr, []uint64{uint64(instr.Operands[0])}) //nolint:gosec // basic block index
+		} else if len(instr.Operands) >= 3 {
+			condDelta := uint64(currentValueID - instr.Operands[2]) //nolint:gosec // delta always positive
+			s.w.EmitRecord(funcCodeInstBr, []uint64{
+				uint64(instr.Operands[0]), //nolint:gosec // true BB index
+				uint64(instr.Operands[1]), //nolint:gosec // false BB index
+				condDelta,
+			})
+		}
+
+	case InstrExtractVal:
+		// EXTRACTVALUE: [opval_delta, idx]
+		if len(instr.Operands) >= 2 {
+			opDelta := uint64(currentValueID - instr.Operands[0]) //nolint:gosec // delta always positive
+			idx := uint64(instr.Operands[1])                      //nolint:gosec // index is small positive int
+			s.w.EmitRecord(26, []uint64{opDelta, idx})            // FUNC_CODE_INST_EXTRACTVAL = 26
+		}
 	}
 }
 

--- a/ir/registry.go
+++ b/ir/registry.go
@@ -15,9 +15,18 @@ type TypeRegistry struct {
 
 // NewTypeRegistry creates a new type registry for deduplication.
 func NewTypeRegistry() *TypeRegistry {
+	return NewTypeRegistryWithCap(16)
+}
+
+// NewTypeRegistryWithCap creates a new type registry with pre-allocated capacity.
+// Use this when the expected number of types is known to avoid slice regrowth.
+func NewTypeRegistryWithCap(initialCap int) *TypeRegistry {
+	if initialCap < 16 {
+		initialCap = 16
+	}
 	return &TypeRegistry{
-		types:   make([]Type, 0, 16),
-		typeMap: make(map[string]TypeHandle, 16),
+		types:   make([]Type, 0, initialCap),
+		typeMap: make(map[string]TypeHandle, initialCap),
 		keyBuf:  make([]byte, 0, 64),
 	}
 }

--- a/wgsl/lower.go
+++ b/wgsl/lower.go
@@ -135,18 +135,49 @@ func LowerWithSource(ast *Module, source string) (*ir.Module, error) {
 
 // LowerWithWarnings converts a WGSL AST module to Naga IR, returning warnings.
 func LowerWithWarnings(ast *Module, source string) (*LowerResult, error) {
+	// Pre-size module-level slices based on AST declaration counts.
+	// This avoids repeated slice growth during lowering.
+	nFuncs := len(ast.Functions)
+	nStructs := len(ast.Structs)
+	nGlobals := len(ast.GlobalVars)
+	nConsts := len(ast.Constants)
+	nOverrides := len(ast.Overrides)
+	// Types: builtins (~15) + struct types + param/return types.
+	estTypes := 16 // default matches NewTypeRegistry
+	if nStructs > 1 || nFuncs > 2 || nGlobals > 2 {
+		estTypes = nStructs*2 + nFuncs + nGlobals + 16
+	}
+	// Global expressions: roughly 1 per constant/override + 1 per global var init.
+	estGlobalExprs := nConsts + nOverrides + nGlobals + 4
+
+	// Build module with pre-sized slices. Only pre-allocate slices that
+	// have enough expected items to benefit from avoiding regrowth.
+	// For small counts (0-2), nil slice append is fine — Go allocates
+	// on first append with no regrowth for single-element slices.
+	mod := &ir.Module{}
+	if nConsts > 2 {
+		mod.Constants = make([]ir.Constant, 0, nConsts)
+	}
+	if nGlobals > 2 {
+		mod.GlobalVariables = make([]ir.GlobalVariable, 0, nGlobals)
+		mod.GlobalExpressions = make([]ir.Expression, 0, estGlobalExprs)
+	}
+	if nOverrides > 2 {
+		mod.Overrides = make([]ir.Override, 0, nOverrides)
+	}
+
 	l := &Lowerer{
-		module:            &ir.Module{},
+		module:            mod,
 		source:            source,
-		registry:          ir.NewTypeRegistry(),
+		registry:          ir.NewTypeRegistryWithCap(estTypes),
 		types:             make(map[string]ir.TypeHandle, 16),
-		globals:           make(map[string]ir.GlobalVariableHandle, 8),
+		globals:           make(map[string]ir.GlobalVariableHandle, max(nGlobals, 8)),
 		locals:            make(map[string]ir.ExpressionHandle, 16),
-		moduleConstants:   make(map[string]ir.ConstantHandle, 16),
-		moduleOverrides:   make(map[string]ir.OverrideHandle, 8),
+		moduleConstants:   make(map[string]ir.ConstantHandle, max(nConsts, 16)),
+		moduleOverrides:   make(map[string]ir.OverrideHandle, max(nOverrides, 8)),
 		inlineConstants:   make(map[string]ir.LiteralValue, 32),
 		abstractConstants: make(map[string]*abstractConstInfo, 4),
-		functions:         make(map[string]ir.FunctionHandle, len(ast.Functions)),
+		functions:         make(map[string]ir.FunctionHandle, nFuncs),
 		entryPointFuncs:   make(map[string]bool, 4),
 		localDecls:        make(map[string]Span, 16),
 		usedLocals:        make(map[string]bool, 16),
@@ -3671,11 +3702,14 @@ func (l *Lowerer) lowerFunction(f *FunctionDecl) error {
 	l.currentExprIdx = 0
 
 	// Estimate sizes based on function complexity.
+	// Each AST statement typically produces ~3 IR expressions (binary ops, loads, etc.).
+	// Parameters each produce 1 expression. Globals referenced add ~1 each.
 	var bodySize int
 	if f.Body != nil {
-		bodySize = len(f.Body.Statements)
+		bodySize = countStatementsDeep(f.Body)
 	}
-	estExprs := bodySize * 3 // rough: ~3 expressions per statement
+	nParams := len(f.Params)
+	estExprs := bodySize*3 + nParams + len(l.globals) + 4
 	if estExprs < 8 {
 		estExprs = 8
 	}
@@ -3687,10 +3721,17 @@ func (l *Lowerer) lowerFunction(f *FunctionDecl) error {
 		Expressions:      make([]ir.Expression, 0, estExprs),
 		ExpressionTypes:  make([]ir.TypeResolution, 0, estExprs),
 		Body:             make([]ir.Statement, 0, bodySize),
-		NamedExpressions: make(map[ir.ExpressionHandle]string),
+		NamedExpressions: make(map[ir.ExpressionHandle]string, nParams+4),
 	}
 	l.currentFunc = fn
-	l.nonConstExprs = make(map[ir.ExpressionHandle]bool)
+	// Reuse nonConstExprs map — clear instead of reallocating.
+	if l.nonConstExprs == nil {
+		l.nonConstExprs = make(map[ir.ExpressionHandle]bool, 8)
+	} else {
+		for k := range l.nonConstExprs {
+			delete(l.nonConstExprs, k)
+		}
+	}
 
 	// Lower parameters
 	for i, p := range f.Params {
@@ -9589,6 +9630,38 @@ func (l *Lowerer) interruptEmitter(expr ir.Expression) ir.ExpressionHandle {
 	}
 
 	return handle
+}
+
+// countStatementsDeep returns a rough count of statements in a block,
+// recursively counting sub-blocks. Used to estimate IR expression count
+// for slice pre-allocation.
+func countStatementsDeep(block *BlockStmt) int {
+	if block == nil {
+		return 0
+	}
+	count := len(block.Statements)
+	for _, s := range block.Statements {
+		switch stmt := s.(type) {
+		case *IfStmt:
+			count += countStatementsDeep(stmt.Body)
+			if elseBlock, ok := stmt.Else.(*BlockStmt); ok {
+				count += countStatementsDeep(elseBlock)
+			}
+		case *ForStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *WhileStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *LoopStmt:
+			count += countStatementsDeep(stmt.Body)
+		case *SwitchStmt:
+			for _, c := range stmt.Cases {
+				count += countStatementsDeep(c.Body)
+			}
+		case *BlockStmt:
+			count += countStatementsDeep(stmt)
+		}
+	}
+	return count
 }
 
 // ensureBlockReturns ensures every control flow path in a block ends with a Return.

--- a/wgsl/parser.go
+++ b/wgsl/parser.go
@@ -31,7 +31,17 @@ func NewParser(tokens []Token) *Parser {
 
 // Parse parses the tokens and returns a Module AST.
 func (p *Parser) Parse() (*Module, error) {
+	// Estimate declaration counts from token count for pre-allocation.
+	// Only pre-allocate for shaders with enough tokens to benefit from
+	// avoiding slice regrowth. Small shaders (< ~100 tokens) are fine
+	// with nil slice append growth.
+	nTokens := len(p.tokens)
 	module := &Module{}
+	if nTokens > 100 {
+		estDecls := nTokens/20 + 1
+		module.Declarations = make([]Decl, 0, estDecls)
+		module.Functions = make([]*FunctionDecl, 0, estDecls/3+1)
+	}
 
 	for !p.isAtEnd() {
 		// Skip optional semicolons between declarations (e.g., struct Foo { ... };)


### PR DESCRIPTION
## Summary

**First Pure Go DXIL generator.** Direct DXIL generation from naga IR for DX12 Shader Model 6.0. Eliminates FXC/DXC compiler dependency entirely. Zero CGO, zero external dependencies.

**Verified: 2400+ frames at 60 FPS on D3D12 (Intel Iris Xe).** Rust naga has not implemented this (open issue since 2020).

### What's included

- **LLVM 3.7 bitcode writer** — VBR encoding, nested blocks, abbreviation records
- **DXBC container** — DXIL, ISG1, OSG1, PSV0, SFI0, HASH parts with BYPASS hash
- **Full IR → DXIL emitter** — 30+ expression kinds, control flow (basic blocks, loops), local variables, type casts, math intrinsics (30+ functions)
- **Resource bindings** — dx.op.createHandle for CBV/SRV/Sampler, dx.op.sample for textures
- **I/O signatures** — semantic mapping (SV_Position, TEXCOORD, SV_Target)
- **Pipeline state validation** — PSV0 with runtime info

### Stats

- ~12,500 LOC across 29 new files
- 190 tests, all passing
- golangci-lint: 0 issues
- Public API: `dxil.Compile()`, `dxil.DefaultOptions()` (2 symbols)
- All implementation in `dxil/internal/` (bitcode, module, container, emit)

### Known limitations (experimental)

- Vertex + fragment shaders only (compute = Phase 2)
- CBV loads (cbufferLoadLegacy) not yet wired for uniform buffer reads
- First entry point only
- BYPASS hash requires Windows 10 21H2+ or Developer Mode

## Test plan

- [x] `go build ./...` clean
- [x] `golangci-lint run --timeout=5m` — 0 issues
- [x] All 190 DXIL tests pass
- [x] All existing backend tests pass (IR, SPIR-V, MSL, GLSL, HLSL, WGSL)
- [x] DXC dumpbin validates generated DXIL
- [x] D3D12 runtime renders triangle at 60 FPS, 2400+ frames stable
