### PR TITLE
docs: update all public docs for v0.17.0 DXIL backend

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ spirvBytes, err := naga.GenerateSPIRV(module, spirvOpts)
 ## Architecture
 
 ```
-naga/                              ~90K LOC total
+naga/                              ~189K LOC total
 ├── wgsl/              # WGSL frontend (~19.5K LOC)
 │   ├── token.go       # Token types (120+)
 │   ├── lexer.go       # Tokenizer
@@ -239,6 +239,13 @@ naga/                              ~90K LOC total
 │   ├── storage.go     # Buffer/atomic operations
 │   ├── functions.go   # Entry points with semantics
 │   └── keywords.go    # HLSL reserved words
+├── dxil/              # DXIL backend, experimental (~12.5K LOC)
+│   ├── dxil.go        # Public API: Compile(), DefaultOptions()
+│   └── internal/      # All implementation internal
+│       ├── bitcode/   # LLVM 3.7 bit-level writer
+│       ├── module/    # DXIL module + bitcode serialization
+│       ├── container/ # DXBC container (ISG1/OSG1/PSV0/SFI0/HASH)
+│       └── emit/      # naga IR → DXIL lowering
 ├── naga.go            # Public API
 └── cmd/
     ├── nagac/         # CLI compiler

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@
 - **SPIR-V Backend** — Vulkan-compatible bytecode generation (**87/87 exact Rust naga parity**): integer div/mod safety wrappers, image bounds checking (Restrict/ReadZeroSkipWrite), ray query helpers, force loop bounding, workgroup zero-init polyfill, NonUniform decorations, capability-aware instruction emission
 - **MSL Backend** — Metal Shading Language output for macOS/iOS (**91/91 exact Rust naga parity**), vertex pulling transform, external textures, override pipeline constants
 - **GLSL Backend** — OpenGL Shading Language for OpenGL 3.3+, ES 3.0+ (**68/68 exact Rust naga parity**), dead code elimination, ProcessOverrides, image bounds checking
-- **HLSL Backend** — High-Level Shading Language for DirectX 11/12 (**58/58 exact Rust naga parity**)
+- **HLSL Backend** — High-Level Shading Language for DirectX 11/12 (**72/72 exact Rust naga parity**)
 - **DXIL Backend** (experimental) — Direct DXIL generation from naga IR. LLVM 3.7 bitcode with dx.op intrinsics, DXBC container with BYPASS hash. Vertex + fragment shaders, SM 6.0. Eliminates FXC/DXC dependency. `dxil.Compile()` API. ~12K LOC, 190 tests.
 - **Type Conversions** — Scalar constructors `f32(x)`, `u32(y)`, `i32(z)` with correct SPIR-V opcodes
 - **Bitcast** — `bitcast<T>(expr)` for reinterpreting bit patterns between types
@@ -327,7 +327,8 @@ naga/                              ~189K LOC total
 | SPIR-V | ✅ **87/87 Rust parity** | Vulkan |
 | MSL | ✅ **91/91 Rust parity** | Metal (macOS/iOS) |
 | GLSL | ✅ **68/68 Rust parity** | OpenGL 3.3+, ES 3.0+ |
-| HLSL | ✅ **58/58 Rust parity** | DirectX 11/12 |
+| HLSL | ✅ **72/72 Rust parity** | DirectX 11/12 |
+| DXIL | Experimental | DirectX 12 (SM 6.0) |
 
 See [ROADMAP.md](ROADMAP.md) for detailed development plans.
 
@@ -355,7 +356,7 @@ naga is tested against **all 144 reference WGSL shaders** from the [Rust naga](h
 | [gogpu/wgpu](https://github.com/gogpu/wgpu) | Pure Go WebGPU implementation |
 | **gogpu/naga** | **Shader compiler (this repo)** |
 | [gogpu/gg](https://github.com/gogpu/gg) | 2D graphics library |
-| [gogpu/ui](https://github.com/gogpu/ui) | GUI toolkit (planned) |
+| [gogpu/ui](https://github.com/gogpu/ui) | GUI toolkit (22 widgets, M3/Fluent/Cupertino) |
 
 ---
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -166,7 +166,7 @@
 | **v0.16.2** | 2026-04 | HLSL 72/72 parity (100%). ForceLoopBounding architecture fix. +14 shaders. |
 | **v0.16.1** | 2026-04 | **164/164 spirv-val pass (100%).** +45 SPIR-V fixes. |
 | **v0.16.0** | 2026-04 | GLSL TextureMappings + 34 SPIR-V validation fixes (119/164 pass) |
-| **v0.15.0** | 2026-03 | ALL 5 backends 100% Rust parity: IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 58/58. ~90K LOC |
+| **v0.15.0** | 2026-03 | ALL 5 backends 100% Rust parity: IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 72/72. ~90K LOC |
 | v0.14.8 | 2026-03 | GLSL bind group collision fix |
 | v0.14.0 | 2026-02 | Major WGSL coverage: 15/15 Essential reference shaders |
 | **v0.13.1** | 2026-02 | SPIR-V OpArrayLength fix, 68 benchmarks, −32% allocs |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -5,7 +5,7 @@ This document describes the architecture of the naga shader compiler.
 ## Overview
 
 naga is a shader compiler written entirely in Go. It compiles WGSL (WebGPU Shading Language)
-to multiple backend formats (SPIR-V, MSL, GLSL, HLSL) without requiring CGO or external
+to multiple backend formats (SPIR-V, MSL, GLSL, HLSL, DXIL) without requiring CGO or external
 dependencies.
 
 **Core principle: one IR, five backends.**
@@ -59,7 +59,7 @@ dependencies.
 ## Package Structure
 
 ```
-naga/                              ~102K LOC total
+naga/                              ~189K LOC total
 ├── naga.go                        # Public API: Compile, Parse, Lower, Validate, GenerateSPIRV
 ├── wgsl/                          # WGSL frontend (~19.5K LOC)
 │   ├── token.go                   # 120+ token types (incl. f16, i64, u64, f64)
@@ -113,7 +113,7 @@ naga/                              ~102K LOC total
 │   └── keywords.go                # HLSL reserved words
 │
 ├── dxil/                          # DXIL backend (experimental, ~12.5K LOC)
-│   ├── dxil.go                    # Public API: Compile, Options (2 symbols only)
+│   ├── dxil.go                    # Public API: Compile, DefaultOptions, Options, ShaderModel
 │   └── internal/                  # ALL implementation internal
 │       ├── bitcode/               # LLVM 3.7 bit-level writer (VBR, blocks, records)
 │       ├── module/                # In-memory DXIL module + bitcode serialization
@@ -184,7 +184,7 @@ Validates the IR module for correctness:
 
 ### Stage 5: Backend Code Generation
 
-Four backends share the same IR but produce different outputs:
+Five backends share the same IR but produce different outputs:
 
 | Backend | Output | Target | Key Feature |
 |---------|--------|--------|-------------|
@@ -192,6 +192,7 @@ Four backends share the same IR but produce different outputs:
 | **MSL** | Text (C++ dialect) | Metal | Bounds check policies |
 | **GLSL** | Text | OpenGL 3.3+, ES 3.0+ | Version targeting, UBO blocks |
 | **HLSL** | Text | DirectX 11/12 | Shader model selection, semantics |
+| **DXIL** | Binary (LLVM 3.7 bitcode) | DirectX 12 (SM 6.0) | Vector scalarization, dx.op intrinsics |
 
 ## Intermediate Representation
 
@@ -409,7 +410,7 @@ type Backend struct {
 - ProcessOverrides for pipeline constants
 - Image bounds checking
 
-### HLSL (DirectX) — 58/58 Rust parity
+### HLSL (DirectX) — 72/72 Rust parity
 
 - Shader model: SM 5.0 (DX11), SM 6.0+ (DX12)
 - Semantics: `SV_Position`, `SV_DispatchThreadID`, `SV_Target0`
@@ -445,7 +446,7 @@ and eliminates redundant type definitions across all backends.
 |----------|-------|----------|
 | **Snapshot Tests** | 164 | WGSL → 4 backends, 994+ golden output files |
 | **SPIR-V Validation** | 164/164 | All shaders pass spirv-val binary validation (100%) |
-| **Rust Reference** | 5-layer 100% | IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 58/58 |
+| **Rust Reference** | 5-layer 100% | IR 144/144, SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 72/72 |
 | **SPIR-V Unit Tests** | 200+ | Shader, loop, if/else, vello, block model, ray query |
 | **Backend Tests** | 50+ | GLSL, HLSL, MSL per-feature golden tests |
 | **Reachability Tests** | 11 | GLSL dead code elimination |
@@ -467,7 +468,7 @@ suite are included as snapshot tests. Coverage includes:
 | Advanced | overrides, binding-arrays, bounds-check (7 variants), mesh-shader (4 variants) |
 
 All 164 shaders compile to SPIR-V and pass spirv-val binary validation (100%).
-Golden output parity with Rust naga: SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 58/58.
+Golden output parity with Rust naga: SPIR-V 87/87, MSL 91/91, GLSL 68/68, HLSL 72/72.
 
 ## Key Design Decisions
 


### PR DESCRIPTION
Fix HLSL 58→72 parity counts across all docs, add DXIL to architecture tables and status, update LOC counts, fix ui description.