### PR TITLE
fix(spirv): OpCopyLogical on Workgroup load — fix OpFunctionCall type mismatch (v0.17.2)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,19 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.2] - 2026-04-10
+
+### Fixed
+
+- **SPIR-V: OpFunctionCall type mismatch with Workgroup values (BUG-SPIRV-002)** — Regression
+  from v0.17.1 Workgroup fix. Values loaded from `Workgroup` variables had layout-free types
+  that propagated into `OpFunctionCall` arguments, causing type mismatch with decorated function
+  parameters. Fix: insert `OpCopyLogical` immediately after every `OpLoad` from Workgroup
+  (in `emitLoad`, `emitAccess`, `emitAccessIndex`), converting layout-free → decorated at the
+  load point. Guard `maybeCopyLogicalForStore` against double-conversion when value is already
+  decorated. Validated: 164/164 naga shaders + 23/23 gg GPU shaders pass spirv-val v2026.1.
+  (gogpu/wgpu#134, reported by @SideFx via gogpu/ui#67)
+
 ## [0.17.1] - 2026-04-08
 
 ### Fixed

--- a/snapshot/testdata/golden/spv/atomicOps-int64.spvasm
+++ b/snapshot/testdata/golden/spv/atomicOps-int64.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
-; Version: 1.1
+; Version: 1.4
 ; Generator: 0x00000000
-; Bound: 614
+; Bound: 625
 ; Schema: 0
 
                OpCapability Shader
@@ -10,7 +10,7 @@
          OpExtension %_1599492179 %_1599227979 %_1919906931 %_1600481121 %_1717990754 %_1935635045 %_1634889588 %_1667196263 %_1936941420 %_0
          %_1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %_33 "cs_main" %_31
+               OpEntryPoint GLCompute %_33 "cs_main" %_31 %_15 %_18 %_21 %_23 %_26 %_29
                OpExecutionMode %_33 LocalSize 2 1 1
                OpDecorate %_7 ArrayStride 8
                OpMemberDecorate %_8 0 Offset 0
@@ -76,89 +76,89 @@
          %_79 = OpTypePointer Workgroup %_4
          %_83 = OpConstant %_4 1 0
          %_87 = OpConstant %_3 1 0
-         %_95 = OpConstant %_4 1 0
-         %_139 = OpConstant %_5 72
-         %_140 = OpConstant %_3 1 0
-         %_147 = OpConstant %_4 1 0
-         %_154 = OpConstant %_3 1 0
-         %_166 = OpConstant %_4 1 0
-         %_168 = OpConstant %_3 1 0
-         %_173 = OpConstant %_4 1 0
-         %_178 = OpConstant %_3 1 0
-         %_187 = OpConstant %_4 1 0
-         %_190 = OpConstant %_3 1 0
-         %_197 = OpConstant %_4 1 0
-         %_204 = OpConstant %_3 1 0
-         %_216 = OpConstant %_4 1 0
-         %_218 = OpConstant %_3 1 0
-         %_223 = OpConstant %_4 1 0
-         %_228 = OpConstant %_3 1 0
-         %_237 = OpConstant %_4 1 0
-         %_240 = OpConstant %_3 1 0
-         %_247 = OpConstant %_4 1 0
-         %_254 = OpConstant %_3 1 0
-         %_266 = OpConstant %_4 1 0
-         %_268 = OpConstant %_3 1 0
-         %_273 = OpConstant %_4 1 0
-         %_278 = OpConstant %_3 1 0
-         %_287 = OpConstant %_4 1 0
-         %_290 = OpConstant %_3 1 0
-         %_297 = OpConstant %_4 1 0
-         %_304 = OpConstant %_3 1 0
-         %_316 = OpConstant %_4 1 0
-         %_318 = OpConstant %_3 1 0
-         %_323 = OpConstant %_4 1 0
-         %_328 = OpConstant %_3 1 0
-         %_337 = OpConstant %_4 1 0
-         %_340 = OpConstant %_3 1 0
-         %_347 = OpConstant %_4 1 0
-         %_354 = OpConstant %_3 1 0
-         %_366 = OpConstant %_4 1 0
-         %_368 = OpConstant %_3 1 0
-         %_373 = OpConstant %_4 1 0
-         %_378 = OpConstant %_3 1 0
-         %_387 = OpConstant %_4 1 0
-         %_390 = OpConstant %_3 1 0
-         %_397 = OpConstant %_4 1 0
-         %_404 = OpConstant %_3 1 0
-         %_416 = OpConstant %_4 1 0
-         %_418 = OpConstant %_3 1 0
+         %_96 = OpConstant %_4 1 0
+         %_141 = OpConstant %_5 72
+         %_142 = OpConstant %_3 1 0
+         %_149 = OpConstant %_4 1 0
+         %_156 = OpConstant %_3 1 0
+         %_168 = OpConstant %_4 1 0
+         %_170 = OpConstant %_3 1 0
+         %_175 = OpConstant %_4 1 0
+         %_180 = OpConstant %_3 1 0
+         %_190 = OpConstant %_4 1 0
+         %_193 = OpConstant %_3 1 0
+         %_200 = OpConstant %_4 1 0
+         %_207 = OpConstant %_3 1 0
+         %_219 = OpConstant %_4 1 0
+         %_221 = OpConstant %_3 1 0
+         %_226 = OpConstant %_4 1 0
+         %_231 = OpConstant %_3 1 0
+         %_241 = OpConstant %_4 1 0
+         %_244 = OpConstant %_3 1 0
+         %_251 = OpConstant %_4 1 0
+         %_258 = OpConstant %_3 1 0
+         %_270 = OpConstant %_4 1 0
+         %_272 = OpConstant %_3 1 0
+         %_277 = OpConstant %_4 1 0
+         %_282 = OpConstant %_3 1 0
+         %_292 = OpConstant %_4 1 0
+         %_295 = OpConstant %_3 1 0
+         %_302 = OpConstant %_4 1 0
+         %_309 = OpConstant %_3 1 0
+         %_321 = OpConstant %_4 1 0
+         %_323 = OpConstant %_3 1 0
+         %_328 = OpConstant %_4 1 0
+         %_333 = OpConstant %_3 1 0
+         %_343 = OpConstant %_4 1 0
+         %_346 = OpConstant %_3 1 0
+         %_353 = OpConstant %_4 1 0
+         %_360 = OpConstant %_3 1 0
+         %_372 = OpConstant %_4 1 0
+         %_374 = OpConstant %_3 1 0
+         %_379 = OpConstant %_4 1 0
+         %_384 = OpConstant %_3 1 0
+         %_394 = OpConstant %_4 1 0
+         %_397 = OpConstant %_3 1 0
+         %_404 = OpConstant %_4 1 0
+         %_411 = OpConstant %_3 1 0
          %_423 = OpConstant %_4 1 0
-         %_428 = OpConstant %_3 1 0
-         %_437 = OpConstant %_4 1 0
-         %_440 = OpConstant %_3 1 0
-         %_447 = OpConstant %_4 1 0
-         %_454 = OpConstant %_3 1 0
-         %_466 = OpConstant %_4 1 0
-         %_468 = OpConstant %_3 1 0
-         %_473 = OpConstant %_4 1 0
-         %_478 = OpConstant %_3 1 0
-         %_487 = OpConstant %_4 1 0
-         %_490 = OpConstant %_3 1 0
-         %_497 = OpConstant %_4 1 0
-         %_504 = OpConstant %_3 1 0
-         %_516 = OpConstant %_4 1 0
-         %_518 = OpConstant %_3 1 0
-         %_523 = OpConstant %_4 1 0
-         %_528 = OpConstant %_3 1 0
-         %_537 = OpConstant %_4 1 0
-         %_540 = OpConstant %_3 2 0
-         %_541 = OpConstant %_3 1 0
-         %_543 = OpConstant %_5 66
-         %_551 = OpConstant %_4 2 0
-         %_552 = OpConstant %_4 1 0
-         %_561 = OpConstant %_3 2 0
-         %_562 = OpConstant %_3 1 0
-         %_576 = OpConstant %_4 2 0
-         %_577 = OpConstant %_4 1 0
-         %_581 = OpConstant %_3 2 0
-         %_582 = OpConstant %_3 1 0
-         %_589 = OpConstant %_4 2 0
-         %_590 = OpConstant %_4 1 0
-         %_597 = OpConstant %_3 2 0
-         %_598 = OpConstant %_3 1 0
-         %_609 = OpConstant %_4 2 0
-         %_610 = OpConstant %_4 1 0
+         %_425 = OpConstant %_3 1 0
+         %_430 = OpConstant %_4 1 0
+         %_435 = OpConstant %_3 1 0
+         %_445 = OpConstant %_4 1 0
+         %_448 = OpConstant %_3 1 0
+         %_455 = OpConstant %_4 1 0
+         %_462 = OpConstant %_3 1 0
+         %_474 = OpConstant %_4 1 0
+         %_476 = OpConstant %_3 1 0
+         %_481 = OpConstant %_4 1 0
+         %_486 = OpConstant %_3 1 0
+         %_496 = OpConstant %_4 1 0
+         %_499 = OpConstant %_3 1 0
+         %_506 = OpConstant %_4 1 0
+         %_513 = OpConstant %_3 1 0
+         %_525 = OpConstant %_4 1 0
+         %_527 = OpConstant %_3 1 0
+         %_532 = OpConstant %_4 1 0
+         %_537 = OpConstant %_3 1 0
+         %_547 = OpConstant %_4 1 0
+         %_550 = OpConstant %_3 2 0
+         %_551 = OpConstant %_3 1 0
+         %_553 = OpConstant %_5 66
+         %_561 = OpConstant %_4 2 0
+         %_562 = OpConstant %_4 1 0
+         %_571 = OpConstant %_3 2 0
+         %_572 = OpConstant %_3 1 0
+         %_586 = OpConstant %_4 2 0
+         %_587 = OpConstant %_4 1 0
+         %_591 = OpConstant %_3 2 0
+         %_592 = OpConstant %_3 1 0
+         %_599 = OpConstant %_4 2 0
+         %_600 = OpConstant %_4 1 0
+         %_607 = OpConstant %_3 2 0
+         %_608 = OpConstant %_3 1 0
+         %_620 = OpConstant %_4 2 0
+         %_621 = OpConstant %_4 1 0
          %_15 = OpVariable %_14 StorageBuffer
          %_18 = OpVariable %_17 StorageBuffer
          %_21 = OpVariable %_20 StorageBuffer
@@ -218,455 +218,466 @@
                OpStore %_86 %_87
          %_88 = OpAccessChain %_25 %_29 %_53
          %_89 = OpLoad %_24 %_88
-         %_90 = OpAccessChain %_25 %_29 %_53
-         %_91 = OpAccessChain %_79 %_90 %_53
-         %_92 = OpLoad %_4 %_91
-         %_93 = OpAccessChain %_25 %_29 %_53
-         %_94 = OpAccessChain %_79 %_93 %_53
-               OpStore %_94 %_95
+         Op400 %_7 %_90 %_89
+         %_91 = OpAccessChain %_25 %_29 %_53
+         %_92 = OpAccessChain %_79 %_91 %_53
+         %_93 = OpLoad %_4 %_92
+         %_94 = OpAccessChain %_25 %_29 %_53
+         %_95 = OpAccessChain %_79 %_94 %_53
+               OpStore %_95 %_96
          OpControlBarrier %_6 %_6 %_45
-         %_96 = OpAccessChain %_47 %_15 %_48
-         %_97 = OpLoad %_3 %_96
-         %_98 = OpAccessChain %_51 %_18 %_48
-         %_99 = OpAccessChain %_54 %_98 %_53
-         %_100 = OpLoad %_4 %_99
-         %_101 = OpAccessChain %_51 %_18 %_48
-         %_102 = OpAccessChain %_54 %_101 %_53
-         %_103 = OpLoad %_4 %_102
-         %_104 = OpAccessChain %_60 %_21 %_48
-         %_105 = OpAccessChain %_47 %_104 %_48
-         %_106 = OpLoad %_3 %_105
-         %_107 = OpAccessChain %_60 %_21 %_48
-         %_108 = OpAccessChain %_47 %_107 %_48
-         %_109 = OpLoad %_3 %_108
-         %_110 = OpAccessChain %_60 %_21 %_48
-         %_111 = OpAccessChain %_51 %_110 %_53
-         %_112 = OpLoad %_7 %_111
-         %_113 = OpAccessChain %_60 %_21 %_48
-         %_114 = OpAccessChain %_51 %_113 %_53
-         %_115 = OpAccessChain %_54 %_114 %_53
-         %_116 = OpLoad %_4 %_115
-         %_117 = OpAccessChain %_60 %_21 %_48
-         %_118 = OpAccessChain %_51 %_117 %_53
-         %_119 = OpAccessChain %_54 %_118 %_53
-         %_120 = OpLoad %_4 %_119
-         %_121 = OpLoad %_3 %_23
-         %_122 = OpAccessChain %_79 %_26 %_53
-         %_123 = OpLoad %_4 %_122
-         %_124 = OpAccessChain %_79 %_26 %_53
-         %_125 = OpLoad %_4 %_124
-         %_126 = OpAccessChain %_22 %_29 %_48
-         %_127 = OpLoad %_3 %_126
-         %_128 = OpAccessChain %_22 %_29 %_48
-         %_129 = OpLoad %_3 %_128
-         %_130 = OpAccessChain %_25 %_29 %_53
-         %_131 = OpLoad %_24 %_130
-         %_132 = OpAccessChain %_25 %_29 %_53
-         %_133 = OpAccessChain %_79 %_132 %_53
-         %_134 = OpLoad %_4 %_133
-         %_135 = OpAccessChain %_25 %_29 %_53
-         %_136 = OpAccessChain %_79 %_135 %_53
-         %_137 = OpLoad %_4 %_136
+         %_97 = OpAccessChain %_47 %_15 %_48
+         %_98 = OpLoad %_3 %_97
+         %_99 = OpAccessChain %_51 %_18 %_48
+         %_100 = OpAccessChain %_54 %_99 %_53
+         %_101 = OpLoad %_4 %_100
+         %_102 = OpAccessChain %_51 %_18 %_48
+         %_103 = OpAccessChain %_54 %_102 %_53
+         %_104 = OpLoad %_4 %_103
+         %_105 = OpAccessChain %_60 %_21 %_48
+         %_106 = OpAccessChain %_47 %_105 %_48
+         %_107 = OpLoad %_3 %_106
+         %_108 = OpAccessChain %_60 %_21 %_48
+         %_109 = OpAccessChain %_47 %_108 %_48
+         %_110 = OpLoad %_3 %_109
+         %_111 = OpAccessChain %_60 %_21 %_48
+         %_112 = OpAccessChain %_51 %_111 %_53
+         %_113 = OpLoad %_7 %_112
+         %_114 = OpAccessChain %_60 %_21 %_48
+         %_115 = OpAccessChain %_51 %_114 %_53
+         %_116 = OpAccessChain %_54 %_115 %_53
+         %_117 = OpLoad %_4 %_116
+         %_118 = OpAccessChain %_60 %_21 %_48
+         %_119 = OpAccessChain %_51 %_118 %_53
+         %_120 = OpAccessChain %_54 %_119 %_53
+         %_121 = OpLoad %_4 %_120
+         %_122 = OpLoad %_3 %_23
+         %_123 = OpAccessChain %_79 %_26 %_53
+         %_124 = OpLoad %_4 %_123
+         %_125 = OpAccessChain %_79 %_26 %_53
+         %_126 = OpLoad %_4 %_125
+         %_127 = OpAccessChain %_22 %_29 %_48
+         %_128 = OpLoad %_3 %_127
+         %_129 = OpAccessChain %_22 %_29 %_48
+         %_130 = OpLoad %_3 %_129
+         %_131 = OpAccessChain %_25 %_29 %_53
+         %_132 = OpLoad %_24 %_131
+         Op400 %_7 %_133 %_132
+         %_134 = OpAccessChain %_25 %_29 %_53
+         %_135 = OpAccessChain %_79 %_134 %_53
+         %_136 = OpLoad %_4 %_135
+         %_137 = OpAccessChain %_25 %_29 %_53
+         %_138 = OpAccessChain %_79 %_137 %_53
+         %_139 = OpLoad %_4 %_138
          OpControlBarrier %_6 %_6 %_45
-         %_138 = OpAccessChain %_47 %_15 %_48
-         OpAtomicIAdd %_3 %_141 %_138 %_53 %_139 %_140
-         %_142 = OpAccessChain %_51 %_18 %_48
-         %_143 = OpAccessChain %_54 %_142 %_53
-         %_144 = OpLoad %_4 %_143
-         %_145 = OpAccessChain %_51 %_18 %_48
-         %_146 = OpAccessChain %_54 %_145 %_53
-         OpAtomicIAdd %_4 %_148 %_146 %_53 %_139 %_147
-         %_149 = OpAccessChain %_60 %_21 %_48
-         %_150 = OpAccessChain %_47 %_149 %_48
-         %_151 = OpLoad %_3 %_150
-         %_152 = OpAccessChain %_60 %_21 %_48
-         %_153 = OpAccessChain %_47 %_152 %_48
-         OpAtomicIAdd %_3 %_155 %_153 %_53 %_139 %_154
-         %_156 = OpAccessChain %_60 %_21 %_48
-         %_157 = OpAccessChain %_51 %_156 %_53
-         %_158 = OpLoad %_7 %_157
-         %_159 = OpAccessChain %_60 %_21 %_48
-         %_160 = OpAccessChain %_51 %_159 %_53
-         %_161 = OpAccessChain %_54 %_160 %_53
-         %_162 = OpLoad %_4 %_161
-         %_163 = OpAccessChain %_60 %_21 %_48
-         %_164 = OpAccessChain %_51 %_163 %_53
-         %_165 = OpAccessChain %_54 %_164 %_53
-         OpAtomicIAdd %_4 %_167 %_165 %_53 %_139 %_166
-         OpAtomicIAdd %_3 %_169 %_23 %_53 %_139 %_168
-         %_170 = OpAccessChain %_79 %_26 %_53
-         %_171 = OpLoad %_4 %_170
+         %_140 = OpAccessChain %_47 %_15 %_48
+         OpAtomicIAdd %_3 %_143 %_140 %_53 %_141 %_142
+         %_144 = OpAccessChain %_51 %_18 %_48
+         %_145 = OpAccessChain %_54 %_144 %_53
+         %_146 = OpLoad %_4 %_145
+         %_147 = OpAccessChain %_51 %_18 %_48
+         %_148 = OpAccessChain %_54 %_147 %_53
+         OpAtomicIAdd %_4 %_150 %_148 %_53 %_141 %_149
+         %_151 = OpAccessChain %_60 %_21 %_48
+         %_152 = OpAccessChain %_47 %_151 %_48
+         %_153 = OpLoad %_3 %_152
+         %_154 = OpAccessChain %_60 %_21 %_48
+         %_155 = OpAccessChain %_47 %_154 %_48
+         OpAtomicIAdd %_3 %_157 %_155 %_53 %_141 %_156
+         %_158 = OpAccessChain %_60 %_21 %_48
+         %_159 = OpAccessChain %_51 %_158 %_53
+         %_160 = OpLoad %_7 %_159
+         %_161 = OpAccessChain %_60 %_21 %_48
+         %_162 = OpAccessChain %_51 %_161 %_53
+         %_163 = OpAccessChain %_54 %_162 %_53
+         %_164 = OpLoad %_4 %_163
+         %_165 = OpAccessChain %_60 %_21 %_48
+         %_166 = OpAccessChain %_51 %_165 %_53
+         %_167 = OpAccessChain %_54 %_166 %_53
+         OpAtomicIAdd %_4 %_169 %_167 %_53 %_141 %_168
+         OpAtomicIAdd %_3 %_171 %_23 %_53 %_141 %_170
          %_172 = OpAccessChain %_79 %_26 %_53
-         OpAtomicIAdd %_4 %_174 %_172 %_53 %_139 %_173
-         %_175 = OpAccessChain %_22 %_29 %_48
-         %_176 = OpLoad %_3 %_175
+         %_173 = OpLoad %_4 %_172
+         %_174 = OpAccessChain %_79 %_26 %_53
+         OpAtomicIAdd %_4 %_176 %_174 %_53 %_141 %_175
          %_177 = OpAccessChain %_22 %_29 %_48
-         OpAtomicIAdd %_3 %_179 %_177 %_53 %_139 %_178
-         %_180 = OpAccessChain %_25 %_29 %_53
-         %_181 = OpLoad %_24 %_180
+         %_178 = OpLoad %_3 %_177
+         %_179 = OpAccessChain %_22 %_29 %_48
+         OpAtomicIAdd %_3 %_181 %_179 %_53 %_141 %_180
          %_182 = OpAccessChain %_25 %_29 %_53
-         %_183 = OpAccessChain %_79 %_182 %_53
-         %_184 = OpLoad %_4 %_183
+         %_183 = OpLoad %_24 %_182
+         Op400 %_7 %_184 %_183
          %_185 = OpAccessChain %_25 %_29 %_53
          %_186 = OpAccessChain %_79 %_185 %_53
-         OpAtomicIAdd %_4 %_188 %_186 %_53 %_139 %_187
+         %_187 = OpLoad %_4 %_186
+         %_188 = OpAccessChain %_25 %_29 %_53
+         %_189 = OpAccessChain %_79 %_188 %_53
+         OpAtomicIAdd %_4 %_191 %_189 %_53 %_141 %_190
          OpControlBarrier %_6 %_6 %_45
-         %_189 = OpAccessChain %_47 %_15 %_48
-         OpAtomicISub %_3 %_191 %_189 %_53 %_139 %_190
-         %_192 = OpAccessChain %_51 %_18 %_48
-         %_193 = OpAccessChain %_54 %_192 %_53
-         %_194 = OpLoad %_4 %_193
+         %_192 = OpAccessChain %_47 %_15 %_48
+         OpAtomicISub %_3 %_194 %_192 %_53 %_141 %_193
          %_195 = OpAccessChain %_51 %_18 %_48
          %_196 = OpAccessChain %_54 %_195 %_53
-         OpAtomicISub %_4 %_198 %_196 %_53 %_139 %_197
-         %_199 = OpAccessChain %_60 %_21 %_48
-         %_200 = OpAccessChain %_47 %_199 %_48
-         %_201 = OpLoad %_3 %_200
+         %_197 = OpLoad %_4 %_196
+         %_198 = OpAccessChain %_51 %_18 %_48
+         %_199 = OpAccessChain %_54 %_198 %_53
+         OpAtomicISub %_4 %_201 %_199 %_53 %_141 %_200
          %_202 = OpAccessChain %_60 %_21 %_48
          %_203 = OpAccessChain %_47 %_202 %_48
-         OpAtomicISub %_3 %_205 %_203 %_53 %_139 %_204
-         %_206 = OpAccessChain %_60 %_21 %_48
-         %_207 = OpAccessChain %_51 %_206 %_53
-         %_208 = OpLoad %_7 %_207
+         %_204 = OpLoad %_3 %_203
+         %_205 = OpAccessChain %_60 %_21 %_48
+         %_206 = OpAccessChain %_47 %_205 %_48
+         OpAtomicISub %_3 %_208 %_206 %_53 %_141 %_207
          %_209 = OpAccessChain %_60 %_21 %_48
          %_210 = OpAccessChain %_51 %_209 %_53
-         %_211 = OpAccessChain %_54 %_210 %_53
-         %_212 = OpLoad %_4 %_211
-         %_213 = OpAccessChain %_60 %_21 %_48
-         %_214 = OpAccessChain %_51 %_213 %_53
-         %_215 = OpAccessChain %_54 %_214 %_53
-         OpAtomicISub %_4 %_217 %_215 %_53 %_139 %_216
-         OpAtomicISub %_3 %_219 %_23 %_53 %_139 %_218
-         %_220 = OpAccessChain %_79 %_26 %_53
-         %_221 = OpLoad %_4 %_220
-         %_222 = OpAccessChain %_79 %_26 %_53
-         OpAtomicISub %_4 %_224 %_222 %_53 %_139 %_223
-         %_225 = OpAccessChain %_22 %_29 %_48
-         %_226 = OpLoad %_3 %_225
-         %_227 = OpAccessChain %_22 %_29 %_48
-         OpAtomicISub %_3 %_229 %_227 %_53 %_139 %_228
-         %_230 = OpAccessChain %_25 %_29 %_53
-         %_231 = OpLoad %_24 %_230
-         %_232 = OpAccessChain %_25 %_29 %_53
-         %_233 = OpAccessChain %_79 %_232 %_53
-         %_234 = OpLoad %_4 %_233
-         %_235 = OpAccessChain %_25 %_29 %_53
-         %_236 = OpAccessChain %_79 %_235 %_53
-         OpAtomicISub %_4 %_238 %_236 %_53 %_139 %_237
+         %_211 = OpLoad %_7 %_210
+         %_212 = OpAccessChain %_60 %_21 %_48
+         %_213 = OpAccessChain %_51 %_212 %_53
+         %_214 = OpAccessChain %_54 %_213 %_53
+         %_215 = OpLoad %_4 %_214
+         %_216 = OpAccessChain %_60 %_21 %_48
+         %_217 = OpAccessChain %_51 %_216 %_53
+         %_218 = OpAccessChain %_54 %_217 %_53
+         OpAtomicISub %_4 %_220 %_218 %_53 %_141 %_219
+         OpAtomicISub %_3 %_222 %_23 %_53 %_141 %_221
+         %_223 = OpAccessChain %_79 %_26 %_53
+         %_224 = OpLoad %_4 %_223
+         %_225 = OpAccessChain %_79 %_26 %_53
+         OpAtomicISub %_4 %_227 %_225 %_53 %_141 %_226
+         %_228 = OpAccessChain %_22 %_29 %_48
+         %_229 = OpLoad %_3 %_228
+         %_230 = OpAccessChain %_22 %_29 %_48
+         OpAtomicISub %_3 %_232 %_230 %_53 %_141 %_231
+         %_233 = OpAccessChain %_25 %_29 %_53
+         %_234 = OpLoad %_24 %_233
+         Op400 %_7 %_235 %_234
+         %_236 = OpAccessChain %_25 %_29 %_53
+         %_237 = OpAccessChain %_79 %_236 %_53
+         %_238 = OpLoad %_4 %_237
+         %_239 = OpAccessChain %_25 %_29 %_53
+         %_240 = OpAccessChain %_79 %_239 %_53
+         OpAtomicISub %_4 %_242 %_240 %_53 %_141 %_241
          OpControlBarrier %_6 %_6 %_45
-         %_239 = OpAccessChain %_47 %_15 %_48
-         OpAtomicUMax %_3 %_241 %_239 %_53 %_139 %_240
-         %_242 = OpAccessChain %_51 %_18 %_48
-         %_243 = OpAccessChain %_54 %_242 %_53
-         %_244 = OpLoad %_4 %_243
-         %_245 = OpAccessChain %_51 %_18 %_48
-         %_246 = OpAccessChain %_54 %_245 %_53
-         OpAtomicSMax %_4 %_248 %_246 %_53 %_139 %_247
-         %_249 = OpAccessChain %_60 %_21 %_48
-         %_250 = OpAccessChain %_47 %_249 %_48
-         %_251 = OpLoad %_3 %_250
-         %_252 = OpAccessChain %_60 %_21 %_48
-         %_253 = OpAccessChain %_47 %_252 %_48
-         OpAtomicUMax %_3 %_255 %_253 %_53 %_139 %_254
+         %_243 = OpAccessChain %_47 %_15 %_48
+         OpAtomicUMax %_3 %_245 %_243 %_53 %_141 %_244
+         %_246 = OpAccessChain %_51 %_18 %_48
+         %_247 = OpAccessChain %_54 %_246 %_53
+         %_248 = OpLoad %_4 %_247
+         %_249 = OpAccessChain %_51 %_18 %_48
+         %_250 = OpAccessChain %_54 %_249 %_53
+         OpAtomicSMax %_4 %_252 %_250 %_53 %_141 %_251
+         %_253 = OpAccessChain %_60 %_21 %_48
+         %_254 = OpAccessChain %_47 %_253 %_48
+         %_255 = OpLoad %_3 %_254
          %_256 = OpAccessChain %_60 %_21 %_48
-         %_257 = OpAccessChain %_51 %_256 %_53
-         %_258 = OpLoad %_7 %_257
-         %_259 = OpAccessChain %_60 %_21 %_48
-         %_260 = OpAccessChain %_51 %_259 %_53
-         %_261 = OpAccessChain %_54 %_260 %_53
-         %_262 = OpLoad %_4 %_261
+         %_257 = OpAccessChain %_47 %_256 %_48
+         OpAtomicUMax %_3 %_259 %_257 %_53 %_141 %_258
+         %_260 = OpAccessChain %_60 %_21 %_48
+         %_261 = OpAccessChain %_51 %_260 %_53
+         %_262 = OpLoad %_7 %_261
          %_263 = OpAccessChain %_60 %_21 %_48
          %_264 = OpAccessChain %_51 %_263 %_53
          %_265 = OpAccessChain %_54 %_264 %_53
-         OpAtomicSMax %_4 %_267 %_265 %_53 %_139 %_266
-         OpAtomicUMax %_3 %_269 %_23 %_53 %_139 %_268
-         %_270 = OpAccessChain %_79 %_26 %_53
-         %_271 = OpLoad %_4 %_270
-         %_272 = OpAccessChain %_79 %_26 %_53
-         OpAtomicSMax %_4 %_274 %_272 %_53 %_139 %_273
-         %_275 = OpAccessChain %_22 %_29 %_48
-         %_276 = OpLoad %_3 %_275
-         %_277 = OpAccessChain %_22 %_29 %_48
-         OpAtomicUMax %_3 %_279 %_277 %_53 %_139 %_278
-         %_280 = OpAccessChain %_25 %_29 %_53
-         %_281 = OpLoad %_24 %_280
-         %_282 = OpAccessChain %_25 %_29 %_53
-         %_283 = OpAccessChain %_79 %_282 %_53
-         %_284 = OpLoad %_4 %_283
-         %_285 = OpAccessChain %_25 %_29 %_53
-         %_286 = OpAccessChain %_79 %_285 %_53
-         OpAtomicSMax %_4 %_288 %_286 %_53 %_139 %_287
+         %_266 = OpLoad %_4 %_265
+         %_267 = OpAccessChain %_60 %_21 %_48
+         %_268 = OpAccessChain %_51 %_267 %_53
+         %_269 = OpAccessChain %_54 %_268 %_53
+         OpAtomicSMax %_4 %_271 %_269 %_53 %_141 %_270
+         OpAtomicUMax %_3 %_273 %_23 %_53 %_141 %_272
+         %_274 = OpAccessChain %_79 %_26 %_53
+         %_275 = OpLoad %_4 %_274
+         %_276 = OpAccessChain %_79 %_26 %_53
+         OpAtomicSMax %_4 %_278 %_276 %_53 %_141 %_277
+         %_279 = OpAccessChain %_22 %_29 %_48
+         %_280 = OpLoad %_3 %_279
+         %_281 = OpAccessChain %_22 %_29 %_48
+         OpAtomicUMax %_3 %_283 %_281 %_53 %_141 %_282
+         %_284 = OpAccessChain %_25 %_29 %_53
+         %_285 = OpLoad %_24 %_284
+         Op400 %_7 %_286 %_285
+         %_287 = OpAccessChain %_25 %_29 %_53
+         %_288 = OpAccessChain %_79 %_287 %_53
+         %_289 = OpLoad %_4 %_288
+         %_290 = OpAccessChain %_25 %_29 %_53
+         %_291 = OpAccessChain %_79 %_290 %_53
+         OpAtomicSMax %_4 %_293 %_291 %_53 %_141 %_292
          OpControlBarrier %_6 %_6 %_45
-         %_289 = OpAccessChain %_47 %_15 %_48
-         OpAtomicUMin %_3 %_291 %_289 %_53 %_139 %_290
-         %_292 = OpAccessChain %_51 %_18 %_48
-         %_293 = OpAccessChain %_54 %_292 %_53
-         %_294 = OpLoad %_4 %_293
-         %_295 = OpAccessChain %_51 %_18 %_48
-         %_296 = OpAccessChain %_54 %_295 %_53
-         OpAtomicSMin %_4 %_298 %_296 %_53 %_139 %_297
-         %_299 = OpAccessChain %_60 %_21 %_48
-         %_300 = OpAccessChain %_47 %_299 %_48
-         %_301 = OpLoad %_3 %_300
-         %_302 = OpAccessChain %_60 %_21 %_48
-         %_303 = OpAccessChain %_47 %_302 %_48
-         OpAtomicUMin %_3 %_305 %_303 %_53 %_139 %_304
-         %_306 = OpAccessChain %_60 %_21 %_48
-         %_307 = OpAccessChain %_51 %_306 %_53
-         %_308 = OpLoad %_7 %_307
-         %_309 = OpAccessChain %_60 %_21 %_48
-         %_310 = OpAccessChain %_51 %_309 %_53
-         %_311 = OpAccessChain %_54 %_310 %_53
-         %_312 = OpLoad %_4 %_311
-         %_313 = OpAccessChain %_60 %_21 %_48
-         %_314 = OpAccessChain %_51 %_313 %_53
-         %_315 = OpAccessChain %_54 %_314 %_53
-         OpAtomicSMin %_4 %_317 %_315 %_53 %_139 %_316
-         OpAtomicUMin %_3 %_319 %_23 %_53 %_139 %_318
-         %_320 = OpAccessChain %_79 %_26 %_53
-         %_321 = OpLoad %_4 %_320
-         %_322 = OpAccessChain %_79 %_26 %_53
-         OpAtomicSMin %_4 %_324 %_322 %_53 %_139 %_323
-         %_325 = OpAccessChain %_22 %_29 %_48
-         %_326 = OpLoad %_3 %_325
-         %_327 = OpAccessChain %_22 %_29 %_48
-         OpAtomicUMin %_3 %_329 %_327 %_53 %_139 %_328
-         %_330 = OpAccessChain %_25 %_29 %_53
-         %_331 = OpLoad %_24 %_330
-         %_332 = OpAccessChain %_25 %_29 %_53
-         %_333 = OpAccessChain %_79 %_332 %_53
-         %_334 = OpLoad %_4 %_333
+         %_294 = OpAccessChain %_47 %_15 %_48
+         OpAtomicUMin %_3 %_296 %_294 %_53 %_141 %_295
+         %_297 = OpAccessChain %_51 %_18 %_48
+         %_298 = OpAccessChain %_54 %_297 %_53
+         %_299 = OpLoad %_4 %_298
+         %_300 = OpAccessChain %_51 %_18 %_48
+         %_301 = OpAccessChain %_54 %_300 %_53
+         OpAtomicSMin %_4 %_303 %_301 %_53 %_141 %_302
+         %_304 = OpAccessChain %_60 %_21 %_48
+         %_305 = OpAccessChain %_47 %_304 %_48
+         %_306 = OpLoad %_3 %_305
+         %_307 = OpAccessChain %_60 %_21 %_48
+         %_308 = OpAccessChain %_47 %_307 %_48
+         OpAtomicUMin %_3 %_310 %_308 %_53 %_141 %_309
+         %_311 = OpAccessChain %_60 %_21 %_48
+         %_312 = OpAccessChain %_51 %_311 %_53
+         %_313 = OpLoad %_7 %_312
+         %_314 = OpAccessChain %_60 %_21 %_48
+         %_315 = OpAccessChain %_51 %_314 %_53
+         %_316 = OpAccessChain %_54 %_315 %_53
+         %_317 = OpLoad %_4 %_316
+         %_318 = OpAccessChain %_60 %_21 %_48
+         %_319 = OpAccessChain %_51 %_318 %_53
+         %_320 = OpAccessChain %_54 %_319 %_53
+         OpAtomicSMin %_4 %_322 %_320 %_53 %_141 %_321
+         OpAtomicUMin %_3 %_324 %_23 %_53 %_141 %_323
+         %_325 = OpAccessChain %_79 %_26 %_53
+         %_326 = OpLoad %_4 %_325
+         %_327 = OpAccessChain %_79 %_26 %_53
+         OpAtomicSMin %_4 %_329 %_327 %_53 %_141 %_328
+         %_330 = OpAccessChain %_22 %_29 %_48
+         %_331 = OpLoad %_3 %_330
+         %_332 = OpAccessChain %_22 %_29 %_48
+         OpAtomicUMin %_3 %_334 %_332 %_53 %_141 %_333
          %_335 = OpAccessChain %_25 %_29 %_53
-         %_336 = OpAccessChain %_79 %_335 %_53
-         OpAtomicSMin %_4 %_338 %_336 %_53 %_139 %_337
+         %_336 = OpLoad %_24 %_335
+         Op400 %_7 %_337 %_336
+         %_338 = OpAccessChain %_25 %_29 %_53
+         %_339 = OpAccessChain %_79 %_338 %_53
+         %_340 = OpLoad %_4 %_339
+         %_341 = OpAccessChain %_25 %_29 %_53
+         %_342 = OpAccessChain %_79 %_341 %_53
+         OpAtomicSMin %_4 %_344 %_342 %_53 %_141 %_343
          OpControlBarrier %_6 %_6 %_45
-         %_339 = OpAccessChain %_47 %_15 %_48
-         OpAtomicAnd %_3 %_341 %_339 %_53 %_139 %_340
-         %_342 = OpAccessChain %_51 %_18 %_48
-         %_343 = OpAccessChain %_54 %_342 %_53
-         %_344 = OpLoad %_4 %_343
-         %_345 = OpAccessChain %_51 %_18 %_48
-         %_346 = OpAccessChain %_54 %_345 %_53
-         OpAtomicAnd %_4 %_348 %_346 %_53 %_139 %_347
-         %_349 = OpAccessChain %_60 %_21 %_48
-         %_350 = OpAccessChain %_47 %_349 %_48
-         %_351 = OpLoad %_3 %_350
-         %_352 = OpAccessChain %_60 %_21 %_48
-         %_353 = OpAccessChain %_47 %_352 %_48
-         OpAtomicAnd %_3 %_355 %_353 %_53 %_139 %_354
-         %_356 = OpAccessChain %_60 %_21 %_48
-         %_357 = OpAccessChain %_51 %_356 %_53
-         %_358 = OpLoad %_7 %_357
-         %_359 = OpAccessChain %_60 %_21 %_48
-         %_360 = OpAccessChain %_51 %_359 %_53
-         %_361 = OpAccessChain %_54 %_360 %_53
-         %_362 = OpLoad %_4 %_361
-         %_363 = OpAccessChain %_60 %_21 %_48
-         %_364 = OpAccessChain %_51 %_363 %_53
-         %_365 = OpAccessChain %_54 %_364 %_53
-         OpAtomicAnd %_4 %_367 %_365 %_53 %_139 %_366
-         OpAtomicAnd %_3 %_369 %_23 %_53 %_139 %_368
-         %_370 = OpAccessChain %_79 %_26 %_53
-         %_371 = OpLoad %_4 %_370
-         %_372 = OpAccessChain %_79 %_26 %_53
-         OpAtomicAnd %_4 %_374 %_372 %_53 %_139 %_373
-         %_375 = OpAccessChain %_22 %_29 %_48
-         %_376 = OpLoad %_3 %_375
-         %_377 = OpAccessChain %_22 %_29 %_48
-         OpAtomicAnd %_3 %_379 %_377 %_53 %_139 %_378
-         %_380 = OpAccessChain %_25 %_29 %_53
-         %_381 = OpLoad %_24 %_380
-         %_382 = OpAccessChain %_25 %_29 %_53
-         %_383 = OpAccessChain %_79 %_382 %_53
-         %_384 = OpLoad %_4 %_383
-         %_385 = OpAccessChain %_25 %_29 %_53
-         %_386 = OpAccessChain %_79 %_385 %_53
-         OpAtomicAnd %_4 %_388 %_386 %_53 %_139 %_387
+         %_345 = OpAccessChain %_47 %_15 %_48
+         OpAtomicAnd %_3 %_347 %_345 %_53 %_141 %_346
+         %_348 = OpAccessChain %_51 %_18 %_48
+         %_349 = OpAccessChain %_54 %_348 %_53
+         %_350 = OpLoad %_4 %_349
+         %_351 = OpAccessChain %_51 %_18 %_48
+         %_352 = OpAccessChain %_54 %_351 %_53
+         OpAtomicAnd %_4 %_354 %_352 %_53 %_141 %_353
+         %_355 = OpAccessChain %_60 %_21 %_48
+         %_356 = OpAccessChain %_47 %_355 %_48
+         %_357 = OpLoad %_3 %_356
+         %_358 = OpAccessChain %_60 %_21 %_48
+         %_359 = OpAccessChain %_47 %_358 %_48
+         OpAtomicAnd %_3 %_361 %_359 %_53 %_141 %_360
+         %_362 = OpAccessChain %_60 %_21 %_48
+         %_363 = OpAccessChain %_51 %_362 %_53
+         %_364 = OpLoad %_7 %_363
+         %_365 = OpAccessChain %_60 %_21 %_48
+         %_366 = OpAccessChain %_51 %_365 %_53
+         %_367 = OpAccessChain %_54 %_366 %_53
+         %_368 = OpLoad %_4 %_367
+         %_369 = OpAccessChain %_60 %_21 %_48
+         %_370 = OpAccessChain %_51 %_369 %_53
+         %_371 = OpAccessChain %_54 %_370 %_53
+         OpAtomicAnd %_4 %_373 %_371 %_53 %_141 %_372
+         OpAtomicAnd %_3 %_375 %_23 %_53 %_141 %_374
+         %_376 = OpAccessChain %_79 %_26 %_53
+         %_377 = OpLoad %_4 %_376
+         %_378 = OpAccessChain %_79 %_26 %_53
+         OpAtomicAnd %_4 %_380 %_378 %_53 %_141 %_379
+         %_381 = OpAccessChain %_22 %_29 %_48
+         %_382 = OpLoad %_3 %_381
+         %_383 = OpAccessChain %_22 %_29 %_48
+         OpAtomicAnd %_3 %_385 %_383 %_53 %_141 %_384
+         %_386 = OpAccessChain %_25 %_29 %_53
+         %_387 = OpLoad %_24 %_386
+         Op400 %_7 %_388 %_387
+         %_389 = OpAccessChain %_25 %_29 %_53
+         %_390 = OpAccessChain %_79 %_389 %_53
+         %_391 = OpLoad %_4 %_390
+         %_392 = OpAccessChain %_25 %_29 %_53
+         %_393 = OpAccessChain %_79 %_392 %_53
+         OpAtomicAnd %_4 %_395 %_393 %_53 %_141 %_394
          OpControlBarrier %_6 %_6 %_45
-         %_389 = OpAccessChain %_47 %_15 %_48
-         OpAtomicOr %_3 %_391 %_389 %_53 %_139 %_390
-         %_392 = OpAccessChain %_51 %_18 %_48
-         %_393 = OpAccessChain %_54 %_392 %_53
-         %_394 = OpLoad %_4 %_393
-         %_395 = OpAccessChain %_51 %_18 %_48
-         %_396 = OpAccessChain %_54 %_395 %_53
-         OpAtomicOr %_4 %_398 %_396 %_53 %_139 %_397
-         %_399 = OpAccessChain %_60 %_21 %_48
-         %_400 = OpAccessChain %_47 %_399 %_48
-         %_401 = OpLoad %_3 %_400
-         %_402 = OpAccessChain %_60 %_21 %_48
-         %_403 = OpAccessChain %_47 %_402 %_48
-         OpAtomicOr %_3 %_405 %_403 %_53 %_139 %_404
+         %_396 = OpAccessChain %_47 %_15 %_48
+         OpAtomicOr %_3 %_398 %_396 %_53 %_141 %_397
+         %_399 = OpAccessChain %_51 %_18 %_48
+         %_400 = OpAccessChain %_54 %_399 %_53
+         %_401 = OpLoad %_4 %_400
+         %_402 = OpAccessChain %_51 %_18 %_48
+         %_403 = OpAccessChain %_54 %_402 %_53
+         OpAtomicOr %_4 %_405 %_403 %_53 %_141 %_404
          %_406 = OpAccessChain %_60 %_21 %_48
-         %_407 = OpAccessChain %_51 %_406 %_53
-         %_408 = OpLoad %_7 %_407
+         %_407 = OpAccessChain %_47 %_406 %_48
+         %_408 = OpLoad %_3 %_407
          %_409 = OpAccessChain %_60 %_21 %_48
-         %_410 = OpAccessChain %_51 %_409 %_53
-         %_411 = OpAccessChain %_54 %_410 %_53
-         %_412 = OpLoad %_4 %_411
+         %_410 = OpAccessChain %_47 %_409 %_48
+         OpAtomicOr %_3 %_412 %_410 %_53 %_141 %_411
          %_413 = OpAccessChain %_60 %_21 %_48
          %_414 = OpAccessChain %_51 %_413 %_53
-         %_415 = OpAccessChain %_54 %_414 %_53
-         OpAtomicOr %_4 %_417 %_415 %_53 %_139 %_416
-         OpAtomicOr %_3 %_419 %_23 %_53 %_139 %_418
-         %_420 = OpAccessChain %_79 %_26 %_53
-         %_421 = OpLoad %_4 %_420
-         %_422 = OpAccessChain %_79 %_26 %_53
-         OpAtomicOr %_4 %_424 %_422 %_53 %_139 %_423
-         %_425 = OpAccessChain %_22 %_29 %_48
-         %_426 = OpLoad %_3 %_425
-         %_427 = OpAccessChain %_22 %_29 %_48
-         OpAtomicOr %_3 %_429 %_427 %_53 %_139 %_428
-         %_430 = OpAccessChain %_25 %_29 %_53
-         %_431 = OpLoad %_24 %_430
-         %_432 = OpAccessChain %_25 %_29 %_53
-         %_433 = OpAccessChain %_79 %_432 %_53
-         %_434 = OpLoad %_4 %_433
-         %_435 = OpAccessChain %_25 %_29 %_53
-         %_436 = OpAccessChain %_79 %_435 %_53
-         OpAtomicOr %_4 %_438 %_436 %_53 %_139 %_437
+         %_415 = OpLoad %_7 %_414
+         %_416 = OpAccessChain %_60 %_21 %_48
+         %_417 = OpAccessChain %_51 %_416 %_53
+         %_418 = OpAccessChain %_54 %_417 %_53
+         %_419 = OpLoad %_4 %_418
+         %_420 = OpAccessChain %_60 %_21 %_48
+         %_421 = OpAccessChain %_51 %_420 %_53
+         %_422 = OpAccessChain %_54 %_421 %_53
+         OpAtomicOr %_4 %_424 %_422 %_53 %_141 %_423
+         OpAtomicOr %_3 %_426 %_23 %_53 %_141 %_425
+         %_427 = OpAccessChain %_79 %_26 %_53
+         %_428 = OpLoad %_4 %_427
+         %_429 = OpAccessChain %_79 %_26 %_53
+         OpAtomicOr %_4 %_431 %_429 %_53 %_141 %_430
+         %_432 = OpAccessChain %_22 %_29 %_48
+         %_433 = OpLoad %_3 %_432
+         %_434 = OpAccessChain %_22 %_29 %_48
+         OpAtomicOr %_3 %_436 %_434 %_53 %_141 %_435
+         %_437 = OpAccessChain %_25 %_29 %_53
+         %_438 = OpLoad %_24 %_437
+         Op400 %_7 %_439 %_438
+         %_440 = OpAccessChain %_25 %_29 %_53
+         %_441 = OpAccessChain %_79 %_440 %_53
+         %_442 = OpLoad %_4 %_441
+         %_443 = OpAccessChain %_25 %_29 %_53
+         %_444 = OpAccessChain %_79 %_443 %_53
+         OpAtomicOr %_4 %_446 %_444 %_53 %_141 %_445
          OpControlBarrier %_6 %_6 %_45
-         %_439 = OpAccessChain %_47 %_15 %_48
-         OpAtomicXor %_3 %_441 %_439 %_53 %_139 %_440
-         %_442 = OpAccessChain %_51 %_18 %_48
-         %_443 = OpAccessChain %_54 %_442 %_53
-         %_444 = OpLoad %_4 %_443
-         %_445 = OpAccessChain %_51 %_18 %_48
-         %_446 = OpAccessChain %_54 %_445 %_53
-         OpAtomicXor %_4 %_448 %_446 %_53 %_139 %_447
-         %_449 = OpAccessChain %_60 %_21 %_48
-         %_450 = OpAccessChain %_47 %_449 %_48
-         %_451 = OpLoad %_3 %_450
-         %_452 = OpAccessChain %_60 %_21 %_48
-         %_453 = OpAccessChain %_47 %_452 %_48
-         OpAtomicXor %_3 %_455 %_453 %_53 %_139 %_454
-         %_456 = OpAccessChain %_60 %_21 %_48
-         %_457 = OpAccessChain %_51 %_456 %_53
-         %_458 = OpLoad %_7 %_457
-         %_459 = OpAccessChain %_60 %_21 %_48
-         %_460 = OpAccessChain %_51 %_459 %_53
-         %_461 = OpAccessChain %_54 %_460 %_53
-         %_462 = OpLoad %_4 %_461
-         %_463 = OpAccessChain %_60 %_21 %_48
-         %_464 = OpAccessChain %_51 %_463 %_53
-         %_465 = OpAccessChain %_54 %_464 %_53
-         OpAtomicXor %_4 %_467 %_465 %_53 %_139 %_466
-         OpAtomicXor %_3 %_469 %_23 %_53 %_139 %_468
-         %_470 = OpAccessChain %_79 %_26 %_53
-         %_471 = OpLoad %_4 %_470
-         %_472 = OpAccessChain %_79 %_26 %_53
-         OpAtomicXor %_4 %_474 %_472 %_53 %_139 %_473
-         %_475 = OpAccessChain %_22 %_29 %_48
-         %_476 = OpLoad %_3 %_475
-         %_477 = OpAccessChain %_22 %_29 %_48
-         OpAtomicXor %_3 %_479 %_477 %_53 %_139 %_478
-         %_480 = OpAccessChain %_25 %_29 %_53
-         %_481 = OpLoad %_24 %_480
-         %_482 = OpAccessChain %_25 %_29 %_53
-         %_483 = OpAccessChain %_79 %_482 %_53
-         %_484 = OpLoad %_4 %_483
-         %_485 = OpAccessChain %_25 %_29 %_53
-         %_486 = OpAccessChain %_79 %_485 %_53
-         OpAtomicXor %_4 %_488 %_486 %_53 %_139 %_487
-         %_489 = OpAccessChain %_47 %_15 %_48
-         OpAtomicExchange %_3 %_491 %_489 %_53 %_139 %_490
-         %_492 = OpAccessChain %_51 %_18 %_48
-         %_493 = OpAccessChain %_54 %_492 %_53
-         %_494 = OpLoad %_4 %_493
-         %_495 = OpAccessChain %_51 %_18 %_48
-         %_496 = OpAccessChain %_54 %_495 %_53
-         OpAtomicExchange %_4 %_498 %_496 %_53 %_139 %_497
-         %_499 = OpAccessChain %_60 %_21 %_48
-         %_500 = OpAccessChain %_47 %_499 %_48
-         %_501 = OpLoad %_3 %_500
-         %_502 = OpAccessChain %_60 %_21 %_48
-         %_503 = OpAccessChain %_47 %_502 %_48
-         OpAtomicExchange %_3 %_505 %_503 %_53 %_139 %_504
-         %_506 = OpAccessChain %_60 %_21 %_48
-         %_507 = OpAccessChain %_51 %_506 %_53
-         %_508 = OpLoad %_7 %_507
-         %_509 = OpAccessChain %_60 %_21 %_48
-         %_510 = OpAccessChain %_51 %_509 %_53
-         %_511 = OpAccessChain %_54 %_510 %_53
-         %_512 = OpLoad %_4 %_511
-         %_513 = OpAccessChain %_60 %_21 %_48
-         %_514 = OpAccessChain %_51 %_513 %_53
-         %_515 = OpAccessChain %_54 %_514 %_53
-         OpAtomicExchange %_4 %_517 %_515 %_53 %_139 %_516
-         OpAtomicExchange %_3 %_519 %_23 %_53 %_139 %_518
-         %_520 = OpAccessChain %_79 %_26 %_53
+         %_447 = OpAccessChain %_47 %_15 %_48
+         OpAtomicXor %_3 %_449 %_447 %_53 %_141 %_448
+         %_450 = OpAccessChain %_51 %_18 %_48
+         %_451 = OpAccessChain %_54 %_450 %_53
+         %_452 = OpLoad %_4 %_451
+         %_453 = OpAccessChain %_51 %_18 %_48
+         %_454 = OpAccessChain %_54 %_453 %_53
+         OpAtomicXor %_4 %_456 %_454 %_53 %_141 %_455
+         %_457 = OpAccessChain %_60 %_21 %_48
+         %_458 = OpAccessChain %_47 %_457 %_48
+         %_459 = OpLoad %_3 %_458
+         %_460 = OpAccessChain %_60 %_21 %_48
+         %_461 = OpAccessChain %_47 %_460 %_48
+         OpAtomicXor %_3 %_463 %_461 %_53 %_141 %_462
+         %_464 = OpAccessChain %_60 %_21 %_48
+         %_465 = OpAccessChain %_51 %_464 %_53
+         %_466 = OpLoad %_7 %_465
+         %_467 = OpAccessChain %_60 %_21 %_48
+         %_468 = OpAccessChain %_51 %_467 %_53
+         %_469 = OpAccessChain %_54 %_468 %_53
+         %_470 = OpLoad %_4 %_469
+         %_471 = OpAccessChain %_60 %_21 %_48
+         %_472 = OpAccessChain %_51 %_471 %_53
+         %_473 = OpAccessChain %_54 %_472 %_53
+         OpAtomicXor %_4 %_475 %_473 %_53 %_141 %_474
+         OpAtomicXor %_3 %_477 %_23 %_53 %_141 %_476
+         %_478 = OpAccessChain %_79 %_26 %_53
+         %_479 = OpLoad %_4 %_478
+         %_480 = OpAccessChain %_79 %_26 %_53
+         OpAtomicXor %_4 %_482 %_480 %_53 %_141 %_481
+         %_483 = OpAccessChain %_22 %_29 %_48
+         %_484 = OpLoad %_3 %_483
+         %_485 = OpAccessChain %_22 %_29 %_48
+         OpAtomicXor %_3 %_487 %_485 %_53 %_141 %_486
+         %_488 = OpAccessChain %_25 %_29 %_53
+         %_489 = OpLoad %_24 %_488
+         Op400 %_7 %_490 %_489
+         %_491 = OpAccessChain %_25 %_29 %_53
+         %_492 = OpAccessChain %_79 %_491 %_53
+         %_493 = OpLoad %_4 %_492
+         %_494 = OpAccessChain %_25 %_29 %_53
+         %_495 = OpAccessChain %_79 %_494 %_53
+         OpAtomicXor %_4 %_497 %_495 %_53 %_141 %_496
+         %_498 = OpAccessChain %_47 %_15 %_48
+         OpAtomicExchange %_3 %_500 %_498 %_53 %_141 %_499
+         %_501 = OpAccessChain %_51 %_18 %_48
+         %_502 = OpAccessChain %_54 %_501 %_53
+         %_503 = OpLoad %_4 %_502
+         %_504 = OpAccessChain %_51 %_18 %_48
+         %_505 = OpAccessChain %_54 %_504 %_53
+         OpAtomicExchange %_4 %_507 %_505 %_53 %_141 %_506
+         %_508 = OpAccessChain %_60 %_21 %_48
+         %_509 = OpAccessChain %_47 %_508 %_48
+         %_510 = OpLoad %_3 %_509
+         %_511 = OpAccessChain %_60 %_21 %_48
+         %_512 = OpAccessChain %_47 %_511 %_48
+         OpAtomicExchange %_3 %_514 %_512 %_53 %_141 %_513
+         %_515 = OpAccessChain %_60 %_21 %_48
+         %_516 = OpAccessChain %_51 %_515 %_53
+         %_517 = OpLoad %_7 %_516
+         %_518 = OpAccessChain %_60 %_21 %_48
+         %_519 = OpAccessChain %_51 %_518 %_53
+         %_520 = OpAccessChain %_54 %_519 %_53
          %_521 = OpLoad %_4 %_520
-         %_522 = OpAccessChain %_79 %_26 %_53
-         OpAtomicExchange %_4 %_524 %_522 %_53 %_139 %_523
-         %_525 = OpAccessChain %_22 %_29 %_48
-         %_526 = OpLoad %_3 %_525
-         %_527 = OpAccessChain %_22 %_29 %_48
-         OpAtomicExchange %_3 %_529 %_527 %_53 %_139 %_528
-         %_530 = OpAccessChain %_25 %_29 %_53
-         %_531 = OpLoad %_24 %_530
-         %_532 = OpAccessChain %_25 %_29 %_53
-         %_533 = OpAccessChain %_79 %_532 %_53
-         %_534 = OpLoad %_4 %_533
-         %_535 = OpAccessChain %_25 %_29 %_53
-         %_536 = OpAccessChain %_79 %_535 %_53
-         OpAtomicExchange %_4 %_538 %_536 %_53 %_139 %_537
-         %_539 = OpAccessChain %_47 %_15 %_48
-         OpAtomicCompareExchange %_3 %_542 %_539 %_53 %_139 %_543 %_540 %_541
-         %_544 = OpSignBitSet %_10 %_542 %_541
-         %_545 = OpCompositeConstruct %_11 %_542 %_544
-         %_546 = OpAccessChain %_51 %_18 %_48
-         %_547 = OpAccessChain %_54 %_546 %_53
-         %_548 = OpLoad %_4 %_547
-         %_549 = OpAccessChain %_51 %_18 %_48
-         %_550 = OpAccessChain %_54 %_549 %_53
-         OpAtomicCompareExchange %_4 %_553 %_550 %_53 %_139 %_543 %_551 %_552
-         %_554 = OpSignBitSet %_10 %_553 %_552
-         %_555 = OpCompositeConstruct %_12 %_553 %_554
-         %_556 = OpAccessChain %_60 %_21 %_48
-         %_557 = OpAccessChain %_47 %_556 %_48
-         %_558 = OpLoad %_3 %_557
-         %_559 = OpAccessChain %_60 %_21 %_48
-         %_560 = OpAccessChain %_47 %_559 %_48
-         OpAtomicCompareExchange %_3 %_563 %_560 %_53 %_139 %_543 %_561 %_562
+         %_522 = OpAccessChain %_60 %_21 %_48
+         %_523 = OpAccessChain %_51 %_522 %_53
+         %_524 = OpAccessChain %_54 %_523 %_53
+         OpAtomicExchange %_4 %_526 %_524 %_53 %_141 %_525
+         OpAtomicExchange %_3 %_528 %_23 %_53 %_141 %_527
+         %_529 = OpAccessChain %_79 %_26 %_53
+         %_530 = OpLoad %_4 %_529
+         %_531 = OpAccessChain %_79 %_26 %_53
+         OpAtomicExchange %_4 %_533 %_531 %_53 %_141 %_532
+         %_534 = OpAccessChain %_22 %_29 %_48
+         %_535 = OpLoad %_3 %_534
+         %_536 = OpAccessChain %_22 %_29 %_48
+         OpAtomicExchange %_3 %_538 %_536 %_53 %_141 %_537
+         %_539 = OpAccessChain %_25 %_29 %_53
+         %_540 = OpLoad %_24 %_539
+         Op400 %_7 %_541 %_540
+         %_542 = OpAccessChain %_25 %_29 %_53
+         %_543 = OpAccessChain %_79 %_542 %_53
+         %_544 = OpLoad %_4 %_543
+         %_545 = OpAccessChain %_25 %_29 %_53
+         %_546 = OpAccessChain %_79 %_545 %_53
+         OpAtomicExchange %_4 %_548 %_546 %_53 %_141 %_547
+         %_549 = OpAccessChain %_47 %_15 %_48
+         OpAtomicCompareExchange %_3 %_552 %_549 %_53 %_141 %_553 %_550 %_551
+         %_554 = OpSignBitSet %_10 %_552 %_551
+         %_555 = OpCompositeConstruct %_11 %_552 %_554
+         %_556 = OpAccessChain %_51 %_18 %_48
+         %_557 = OpAccessChain %_54 %_556 %_53
+         %_558 = OpLoad %_4 %_557
+         %_559 = OpAccessChain %_51 %_18 %_48
+         %_560 = OpAccessChain %_54 %_559 %_53
+         OpAtomicCompareExchange %_4 %_563 %_560 %_53 %_141 %_553 %_561 %_562
          %_564 = OpSignBitSet %_10 %_563 %_562
-         %_565 = OpCompositeConstruct %_11 %_563 %_564
+         %_565 = OpCompositeConstruct %_12 %_563 %_564
          %_566 = OpAccessChain %_60 %_21 %_48
-         %_567 = OpAccessChain %_51 %_566 %_53
-         %_568 = OpLoad %_7 %_567
+         %_567 = OpAccessChain %_47 %_566 %_48
+         %_568 = OpLoad %_3 %_567
          %_569 = OpAccessChain %_60 %_21 %_48
-         %_570 = OpAccessChain %_51 %_569 %_53
-         %_571 = OpAccessChain %_54 %_570 %_53
-         %_572 = OpLoad %_4 %_571
-         %_573 = OpAccessChain %_60 %_21 %_48
-         %_574 = OpAccessChain %_51 %_573 %_53
-         %_575 = OpAccessChain %_54 %_574 %_53
-         OpAtomicCompareExchange %_4 %_578 %_575 %_53 %_139 %_543 %_576 %_577
-         %_579 = OpSignBitSet %_10 %_578 %_577
-         %_580 = OpCompositeConstruct %_12 %_578 %_579
-         OpAtomicCompareExchange %_3 %_583 %_23 %_53 %_139 %_543 %_581 %_582
-         %_584 = OpSignBitSet %_10 %_583 %_582
-         %_585 = OpCompositeConstruct %_11 %_583 %_584
-         %_586 = OpAccessChain %_79 %_26 %_53
-         %_587 = OpLoad %_4 %_586
-         %_588 = OpAccessChain %_79 %_26 %_53
-         OpAtomicCompareExchange %_4 %_591 %_588 %_53 %_139 %_543 %_589 %_590
-         %_592 = OpSignBitSet %_10 %_591 %_590
-         %_593 = OpCompositeConstruct %_12 %_591 %_592
-         %_594 = OpAccessChain %_22 %_29 %_48
-         %_595 = OpLoad %_3 %_594
-         %_596 = OpAccessChain %_22 %_29 %_48
-         OpAtomicCompareExchange %_3 %_599 %_596 %_53 %_139 %_543 %_597 %_598
-         %_600 = OpSignBitSet %_10 %_599 %_598
-         %_601 = OpCompositeConstruct %_11 %_599 %_600
-         %_602 = OpAccessChain %_25 %_29 %_53
-         %_603 = OpLoad %_24 %_602
-         %_604 = OpAccessChain %_25 %_29 %_53
-         %_605 = OpAccessChain %_79 %_604 %_53
-         %_606 = OpLoad %_4 %_605
-         %_607 = OpAccessChain %_25 %_29 %_53
-         %_608 = OpAccessChain %_79 %_607 %_53
-         OpAtomicCompareExchange %_4 %_611 %_608 %_53 %_139 %_543 %_609 %_610
-         %_612 = OpSignBitSet %_10 %_611 %_610
-         %_613 = OpCompositeConstruct %_12 %_611 %_612
+         %_570 = OpAccessChain %_47 %_569 %_48
+         OpAtomicCompareExchange %_3 %_573 %_570 %_53 %_141 %_553 %_571 %_572
+         %_574 = OpSignBitSet %_10 %_573 %_572
+         %_575 = OpCompositeConstruct %_11 %_573 %_574
+         %_576 = OpAccessChain %_60 %_21 %_48
+         %_577 = OpAccessChain %_51 %_576 %_53
+         %_578 = OpLoad %_7 %_577
+         %_579 = OpAccessChain %_60 %_21 %_48
+         %_580 = OpAccessChain %_51 %_579 %_53
+         %_581 = OpAccessChain %_54 %_580 %_53
+         %_582 = OpLoad %_4 %_581
+         %_583 = OpAccessChain %_60 %_21 %_48
+         %_584 = OpAccessChain %_51 %_583 %_53
+         %_585 = OpAccessChain %_54 %_584 %_53
+         OpAtomicCompareExchange %_4 %_588 %_585 %_53 %_141 %_553 %_586 %_587
+         %_589 = OpSignBitSet %_10 %_588 %_587
+         %_590 = OpCompositeConstruct %_12 %_588 %_589
+         OpAtomicCompareExchange %_3 %_593 %_23 %_53 %_141 %_553 %_591 %_592
+         %_594 = OpSignBitSet %_10 %_593 %_592
+         %_595 = OpCompositeConstruct %_11 %_593 %_594
+         %_596 = OpAccessChain %_79 %_26 %_53
+         %_597 = OpLoad %_4 %_596
+         %_598 = OpAccessChain %_79 %_26 %_53
+         OpAtomicCompareExchange %_4 %_601 %_598 %_53 %_141 %_553 %_599 %_600
+         %_602 = OpSignBitSet %_10 %_601 %_600
+         %_603 = OpCompositeConstruct %_12 %_601 %_602
+         %_604 = OpAccessChain %_22 %_29 %_48
+         %_605 = OpLoad %_3 %_604
+         %_606 = OpAccessChain %_22 %_29 %_48
+         OpAtomicCompareExchange %_3 %_609 %_606 %_53 %_141 %_553 %_607 %_608
+         %_610 = OpSignBitSet %_10 %_609 %_608
+         %_611 = OpCompositeConstruct %_11 %_609 %_610
+         %_612 = OpAccessChain %_25 %_29 %_53
+         %_613 = OpLoad %_24 %_612
+         Op400 %_7 %_614 %_613
+         %_615 = OpAccessChain %_25 %_29 %_53
+         %_616 = OpAccessChain %_79 %_615 %_53
+         %_617 = OpLoad %_4 %_616
+         %_618 = OpAccessChain %_25 %_29 %_53
+         %_619 = OpAccessChain %_79 %_618 %_53
+         OpAtomicCompareExchange %_4 %_622 %_619 %_53 %_141 %_553 %_620 %_621
+         %_623 = OpSignBitSet %_10 %_622 %_621
+         %_624 = OpCompositeConstruct %_12 %_622 %_623
                OpReturn
                OpFunctionEnd

--- a/snapshot/testdata/golden/spv/atomicOps.spvasm
+++ b/snapshot/testdata/golden/spv/atomicOps.spvasm
@@ -1,14 +1,14 @@
 ; SPIR-V
-; Version: 1.1
+; Version: 1.4
 ; Generator: 0x00000000
-; Bound: 527
+; Bound: 538
 ; Schema: 0
 
                OpCapability Shader
          OpExtension %_1599492179 %_1599227979 %_1919906931 %_1600481121 %_1717990754 %_1935635045 %_1634889588 %_1667196263 %_1936941420 %_0
          %_1 = OpExtInstImport "GLSL.std.450"
                OpMemoryModel Logical GLSL450
-               OpEntryPoint GLCompute %_32 "cs_main" %_30
+               OpEntryPoint GLCompute %_32 "cs_main" %_30 %_14 %_17 %_20 %_22 %_25 %_28
                OpExecutionMode %_32 LocalSize 2 1 1
                OpDecorate %_6 ArrayStride 4
                OpMemberDecorate %_7 0 Offset 0
@@ -67,9 +67,9 @@
          %_57 = OpConstant %_4 1
          %_58 = OpTypePointer StorageBuffer %_7
          %_74 = OpTypePointer Workgroup %_4
-         %_131 = OpConstant %_3 72
-         %_469 = OpConstant %_3 66
-         %_477 = OpConstant %_4 2
+         %_133 = OpConstant %_3 72
+         %_479 = OpConstant %_3 66
+         %_487 = OpConstant %_4 2
          %_14 = OpVariable %_13 StorageBuffer
          %_17 = OpVariable %_16 StorageBuffer
          %_20 = OpVariable %_19 StorageBuffer
@@ -129,455 +129,466 @@
                OpStore %_80 %_49
          %_81 = OpAccessChain %_24 %_28 %_49
          %_82 = OpLoad %_23 %_81
-         %_83 = OpAccessChain %_24 %_28 %_49
-         %_84 = OpAccessChain %_74 %_83 %_49
-         %_85 = OpLoad %_4 %_84
-         %_86 = OpAccessChain %_24 %_28 %_49
-         %_87 = OpAccessChain %_74 %_86 %_49
-               OpStore %_87 %_57
+         Op400 %_6 %_83 %_82
+         %_84 = OpAccessChain %_24 %_28 %_49
+         %_85 = OpAccessChain %_74 %_84 %_49
+         %_86 = OpLoad %_4 %_85
+         %_87 = OpAccessChain %_24 %_28 %_49
+         %_88 = OpAccessChain %_74 %_87 %_49
+               OpStore %_88 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_88 = OpAccessChain %_46 %_14 %_47
-         %_89 = OpLoad %_3 %_88
-         %_90 = OpAccessChain %_50 %_17 %_47
-         %_91 = OpAccessChain %_52 %_90 %_49
-         %_92 = OpLoad %_4 %_91
-         %_93 = OpAccessChain %_50 %_17 %_47
-         %_94 = OpAccessChain %_52 %_93 %_49
-         %_95 = OpLoad %_4 %_94
-         %_96 = OpAccessChain %_58 %_20 %_47
-         %_97 = OpAccessChain %_46 %_96 %_47
-         %_98 = OpLoad %_3 %_97
-         %_99 = OpAccessChain %_58 %_20 %_47
-         %_100 = OpAccessChain %_46 %_99 %_47
-         %_101 = OpLoad %_3 %_100
-         %_102 = OpAccessChain %_58 %_20 %_47
-         %_103 = OpAccessChain %_50 %_102 %_49
-         %_104 = OpLoad %_6 %_103
-         %_105 = OpAccessChain %_58 %_20 %_47
-         %_106 = OpAccessChain %_50 %_105 %_49
-         %_107 = OpAccessChain %_52 %_106 %_49
-         %_108 = OpLoad %_4 %_107
-         %_109 = OpAccessChain %_58 %_20 %_47
-         %_110 = OpAccessChain %_50 %_109 %_49
-         %_111 = OpAccessChain %_52 %_110 %_49
-         %_112 = OpLoad %_4 %_111
-         %_113 = OpLoad %_3 %_22
-         %_114 = OpAccessChain %_74 %_25 %_49
-         %_115 = OpLoad %_4 %_114
-         %_116 = OpAccessChain %_74 %_25 %_49
-         %_117 = OpLoad %_4 %_116
-         %_118 = OpAccessChain %_21 %_28 %_47
-         %_119 = OpLoad %_3 %_118
-         %_120 = OpAccessChain %_21 %_28 %_47
-         %_121 = OpLoad %_3 %_120
-         %_122 = OpAccessChain %_24 %_28 %_49
-         %_123 = OpLoad %_23 %_122
-         %_124 = OpAccessChain %_24 %_28 %_49
-         %_125 = OpAccessChain %_74 %_124 %_49
-         %_126 = OpLoad %_4 %_125
-         %_127 = OpAccessChain %_24 %_28 %_49
-         %_128 = OpAccessChain %_74 %_127 %_49
-         %_129 = OpLoad %_4 %_128
+         %_89 = OpAccessChain %_46 %_14 %_47
+         %_90 = OpLoad %_3 %_89
+         %_91 = OpAccessChain %_50 %_17 %_47
+         %_92 = OpAccessChain %_52 %_91 %_49
+         %_93 = OpLoad %_4 %_92
+         %_94 = OpAccessChain %_50 %_17 %_47
+         %_95 = OpAccessChain %_52 %_94 %_49
+         %_96 = OpLoad %_4 %_95
+         %_97 = OpAccessChain %_58 %_20 %_47
+         %_98 = OpAccessChain %_46 %_97 %_47
+         %_99 = OpLoad %_3 %_98
+         %_100 = OpAccessChain %_58 %_20 %_47
+         %_101 = OpAccessChain %_46 %_100 %_47
+         %_102 = OpLoad %_3 %_101
+         %_103 = OpAccessChain %_58 %_20 %_47
+         %_104 = OpAccessChain %_50 %_103 %_49
+         %_105 = OpLoad %_6 %_104
+         %_106 = OpAccessChain %_58 %_20 %_47
+         %_107 = OpAccessChain %_50 %_106 %_49
+         %_108 = OpAccessChain %_52 %_107 %_49
+         %_109 = OpLoad %_4 %_108
+         %_110 = OpAccessChain %_58 %_20 %_47
+         %_111 = OpAccessChain %_50 %_110 %_49
+         %_112 = OpAccessChain %_52 %_111 %_49
+         %_113 = OpLoad %_4 %_112
+         %_114 = OpLoad %_3 %_22
+         %_115 = OpAccessChain %_74 %_25 %_49
+         %_116 = OpLoad %_4 %_115
+         %_117 = OpAccessChain %_74 %_25 %_49
+         %_118 = OpLoad %_4 %_117
+         %_119 = OpAccessChain %_21 %_28 %_47
+         %_120 = OpLoad %_3 %_119
+         %_121 = OpAccessChain %_21 %_28 %_47
+         %_122 = OpLoad %_3 %_121
+         %_123 = OpAccessChain %_24 %_28 %_49
+         %_124 = OpLoad %_23 %_123
+         Op400 %_6 %_125 %_124
+         %_126 = OpAccessChain %_24 %_28 %_49
+         %_127 = OpAccessChain %_74 %_126 %_49
+         %_128 = OpLoad %_4 %_127
+         %_129 = OpAccessChain %_24 %_28 %_49
+         %_130 = OpAccessChain %_74 %_129 %_49
+         %_131 = OpLoad %_4 %_130
          OpControlBarrier %_5 %_5 %_44
-         %_130 = OpAccessChain %_46 %_14 %_47
-         OpAtomicIAdd %_3 %_132 %_130 %_49 %_131 %_49
-         %_133 = OpAccessChain %_50 %_17 %_47
-         %_134 = OpAccessChain %_52 %_133 %_49
-         %_135 = OpLoad %_4 %_134
-         %_136 = OpAccessChain %_50 %_17 %_47
-         %_137 = OpAccessChain %_52 %_136 %_49
-         OpAtomicIAdd %_4 %_138 %_137 %_49 %_131 %_57
-         %_139 = OpAccessChain %_58 %_20 %_47
-         %_140 = OpAccessChain %_46 %_139 %_47
-         %_141 = OpLoad %_3 %_140
-         %_142 = OpAccessChain %_58 %_20 %_47
-         %_143 = OpAccessChain %_46 %_142 %_47
-         OpAtomicIAdd %_3 %_144 %_143 %_49 %_131 %_49
-         %_145 = OpAccessChain %_58 %_20 %_47
-         %_146 = OpAccessChain %_50 %_145 %_49
-         %_147 = OpLoad %_6 %_146
-         %_148 = OpAccessChain %_58 %_20 %_47
-         %_149 = OpAccessChain %_50 %_148 %_49
-         %_150 = OpAccessChain %_52 %_149 %_49
-         %_151 = OpLoad %_4 %_150
-         %_152 = OpAccessChain %_58 %_20 %_47
-         %_153 = OpAccessChain %_50 %_152 %_49
-         %_154 = OpAccessChain %_52 %_153 %_49
-         OpAtomicIAdd %_4 %_155 %_154 %_49 %_131 %_57
-         OpAtomicIAdd %_3 %_156 %_22 %_49 %_131 %_49
-         %_157 = OpAccessChain %_74 %_25 %_49
-         %_158 = OpLoad %_4 %_157
+         %_132 = OpAccessChain %_46 %_14 %_47
+         OpAtomicIAdd %_3 %_134 %_132 %_49 %_133 %_49
+         %_135 = OpAccessChain %_50 %_17 %_47
+         %_136 = OpAccessChain %_52 %_135 %_49
+         %_137 = OpLoad %_4 %_136
+         %_138 = OpAccessChain %_50 %_17 %_47
+         %_139 = OpAccessChain %_52 %_138 %_49
+         OpAtomicIAdd %_4 %_140 %_139 %_49 %_133 %_57
+         %_141 = OpAccessChain %_58 %_20 %_47
+         %_142 = OpAccessChain %_46 %_141 %_47
+         %_143 = OpLoad %_3 %_142
+         %_144 = OpAccessChain %_58 %_20 %_47
+         %_145 = OpAccessChain %_46 %_144 %_47
+         OpAtomicIAdd %_3 %_146 %_145 %_49 %_133 %_49
+         %_147 = OpAccessChain %_58 %_20 %_47
+         %_148 = OpAccessChain %_50 %_147 %_49
+         %_149 = OpLoad %_6 %_148
+         %_150 = OpAccessChain %_58 %_20 %_47
+         %_151 = OpAccessChain %_50 %_150 %_49
+         %_152 = OpAccessChain %_52 %_151 %_49
+         %_153 = OpLoad %_4 %_152
+         %_154 = OpAccessChain %_58 %_20 %_47
+         %_155 = OpAccessChain %_50 %_154 %_49
+         %_156 = OpAccessChain %_52 %_155 %_49
+         OpAtomicIAdd %_4 %_157 %_156 %_49 %_133 %_57
+         OpAtomicIAdd %_3 %_158 %_22 %_49 %_133 %_49
          %_159 = OpAccessChain %_74 %_25 %_49
-         OpAtomicIAdd %_4 %_160 %_159 %_49 %_131 %_57
-         %_161 = OpAccessChain %_21 %_28 %_47
-         %_162 = OpLoad %_3 %_161
+         %_160 = OpLoad %_4 %_159
+         %_161 = OpAccessChain %_74 %_25 %_49
+         OpAtomicIAdd %_4 %_162 %_161 %_49 %_133 %_57
          %_163 = OpAccessChain %_21 %_28 %_47
-         OpAtomicIAdd %_3 %_164 %_163 %_49 %_131 %_49
-         %_165 = OpAccessChain %_24 %_28 %_49
-         %_166 = OpLoad %_23 %_165
+         %_164 = OpLoad %_3 %_163
+         %_165 = OpAccessChain %_21 %_28 %_47
+         OpAtomicIAdd %_3 %_166 %_165 %_49 %_133 %_49
          %_167 = OpAccessChain %_24 %_28 %_49
-         %_168 = OpAccessChain %_74 %_167 %_49
-         %_169 = OpLoad %_4 %_168
+         %_168 = OpLoad %_23 %_167
+         Op400 %_6 %_169 %_168
          %_170 = OpAccessChain %_24 %_28 %_49
          %_171 = OpAccessChain %_74 %_170 %_49
-         OpAtomicIAdd %_4 %_172 %_171 %_49 %_131 %_57
+         %_172 = OpLoad %_4 %_171
+         %_173 = OpAccessChain %_24 %_28 %_49
+         %_174 = OpAccessChain %_74 %_173 %_49
+         OpAtomicIAdd %_4 %_175 %_174 %_49 %_133 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_173 = OpAccessChain %_46 %_14 %_47
-         OpAtomicISub %_3 %_174 %_173 %_49 %_131 %_49
-         %_175 = OpAccessChain %_50 %_17 %_47
-         %_176 = OpAccessChain %_52 %_175 %_49
-         %_177 = OpLoad %_4 %_176
+         %_176 = OpAccessChain %_46 %_14 %_47
+         OpAtomicISub %_3 %_177 %_176 %_49 %_133 %_49
          %_178 = OpAccessChain %_50 %_17 %_47
          %_179 = OpAccessChain %_52 %_178 %_49
-         OpAtomicISub %_4 %_180 %_179 %_49 %_131 %_57
-         %_181 = OpAccessChain %_58 %_20 %_47
-         %_182 = OpAccessChain %_46 %_181 %_47
-         %_183 = OpLoad %_3 %_182
+         %_180 = OpLoad %_4 %_179
+         %_181 = OpAccessChain %_50 %_17 %_47
+         %_182 = OpAccessChain %_52 %_181 %_49
+         OpAtomicISub %_4 %_183 %_182 %_49 %_133 %_57
          %_184 = OpAccessChain %_58 %_20 %_47
          %_185 = OpAccessChain %_46 %_184 %_47
-         OpAtomicISub %_3 %_186 %_185 %_49 %_131 %_49
+         %_186 = OpLoad %_3 %_185
          %_187 = OpAccessChain %_58 %_20 %_47
-         %_188 = OpAccessChain %_50 %_187 %_49
-         %_189 = OpLoad %_6 %_188
+         %_188 = OpAccessChain %_46 %_187 %_47
+         OpAtomicISub %_3 %_189 %_188 %_49 %_133 %_49
          %_190 = OpAccessChain %_58 %_20 %_47
          %_191 = OpAccessChain %_50 %_190 %_49
-         %_192 = OpAccessChain %_52 %_191 %_49
-         %_193 = OpLoad %_4 %_192
-         %_194 = OpAccessChain %_58 %_20 %_47
-         %_195 = OpAccessChain %_50 %_194 %_49
-         %_196 = OpAccessChain %_52 %_195 %_49
-         OpAtomicISub %_4 %_197 %_196 %_49 %_131 %_57
-         OpAtomicISub %_3 %_198 %_22 %_49 %_131 %_49
-         %_199 = OpAccessChain %_74 %_25 %_49
-         %_200 = OpLoad %_4 %_199
-         %_201 = OpAccessChain %_74 %_25 %_49
-         OpAtomicISub %_4 %_202 %_201 %_49 %_131 %_57
-         %_203 = OpAccessChain %_21 %_28 %_47
-         %_204 = OpLoad %_3 %_203
-         %_205 = OpAccessChain %_21 %_28 %_47
-         OpAtomicISub %_3 %_206 %_205 %_49 %_131 %_49
-         %_207 = OpAccessChain %_24 %_28 %_49
-         %_208 = OpLoad %_23 %_207
-         %_209 = OpAccessChain %_24 %_28 %_49
-         %_210 = OpAccessChain %_74 %_209 %_49
-         %_211 = OpLoad %_4 %_210
-         %_212 = OpAccessChain %_24 %_28 %_49
-         %_213 = OpAccessChain %_74 %_212 %_49
-         OpAtomicISub %_4 %_214 %_213 %_49 %_131 %_57
+         %_192 = OpLoad %_6 %_191
+         %_193 = OpAccessChain %_58 %_20 %_47
+         %_194 = OpAccessChain %_50 %_193 %_49
+         %_195 = OpAccessChain %_52 %_194 %_49
+         %_196 = OpLoad %_4 %_195
+         %_197 = OpAccessChain %_58 %_20 %_47
+         %_198 = OpAccessChain %_50 %_197 %_49
+         %_199 = OpAccessChain %_52 %_198 %_49
+         OpAtomicISub %_4 %_200 %_199 %_49 %_133 %_57
+         OpAtomicISub %_3 %_201 %_22 %_49 %_133 %_49
+         %_202 = OpAccessChain %_74 %_25 %_49
+         %_203 = OpLoad %_4 %_202
+         %_204 = OpAccessChain %_74 %_25 %_49
+         OpAtomicISub %_4 %_205 %_204 %_49 %_133 %_57
+         %_206 = OpAccessChain %_21 %_28 %_47
+         %_207 = OpLoad %_3 %_206
+         %_208 = OpAccessChain %_21 %_28 %_47
+         OpAtomicISub %_3 %_209 %_208 %_49 %_133 %_49
+         %_210 = OpAccessChain %_24 %_28 %_49
+         %_211 = OpLoad %_23 %_210
+         Op400 %_6 %_212 %_211
+         %_213 = OpAccessChain %_24 %_28 %_49
+         %_214 = OpAccessChain %_74 %_213 %_49
+         %_215 = OpLoad %_4 %_214
+         %_216 = OpAccessChain %_24 %_28 %_49
+         %_217 = OpAccessChain %_74 %_216 %_49
+         OpAtomicISub %_4 %_218 %_217 %_49 %_133 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_215 = OpAccessChain %_46 %_14 %_47
-         OpAtomicUMax %_3 %_216 %_215 %_49 %_131 %_49
-         %_217 = OpAccessChain %_50 %_17 %_47
-         %_218 = OpAccessChain %_52 %_217 %_49
-         %_219 = OpLoad %_4 %_218
-         %_220 = OpAccessChain %_50 %_17 %_47
-         %_221 = OpAccessChain %_52 %_220 %_49
-         OpAtomicSMax %_4 %_222 %_221 %_49 %_131 %_57
-         %_223 = OpAccessChain %_58 %_20 %_47
-         %_224 = OpAccessChain %_46 %_223 %_47
-         %_225 = OpLoad %_3 %_224
-         %_226 = OpAccessChain %_58 %_20 %_47
-         %_227 = OpAccessChain %_46 %_226 %_47
-         OpAtomicUMax %_3 %_228 %_227 %_49 %_131 %_49
-         %_229 = OpAccessChain %_58 %_20 %_47
-         %_230 = OpAccessChain %_50 %_229 %_49
-         %_231 = OpLoad %_6 %_230
-         %_232 = OpAccessChain %_58 %_20 %_47
-         %_233 = OpAccessChain %_50 %_232 %_49
-         %_234 = OpAccessChain %_52 %_233 %_49
-         %_235 = OpLoad %_4 %_234
+         %_219 = OpAccessChain %_46 %_14 %_47
+         OpAtomicUMax %_3 %_220 %_219 %_49 %_133 %_49
+         %_221 = OpAccessChain %_50 %_17 %_47
+         %_222 = OpAccessChain %_52 %_221 %_49
+         %_223 = OpLoad %_4 %_222
+         %_224 = OpAccessChain %_50 %_17 %_47
+         %_225 = OpAccessChain %_52 %_224 %_49
+         OpAtomicSMax %_4 %_226 %_225 %_49 %_133 %_57
+         %_227 = OpAccessChain %_58 %_20 %_47
+         %_228 = OpAccessChain %_46 %_227 %_47
+         %_229 = OpLoad %_3 %_228
+         %_230 = OpAccessChain %_58 %_20 %_47
+         %_231 = OpAccessChain %_46 %_230 %_47
+         OpAtomicUMax %_3 %_232 %_231 %_49 %_133 %_49
+         %_233 = OpAccessChain %_58 %_20 %_47
+         %_234 = OpAccessChain %_50 %_233 %_49
+         %_235 = OpLoad %_6 %_234
          %_236 = OpAccessChain %_58 %_20 %_47
          %_237 = OpAccessChain %_50 %_236 %_49
          %_238 = OpAccessChain %_52 %_237 %_49
-         OpAtomicSMax %_4 %_239 %_238 %_49 %_131 %_57
-         OpAtomicUMax %_3 %_240 %_22 %_49 %_131 %_49
-         %_241 = OpAccessChain %_74 %_25 %_49
-         %_242 = OpLoad %_4 %_241
-         %_243 = OpAccessChain %_74 %_25 %_49
-         OpAtomicSMax %_4 %_244 %_243 %_49 %_131 %_57
-         %_245 = OpAccessChain %_21 %_28 %_47
-         %_246 = OpLoad %_3 %_245
-         %_247 = OpAccessChain %_21 %_28 %_47
-         OpAtomicUMax %_3 %_248 %_247 %_49 %_131 %_49
-         %_249 = OpAccessChain %_24 %_28 %_49
-         %_250 = OpLoad %_23 %_249
-         %_251 = OpAccessChain %_24 %_28 %_49
-         %_252 = OpAccessChain %_74 %_251 %_49
-         %_253 = OpLoad %_4 %_252
-         %_254 = OpAccessChain %_24 %_28 %_49
-         %_255 = OpAccessChain %_74 %_254 %_49
-         OpAtomicSMax %_4 %_256 %_255 %_49 %_131 %_57
+         %_239 = OpLoad %_4 %_238
+         %_240 = OpAccessChain %_58 %_20 %_47
+         %_241 = OpAccessChain %_50 %_240 %_49
+         %_242 = OpAccessChain %_52 %_241 %_49
+         OpAtomicSMax %_4 %_243 %_242 %_49 %_133 %_57
+         OpAtomicUMax %_3 %_244 %_22 %_49 %_133 %_49
+         %_245 = OpAccessChain %_74 %_25 %_49
+         %_246 = OpLoad %_4 %_245
+         %_247 = OpAccessChain %_74 %_25 %_49
+         OpAtomicSMax %_4 %_248 %_247 %_49 %_133 %_57
+         %_249 = OpAccessChain %_21 %_28 %_47
+         %_250 = OpLoad %_3 %_249
+         %_251 = OpAccessChain %_21 %_28 %_47
+         OpAtomicUMax %_3 %_252 %_251 %_49 %_133 %_49
+         %_253 = OpAccessChain %_24 %_28 %_49
+         %_254 = OpLoad %_23 %_253
+         Op400 %_6 %_255 %_254
+         %_256 = OpAccessChain %_24 %_28 %_49
+         %_257 = OpAccessChain %_74 %_256 %_49
+         %_258 = OpLoad %_4 %_257
+         %_259 = OpAccessChain %_24 %_28 %_49
+         %_260 = OpAccessChain %_74 %_259 %_49
+         OpAtomicSMax %_4 %_261 %_260 %_49 %_133 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_257 = OpAccessChain %_46 %_14 %_47
-         OpAtomicUMin %_3 %_258 %_257 %_49 %_131 %_49
-         %_259 = OpAccessChain %_50 %_17 %_47
-         %_260 = OpAccessChain %_52 %_259 %_49
-         %_261 = OpLoad %_4 %_260
-         %_262 = OpAccessChain %_50 %_17 %_47
-         %_263 = OpAccessChain %_52 %_262 %_49
-         OpAtomicSMin %_4 %_264 %_263 %_49 %_131 %_57
-         %_265 = OpAccessChain %_58 %_20 %_47
-         %_266 = OpAccessChain %_46 %_265 %_47
-         %_267 = OpLoad %_3 %_266
-         %_268 = OpAccessChain %_58 %_20 %_47
-         %_269 = OpAccessChain %_46 %_268 %_47
-         OpAtomicUMin %_3 %_270 %_269 %_49 %_131 %_49
-         %_271 = OpAccessChain %_58 %_20 %_47
-         %_272 = OpAccessChain %_50 %_271 %_49
-         %_273 = OpLoad %_6 %_272
-         %_274 = OpAccessChain %_58 %_20 %_47
-         %_275 = OpAccessChain %_50 %_274 %_49
-         %_276 = OpAccessChain %_52 %_275 %_49
-         %_277 = OpLoad %_4 %_276
-         %_278 = OpAccessChain %_58 %_20 %_47
-         %_279 = OpAccessChain %_50 %_278 %_49
-         %_280 = OpAccessChain %_52 %_279 %_49
-         OpAtomicSMin %_4 %_281 %_280 %_49 %_131 %_57
-         OpAtomicUMin %_3 %_282 %_22 %_49 %_131 %_49
-         %_283 = OpAccessChain %_74 %_25 %_49
-         %_284 = OpLoad %_4 %_283
-         %_285 = OpAccessChain %_74 %_25 %_49
-         OpAtomicSMin %_4 %_286 %_285 %_49 %_131 %_57
-         %_287 = OpAccessChain %_21 %_28 %_47
-         %_288 = OpLoad %_3 %_287
-         %_289 = OpAccessChain %_21 %_28 %_47
-         OpAtomicUMin %_3 %_290 %_289 %_49 %_131 %_49
-         %_291 = OpAccessChain %_24 %_28 %_49
-         %_292 = OpLoad %_23 %_291
-         %_293 = OpAccessChain %_24 %_28 %_49
-         %_294 = OpAccessChain %_74 %_293 %_49
-         %_295 = OpLoad %_4 %_294
+         %_262 = OpAccessChain %_46 %_14 %_47
+         OpAtomicUMin %_3 %_263 %_262 %_49 %_133 %_49
+         %_264 = OpAccessChain %_50 %_17 %_47
+         %_265 = OpAccessChain %_52 %_264 %_49
+         %_266 = OpLoad %_4 %_265
+         %_267 = OpAccessChain %_50 %_17 %_47
+         %_268 = OpAccessChain %_52 %_267 %_49
+         OpAtomicSMin %_4 %_269 %_268 %_49 %_133 %_57
+         %_270 = OpAccessChain %_58 %_20 %_47
+         %_271 = OpAccessChain %_46 %_270 %_47
+         %_272 = OpLoad %_3 %_271
+         %_273 = OpAccessChain %_58 %_20 %_47
+         %_274 = OpAccessChain %_46 %_273 %_47
+         OpAtomicUMin %_3 %_275 %_274 %_49 %_133 %_49
+         %_276 = OpAccessChain %_58 %_20 %_47
+         %_277 = OpAccessChain %_50 %_276 %_49
+         %_278 = OpLoad %_6 %_277
+         %_279 = OpAccessChain %_58 %_20 %_47
+         %_280 = OpAccessChain %_50 %_279 %_49
+         %_281 = OpAccessChain %_52 %_280 %_49
+         %_282 = OpLoad %_4 %_281
+         %_283 = OpAccessChain %_58 %_20 %_47
+         %_284 = OpAccessChain %_50 %_283 %_49
+         %_285 = OpAccessChain %_52 %_284 %_49
+         OpAtomicSMin %_4 %_286 %_285 %_49 %_133 %_57
+         OpAtomicUMin %_3 %_287 %_22 %_49 %_133 %_49
+         %_288 = OpAccessChain %_74 %_25 %_49
+         %_289 = OpLoad %_4 %_288
+         %_290 = OpAccessChain %_74 %_25 %_49
+         OpAtomicSMin %_4 %_291 %_290 %_49 %_133 %_57
+         %_292 = OpAccessChain %_21 %_28 %_47
+         %_293 = OpLoad %_3 %_292
+         %_294 = OpAccessChain %_21 %_28 %_47
+         OpAtomicUMin %_3 %_295 %_294 %_49 %_133 %_49
          %_296 = OpAccessChain %_24 %_28 %_49
-         %_297 = OpAccessChain %_74 %_296 %_49
-         OpAtomicSMin %_4 %_298 %_297 %_49 %_131 %_57
+         %_297 = OpLoad %_23 %_296
+         Op400 %_6 %_298 %_297
+         %_299 = OpAccessChain %_24 %_28 %_49
+         %_300 = OpAccessChain %_74 %_299 %_49
+         %_301 = OpLoad %_4 %_300
+         %_302 = OpAccessChain %_24 %_28 %_49
+         %_303 = OpAccessChain %_74 %_302 %_49
+         OpAtomicSMin %_4 %_304 %_303 %_49 %_133 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_299 = OpAccessChain %_46 %_14 %_47
-         OpAtomicAnd %_3 %_300 %_299 %_49 %_131 %_49
-         %_301 = OpAccessChain %_50 %_17 %_47
-         %_302 = OpAccessChain %_52 %_301 %_49
-         %_303 = OpLoad %_4 %_302
-         %_304 = OpAccessChain %_50 %_17 %_47
-         %_305 = OpAccessChain %_52 %_304 %_49
-         OpAtomicAnd %_4 %_306 %_305 %_49 %_131 %_57
-         %_307 = OpAccessChain %_58 %_20 %_47
-         %_308 = OpAccessChain %_46 %_307 %_47
-         %_309 = OpLoad %_3 %_308
-         %_310 = OpAccessChain %_58 %_20 %_47
-         %_311 = OpAccessChain %_46 %_310 %_47
-         OpAtomicAnd %_3 %_312 %_311 %_49 %_131 %_49
+         %_305 = OpAccessChain %_46 %_14 %_47
+         OpAtomicAnd %_3 %_306 %_305 %_49 %_133 %_49
+         %_307 = OpAccessChain %_50 %_17 %_47
+         %_308 = OpAccessChain %_52 %_307 %_49
+         %_309 = OpLoad %_4 %_308
+         %_310 = OpAccessChain %_50 %_17 %_47
+         %_311 = OpAccessChain %_52 %_310 %_49
+         OpAtomicAnd %_4 %_312 %_311 %_49 %_133 %_57
          %_313 = OpAccessChain %_58 %_20 %_47
-         %_314 = OpAccessChain %_50 %_313 %_49
-         %_315 = OpLoad %_6 %_314
+         %_314 = OpAccessChain %_46 %_313 %_47
+         %_315 = OpLoad %_3 %_314
          %_316 = OpAccessChain %_58 %_20 %_47
-         %_317 = OpAccessChain %_50 %_316 %_49
-         %_318 = OpAccessChain %_52 %_317 %_49
-         %_319 = OpLoad %_4 %_318
-         %_320 = OpAccessChain %_58 %_20 %_47
-         %_321 = OpAccessChain %_50 %_320 %_49
-         %_322 = OpAccessChain %_52 %_321 %_49
-         OpAtomicAnd %_4 %_323 %_322 %_49 %_131 %_57
-         OpAtomicAnd %_3 %_324 %_22 %_49 %_131 %_49
-         %_325 = OpAccessChain %_74 %_25 %_49
-         %_326 = OpLoad %_4 %_325
-         %_327 = OpAccessChain %_74 %_25 %_49
-         OpAtomicAnd %_4 %_328 %_327 %_49 %_131 %_57
-         %_329 = OpAccessChain %_21 %_28 %_47
-         %_330 = OpLoad %_3 %_329
-         %_331 = OpAccessChain %_21 %_28 %_47
-         OpAtomicAnd %_3 %_332 %_331 %_49 %_131 %_49
-         %_333 = OpAccessChain %_24 %_28 %_49
-         %_334 = OpLoad %_23 %_333
-         %_335 = OpAccessChain %_24 %_28 %_49
-         %_336 = OpAccessChain %_74 %_335 %_49
-         %_337 = OpLoad %_4 %_336
-         %_338 = OpAccessChain %_24 %_28 %_49
-         %_339 = OpAccessChain %_74 %_338 %_49
-         OpAtomicAnd %_4 %_340 %_339 %_49 %_131 %_57
+         %_317 = OpAccessChain %_46 %_316 %_47
+         OpAtomicAnd %_3 %_318 %_317 %_49 %_133 %_49
+         %_319 = OpAccessChain %_58 %_20 %_47
+         %_320 = OpAccessChain %_50 %_319 %_49
+         %_321 = OpLoad %_6 %_320
+         %_322 = OpAccessChain %_58 %_20 %_47
+         %_323 = OpAccessChain %_50 %_322 %_49
+         %_324 = OpAccessChain %_52 %_323 %_49
+         %_325 = OpLoad %_4 %_324
+         %_326 = OpAccessChain %_58 %_20 %_47
+         %_327 = OpAccessChain %_50 %_326 %_49
+         %_328 = OpAccessChain %_52 %_327 %_49
+         OpAtomicAnd %_4 %_329 %_328 %_49 %_133 %_57
+         OpAtomicAnd %_3 %_330 %_22 %_49 %_133 %_49
+         %_331 = OpAccessChain %_74 %_25 %_49
+         %_332 = OpLoad %_4 %_331
+         %_333 = OpAccessChain %_74 %_25 %_49
+         OpAtomicAnd %_4 %_334 %_333 %_49 %_133 %_57
+         %_335 = OpAccessChain %_21 %_28 %_47
+         %_336 = OpLoad %_3 %_335
+         %_337 = OpAccessChain %_21 %_28 %_47
+         OpAtomicAnd %_3 %_338 %_337 %_49 %_133 %_49
+         %_339 = OpAccessChain %_24 %_28 %_49
+         %_340 = OpLoad %_23 %_339
+         Op400 %_6 %_341 %_340
+         %_342 = OpAccessChain %_24 %_28 %_49
+         %_343 = OpAccessChain %_74 %_342 %_49
+         %_344 = OpLoad %_4 %_343
+         %_345 = OpAccessChain %_24 %_28 %_49
+         %_346 = OpAccessChain %_74 %_345 %_49
+         OpAtomicAnd %_4 %_347 %_346 %_49 %_133 %_57
          OpControlBarrier %_5 %_5 %_44
-         %_341 = OpAccessChain %_46 %_14 %_47
-         OpAtomicOr %_3 %_342 %_341 %_49 %_131 %_49
-         %_343 = OpAccessChain %_50 %_17 %_47
-         %_344 = OpAccessChain %_52 %_343 %_49
-         %_345 = OpLoad %_4 %_344
-         %_346 = OpAccessChain %_50 %_17 %_47
-         %_347 = OpAccessChain %_52 %_346 %_49
-         OpAtomicOr %_4 %_348 %_347 %_49 %_131 %_57
-         %_349 = OpAccessChain %_58 %_20 %_47
-         %_350 = OpAccessChain %_46 %_349 %_47
-         %_351 = OpLoad %_3 %_350
-         %_352 = OpAccessChain %_58 %_20 %_47
-         %_353 = OpAccessChain %_46 %_352 %_47
-         OpAtomicOr %_3 %_354 %_353 %_49 %_131 %_49
-         %_355 = OpAccessChain %_58 %_20 %_47
-         %_356 = OpAccessChain %_50 %_355 %_49
-         %_357 = OpLoad %_6 %_356
-         %_358 = OpAccessChain %_58 %_20 %_47
-         %_359 = OpAccessChain %_50 %_358 %_49
-         %_360 = OpAccessChain %_52 %_359 %_49
-         %_361 = OpLoad %_4 %_360
+         %_348 = OpAccessChain %_46 %_14 %_47
+         OpAtomicOr %_3 %_349 %_348 %_49 %_133 %_49
+         %_350 = OpAccessChain %_50 %_17 %_47
+         %_351 = OpAccessChain %_52 %_350 %_49
+         %_352 = OpLoad %_4 %_351
+         %_353 = OpAccessChain %_50 %_17 %_47
+         %_354 = OpAccessChain %_52 %_353 %_49
+         OpAtomicOr %_4 %_355 %_354 %_49 %_133 %_57
+         %_356 = OpAccessChain %_58 %_20 %_47
+         %_357 = OpAccessChain %_46 %_356 %_47
+         %_358 = OpLoad %_3 %_357
+         %_359 = OpAccessChain %_58 %_20 %_47
+         %_360 = OpAccessChain %_46 %_359 %_47
+         OpAtomicOr %_3 %_361 %_360 %_49 %_133 %_49
          %_362 = OpAccessChain %_58 %_20 %_47
          %_363 = OpAccessChain %_50 %_362 %_49
-         %_364 = OpAccessChain %_52 %_363 %_49
-         OpAtomicOr %_4 %_365 %_364 %_49 %_131 %_57
-         OpAtomicOr %_3 %_366 %_22 %_49 %_131 %_49
-         %_367 = OpAccessChain %_74 %_25 %_49
+         %_364 = OpLoad %_6 %_363
+         %_365 = OpAccessChain %_58 %_20 %_47
+         %_366 = OpAccessChain %_50 %_365 %_49
+         %_367 = OpAccessChain %_52 %_366 %_49
          %_368 = OpLoad %_4 %_367
-         %_369 = OpAccessChain %_74 %_25 %_49
-         OpAtomicOr %_4 %_370 %_369 %_49 %_131 %_57
-         %_371 = OpAccessChain %_21 %_28 %_47
-         %_372 = OpLoad %_3 %_371
-         %_373 = OpAccessChain %_21 %_28 %_47
-         OpAtomicOr %_3 %_374 %_373 %_49 %_131 %_49
-         %_375 = OpAccessChain %_24 %_28 %_49
-         %_376 = OpLoad %_23 %_375
-         %_377 = OpAccessChain %_24 %_28 %_49
-         %_378 = OpAccessChain %_74 %_377 %_49
-         %_379 = OpLoad %_4 %_378
-         %_380 = OpAccessChain %_24 %_28 %_49
-         %_381 = OpAccessChain %_74 %_380 %_49
-         OpAtomicOr %_4 %_382 %_381 %_49 %_131 %_57
-         OpControlBarrier %_5 %_5 %_44
-         %_383 = OpAccessChain %_46 %_14 %_47
-         OpAtomicXor %_3 %_384 %_383 %_49 %_131 %_49
-         %_385 = OpAccessChain %_50 %_17 %_47
-         %_386 = OpAccessChain %_52 %_385 %_49
+         %_369 = OpAccessChain %_58 %_20 %_47
+         %_370 = OpAccessChain %_50 %_369 %_49
+         %_371 = OpAccessChain %_52 %_370 %_49
+         OpAtomicOr %_4 %_372 %_371 %_49 %_133 %_57
+         OpAtomicOr %_3 %_373 %_22 %_49 %_133 %_49
+         %_374 = OpAccessChain %_74 %_25 %_49
+         %_375 = OpLoad %_4 %_374
+         %_376 = OpAccessChain %_74 %_25 %_49
+         OpAtomicOr %_4 %_377 %_376 %_49 %_133 %_57
+         %_378 = OpAccessChain %_21 %_28 %_47
+         %_379 = OpLoad %_3 %_378
+         %_380 = OpAccessChain %_21 %_28 %_47
+         OpAtomicOr %_3 %_381 %_380 %_49 %_133 %_49
+         %_382 = OpAccessChain %_24 %_28 %_49
+         %_383 = OpLoad %_23 %_382
+         Op400 %_6 %_384 %_383
+         %_385 = OpAccessChain %_24 %_28 %_49
+         %_386 = OpAccessChain %_74 %_385 %_49
          %_387 = OpLoad %_4 %_386
-         %_388 = OpAccessChain %_50 %_17 %_47
-         %_389 = OpAccessChain %_52 %_388 %_49
-         OpAtomicXor %_4 %_390 %_389 %_49 %_131 %_57
-         %_391 = OpAccessChain %_58 %_20 %_47
-         %_392 = OpAccessChain %_46 %_391 %_47
-         %_393 = OpLoad %_3 %_392
-         %_394 = OpAccessChain %_58 %_20 %_47
-         %_395 = OpAccessChain %_46 %_394 %_47
-         OpAtomicXor %_3 %_396 %_395 %_49 %_131 %_49
-         %_397 = OpAccessChain %_58 %_20 %_47
-         %_398 = OpAccessChain %_50 %_397 %_49
-         %_399 = OpLoad %_6 %_398
-         %_400 = OpAccessChain %_58 %_20 %_47
-         %_401 = OpAccessChain %_50 %_400 %_49
-         %_402 = OpAccessChain %_52 %_401 %_49
-         %_403 = OpLoad %_4 %_402
-         %_404 = OpAccessChain %_58 %_20 %_47
-         %_405 = OpAccessChain %_50 %_404 %_49
-         %_406 = OpAccessChain %_52 %_405 %_49
-         OpAtomicXor %_4 %_407 %_406 %_49 %_131 %_57
-         OpAtomicXor %_3 %_408 %_22 %_49 %_131 %_49
-         %_409 = OpAccessChain %_74 %_25 %_49
-         %_410 = OpLoad %_4 %_409
-         %_411 = OpAccessChain %_74 %_25 %_49
-         OpAtomicXor %_4 %_412 %_411 %_49 %_131 %_57
-         %_413 = OpAccessChain %_21 %_28 %_47
-         %_414 = OpLoad %_3 %_413
-         %_415 = OpAccessChain %_21 %_28 %_47
-         OpAtomicXor %_3 %_416 %_415 %_49 %_131 %_49
-         %_417 = OpAccessChain %_24 %_28 %_49
-         %_418 = OpLoad %_23 %_417
-         %_419 = OpAccessChain %_24 %_28 %_49
-         %_420 = OpAccessChain %_74 %_419 %_49
-         %_421 = OpLoad %_4 %_420
-         %_422 = OpAccessChain %_24 %_28 %_49
-         %_423 = OpAccessChain %_74 %_422 %_49
-         OpAtomicXor %_4 %_424 %_423 %_49 %_131 %_57
-         %_425 = OpAccessChain %_46 %_14 %_47
-         OpAtomicExchange %_3 %_426 %_425 %_49 %_131 %_49
-         %_427 = OpAccessChain %_50 %_17 %_47
-         %_428 = OpAccessChain %_52 %_427 %_49
-         %_429 = OpLoad %_4 %_428
-         %_430 = OpAccessChain %_50 %_17 %_47
-         %_431 = OpAccessChain %_52 %_430 %_49
-         OpAtomicExchange %_4 %_432 %_431 %_49 %_131 %_57
-         %_433 = OpAccessChain %_58 %_20 %_47
-         %_434 = OpAccessChain %_46 %_433 %_47
-         %_435 = OpLoad %_3 %_434
-         %_436 = OpAccessChain %_58 %_20 %_47
-         %_437 = OpAccessChain %_46 %_436 %_47
-         OpAtomicExchange %_3 %_438 %_437 %_49 %_131 %_49
-         %_439 = OpAccessChain %_58 %_20 %_47
-         %_440 = OpAccessChain %_50 %_439 %_49
-         %_441 = OpLoad %_6 %_440
+         %_388 = OpAccessChain %_24 %_28 %_49
+         %_389 = OpAccessChain %_74 %_388 %_49
+         OpAtomicOr %_4 %_390 %_389 %_49 %_133 %_57
+         OpControlBarrier %_5 %_5 %_44
+         %_391 = OpAccessChain %_46 %_14 %_47
+         OpAtomicXor %_3 %_392 %_391 %_49 %_133 %_49
+         %_393 = OpAccessChain %_50 %_17 %_47
+         %_394 = OpAccessChain %_52 %_393 %_49
+         %_395 = OpLoad %_4 %_394
+         %_396 = OpAccessChain %_50 %_17 %_47
+         %_397 = OpAccessChain %_52 %_396 %_49
+         OpAtomicXor %_4 %_398 %_397 %_49 %_133 %_57
+         %_399 = OpAccessChain %_58 %_20 %_47
+         %_400 = OpAccessChain %_46 %_399 %_47
+         %_401 = OpLoad %_3 %_400
+         %_402 = OpAccessChain %_58 %_20 %_47
+         %_403 = OpAccessChain %_46 %_402 %_47
+         OpAtomicXor %_3 %_404 %_403 %_49 %_133 %_49
+         %_405 = OpAccessChain %_58 %_20 %_47
+         %_406 = OpAccessChain %_50 %_405 %_49
+         %_407 = OpLoad %_6 %_406
+         %_408 = OpAccessChain %_58 %_20 %_47
+         %_409 = OpAccessChain %_50 %_408 %_49
+         %_410 = OpAccessChain %_52 %_409 %_49
+         %_411 = OpLoad %_4 %_410
+         %_412 = OpAccessChain %_58 %_20 %_47
+         %_413 = OpAccessChain %_50 %_412 %_49
+         %_414 = OpAccessChain %_52 %_413 %_49
+         OpAtomicXor %_4 %_415 %_414 %_49 %_133 %_57
+         OpAtomicXor %_3 %_416 %_22 %_49 %_133 %_49
+         %_417 = OpAccessChain %_74 %_25 %_49
+         %_418 = OpLoad %_4 %_417
+         %_419 = OpAccessChain %_74 %_25 %_49
+         OpAtomicXor %_4 %_420 %_419 %_49 %_133 %_57
+         %_421 = OpAccessChain %_21 %_28 %_47
+         %_422 = OpLoad %_3 %_421
+         %_423 = OpAccessChain %_21 %_28 %_47
+         OpAtomicXor %_3 %_424 %_423 %_49 %_133 %_49
+         %_425 = OpAccessChain %_24 %_28 %_49
+         %_426 = OpLoad %_23 %_425
+         Op400 %_6 %_427 %_426
+         %_428 = OpAccessChain %_24 %_28 %_49
+         %_429 = OpAccessChain %_74 %_428 %_49
+         %_430 = OpLoad %_4 %_429
+         %_431 = OpAccessChain %_24 %_28 %_49
+         %_432 = OpAccessChain %_74 %_431 %_49
+         OpAtomicXor %_4 %_433 %_432 %_49 %_133 %_57
+         %_434 = OpAccessChain %_46 %_14 %_47
+         OpAtomicExchange %_3 %_435 %_434 %_49 %_133 %_49
+         %_436 = OpAccessChain %_50 %_17 %_47
+         %_437 = OpAccessChain %_52 %_436 %_49
+         %_438 = OpLoad %_4 %_437
+         %_439 = OpAccessChain %_50 %_17 %_47
+         %_440 = OpAccessChain %_52 %_439 %_49
+         OpAtomicExchange %_4 %_441 %_440 %_49 %_133 %_57
          %_442 = OpAccessChain %_58 %_20 %_47
-         %_443 = OpAccessChain %_50 %_442 %_49
-         %_444 = OpAccessChain %_52 %_443 %_49
-         %_445 = OpLoad %_4 %_444
-         %_446 = OpAccessChain %_58 %_20 %_47
-         %_447 = OpAccessChain %_50 %_446 %_49
-         %_448 = OpAccessChain %_52 %_447 %_49
-         OpAtomicExchange %_4 %_449 %_448 %_49 %_131 %_57
-         OpAtomicExchange %_3 %_450 %_22 %_49 %_131 %_49
-         %_451 = OpAccessChain %_74 %_25 %_49
-         %_452 = OpLoad %_4 %_451
-         %_453 = OpAccessChain %_74 %_25 %_49
-         OpAtomicExchange %_4 %_454 %_453 %_49 %_131 %_57
-         %_455 = OpAccessChain %_21 %_28 %_47
-         %_456 = OpLoad %_3 %_455
-         %_457 = OpAccessChain %_21 %_28 %_47
-         OpAtomicExchange %_3 %_458 %_457 %_49 %_131 %_49
-         %_459 = OpAccessChain %_24 %_28 %_49
-         %_460 = OpLoad %_23 %_459
-         %_461 = OpAccessChain %_24 %_28 %_49
-         %_462 = OpAccessChain %_74 %_461 %_49
-         %_463 = OpLoad %_4 %_462
-         %_464 = OpAccessChain %_24 %_28 %_49
-         %_465 = OpAccessChain %_74 %_464 %_49
-         OpAtomicExchange %_4 %_466 %_465 %_49 %_131 %_57
-         %_467 = OpAccessChain %_46 %_14 %_47
-         OpAtomicCompareExchange %_3 %_468 %_467 %_49 %_131 %_469 %_5 %_49
-         %_470 = OpSignBitSet %_9 %_468 %_49
-         %_471 = OpCompositeConstruct %_10 %_468 %_470
-         %_472 = OpAccessChain %_50 %_17 %_47
-         %_473 = OpAccessChain %_52 %_472 %_49
-         %_474 = OpLoad %_4 %_473
-         %_475 = OpAccessChain %_50 %_17 %_47
-         %_476 = OpAccessChain %_52 %_475 %_49
-         OpAtomicCompareExchange %_4 %_478 %_476 %_49 %_131 %_469 %_477 %_57
-         %_479 = OpSignBitSet %_9 %_478 %_57
-         %_480 = OpCompositeConstruct %_11 %_478 %_479
-         %_481 = OpAccessChain %_58 %_20 %_47
-         %_482 = OpAccessChain %_46 %_481 %_47
-         %_483 = OpLoad %_3 %_482
-         %_484 = OpAccessChain %_58 %_20 %_47
-         %_485 = OpAccessChain %_46 %_484 %_47
-         OpAtomicCompareExchange %_3 %_486 %_485 %_49 %_131 %_469 %_5 %_49
-         %_487 = OpSignBitSet %_9 %_486 %_49
-         %_488 = OpCompositeConstruct %_10 %_486 %_487
-         %_489 = OpAccessChain %_58 %_20 %_47
-         %_490 = OpAccessChain %_50 %_489 %_49
-         %_491 = OpLoad %_6 %_490
-         %_492 = OpAccessChain %_58 %_20 %_47
-         %_493 = OpAccessChain %_50 %_492 %_49
-         %_494 = OpAccessChain %_52 %_493 %_49
-         %_495 = OpLoad %_4 %_494
-         %_496 = OpAccessChain %_58 %_20 %_47
-         %_497 = OpAccessChain %_50 %_496 %_49
-         %_498 = OpAccessChain %_52 %_497 %_49
-         OpAtomicCompareExchange %_4 %_499 %_498 %_49 %_131 %_469 %_477 %_57
-         %_500 = OpSignBitSet %_9 %_499 %_57
-         %_501 = OpCompositeConstruct %_11 %_499 %_500
-         OpAtomicCompareExchange %_3 %_502 %_22 %_49 %_131 %_469 %_5 %_49
-         %_503 = OpSignBitSet %_9 %_502 %_49
-         %_504 = OpCompositeConstruct %_10 %_502 %_503
-         %_505 = OpAccessChain %_74 %_25 %_49
-         %_506 = OpLoad %_4 %_505
-         %_507 = OpAccessChain %_74 %_25 %_49
-         OpAtomicCompareExchange %_4 %_508 %_507 %_49 %_131 %_469 %_477 %_57
-         %_509 = OpSignBitSet %_9 %_508 %_57
-         %_510 = OpCompositeConstruct %_11 %_508 %_509
-         %_511 = OpAccessChain %_21 %_28 %_47
-         %_512 = OpLoad %_3 %_511
-         %_513 = OpAccessChain %_21 %_28 %_47
-         OpAtomicCompareExchange %_3 %_514 %_513 %_49 %_131 %_469 %_5 %_49
-         %_515 = OpSignBitSet %_9 %_514 %_49
-         %_516 = OpCompositeConstruct %_10 %_514 %_515
-         %_517 = OpAccessChain %_24 %_28 %_49
-         %_518 = OpLoad %_23 %_517
-         %_519 = OpAccessChain %_24 %_28 %_49
-         %_520 = OpAccessChain %_74 %_519 %_49
-         %_521 = OpLoad %_4 %_520
-         %_522 = OpAccessChain %_24 %_28 %_49
-         %_523 = OpAccessChain %_74 %_522 %_49
-         OpAtomicCompareExchange %_4 %_524 %_523 %_49 %_131 %_469 %_477 %_57
-         %_525 = OpSignBitSet %_9 %_524 %_57
-         %_526 = OpCompositeConstruct %_11 %_524 %_525
+         %_443 = OpAccessChain %_46 %_442 %_47
+         %_444 = OpLoad %_3 %_443
+         %_445 = OpAccessChain %_58 %_20 %_47
+         %_446 = OpAccessChain %_46 %_445 %_47
+         OpAtomicExchange %_3 %_447 %_446 %_49 %_133 %_49
+         %_448 = OpAccessChain %_58 %_20 %_47
+         %_449 = OpAccessChain %_50 %_448 %_49
+         %_450 = OpLoad %_6 %_449
+         %_451 = OpAccessChain %_58 %_20 %_47
+         %_452 = OpAccessChain %_50 %_451 %_49
+         %_453 = OpAccessChain %_52 %_452 %_49
+         %_454 = OpLoad %_4 %_453
+         %_455 = OpAccessChain %_58 %_20 %_47
+         %_456 = OpAccessChain %_50 %_455 %_49
+         %_457 = OpAccessChain %_52 %_456 %_49
+         OpAtomicExchange %_4 %_458 %_457 %_49 %_133 %_57
+         OpAtomicExchange %_3 %_459 %_22 %_49 %_133 %_49
+         %_460 = OpAccessChain %_74 %_25 %_49
+         %_461 = OpLoad %_4 %_460
+         %_462 = OpAccessChain %_74 %_25 %_49
+         OpAtomicExchange %_4 %_463 %_462 %_49 %_133 %_57
+         %_464 = OpAccessChain %_21 %_28 %_47
+         %_465 = OpLoad %_3 %_464
+         %_466 = OpAccessChain %_21 %_28 %_47
+         OpAtomicExchange %_3 %_467 %_466 %_49 %_133 %_49
+         %_468 = OpAccessChain %_24 %_28 %_49
+         %_469 = OpLoad %_23 %_468
+         Op400 %_6 %_470 %_469
+         %_471 = OpAccessChain %_24 %_28 %_49
+         %_472 = OpAccessChain %_74 %_471 %_49
+         %_473 = OpLoad %_4 %_472
+         %_474 = OpAccessChain %_24 %_28 %_49
+         %_475 = OpAccessChain %_74 %_474 %_49
+         OpAtomicExchange %_4 %_476 %_475 %_49 %_133 %_57
+         %_477 = OpAccessChain %_46 %_14 %_47
+         OpAtomicCompareExchange %_3 %_478 %_477 %_49 %_133 %_479 %_5 %_49
+         %_480 = OpSignBitSet %_9 %_478 %_49
+         %_481 = OpCompositeConstruct %_10 %_478 %_480
+         %_482 = OpAccessChain %_50 %_17 %_47
+         %_483 = OpAccessChain %_52 %_482 %_49
+         %_484 = OpLoad %_4 %_483
+         %_485 = OpAccessChain %_50 %_17 %_47
+         %_486 = OpAccessChain %_52 %_485 %_49
+         OpAtomicCompareExchange %_4 %_488 %_486 %_49 %_133 %_479 %_487 %_57
+         %_489 = OpSignBitSet %_9 %_488 %_57
+         %_490 = OpCompositeConstruct %_11 %_488 %_489
+         %_491 = OpAccessChain %_58 %_20 %_47
+         %_492 = OpAccessChain %_46 %_491 %_47
+         %_493 = OpLoad %_3 %_492
+         %_494 = OpAccessChain %_58 %_20 %_47
+         %_495 = OpAccessChain %_46 %_494 %_47
+         OpAtomicCompareExchange %_3 %_496 %_495 %_49 %_133 %_479 %_5 %_49
+         %_497 = OpSignBitSet %_9 %_496 %_49
+         %_498 = OpCompositeConstruct %_10 %_496 %_497
+         %_499 = OpAccessChain %_58 %_20 %_47
+         %_500 = OpAccessChain %_50 %_499 %_49
+         %_501 = OpLoad %_6 %_500
+         %_502 = OpAccessChain %_58 %_20 %_47
+         %_503 = OpAccessChain %_50 %_502 %_49
+         %_504 = OpAccessChain %_52 %_503 %_49
+         %_505 = OpLoad %_4 %_504
+         %_506 = OpAccessChain %_58 %_20 %_47
+         %_507 = OpAccessChain %_50 %_506 %_49
+         %_508 = OpAccessChain %_52 %_507 %_49
+         OpAtomicCompareExchange %_4 %_509 %_508 %_49 %_133 %_479 %_487 %_57
+         %_510 = OpSignBitSet %_9 %_509 %_57
+         %_511 = OpCompositeConstruct %_11 %_509 %_510
+         OpAtomicCompareExchange %_3 %_512 %_22 %_49 %_133 %_479 %_5 %_49
+         %_513 = OpSignBitSet %_9 %_512 %_49
+         %_514 = OpCompositeConstruct %_10 %_512 %_513
+         %_515 = OpAccessChain %_74 %_25 %_49
+         %_516 = OpLoad %_4 %_515
+         %_517 = OpAccessChain %_74 %_25 %_49
+         OpAtomicCompareExchange %_4 %_518 %_517 %_49 %_133 %_479 %_487 %_57
+         %_519 = OpSignBitSet %_9 %_518 %_57
+         %_520 = OpCompositeConstruct %_11 %_518 %_519
+         %_521 = OpAccessChain %_21 %_28 %_47
+         %_522 = OpLoad %_3 %_521
+         %_523 = OpAccessChain %_21 %_28 %_47
+         OpAtomicCompareExchange %_3 %_524 %_523 %_49 %_133 %_479 %_5 %_49
+         %_525 = OpSignBitSet %_9 %_524 %_49
+         %_526 = OpCompositeConstruct %_10 %_524 %_525
+         %_527 = OpAccessChain %_24 %_28 %_49
+         %_528 = OpLoad %_23 %_527
+         Op400 %_6 %_529 %_528
+         %_530 = OpAccessChain %_24 %_28 %_49
+         %_531 = OpAccessChain %_74 %_530 %_49
+         %_532 = OpLoad %_4 %_531
+         %_533 = OpAccessChain %_24 %_28 %_49
+         %_534 = OpAccessChain %_74 %_533 %_49
+         OpAtomicCompareExchange %_4 %_535 %_534 %_49 %_133 %_479 %_487 %_57
+         %_536 = OpSignBitSet %_9 %_535 %_57
+         %_537 = OpCompositeConstruct %_11 %_535 %_536
                OpReturn
                OpFunctionEnd

--- a/snapshot/testdata/golden/spv/workgroup-var-init.spvasm
+++ b/snapshot/testdata/golden/spv/workgroup-var-init.spvasm
@@ -1,7 +1,7 @@
 ; SPIR-V
 ; Version: 1.4
 ; Generator: 0x00000000
-; Bound: 47
+; Bound: 48
 ; Schema: 0
 
                OpCapability Shader
@@ -48,7 +48,7 @@
          %_36 = OpConstant %_3 264
          %_38 = OpConstant %_3 0
          %_39 = OpTypePointer Workgroup %_11
-         %_44 = OpTypePointer StorageBuffer %_5
+         %_46 = OpTypePointer StorageBuffer %_5
          %_16 = OpVariable %_15 Workgroup
          %_19 = OpVariable %_18 StorageBuffer
          %_25 = OpVariable %_24 Input
@@ -68,10 +68,11 @@
          %_37 = OpLabel
          %_40 = OpAccessChain %_39 %_16 %_38
          %_41 = OpLoad %_11 %_40
-         %_42 = OpAccessChain %_39 %_16 %_38
-         %_43 = OpLoad %_11 %_42
-         %_45 = OpAccessChain %_44 %_19 %_38
-         Op400 %_5 %_46 %_43
-               OpStore %_45 %_46
+         Op400 %_5 %_42 %_41
+         %_43 = OpAccessChain %_39 %_16 %_38
+         %_44 = OpLoad %_11 %_43
+         Op400 %_5 %_45 %_44
+         %_47 = OpAccessChain %_46 %_19 %_38
+               OpStore %_47 %_45
                OpReturn
                OpFunctionEnd

--- a/spirv/backend.go
+++ b/spirv/backend.go
@@ -3773,6 +3773,19 @@ func (e *ExpressionEmitter) emitGlobalVarValue(kind ir.ExprGlobalVariable) (uint
 		return 0, err
 	}
 
+	// For Workgroup variables, the pointer uses layout-free types (no ArrayStride/Offset).
+	// OpLoad returns the layout-free type. We must OpCopyLogical to the decorated type
+	// immediately, so all downstream uses (OpFunctionCall, OpStore, OpComposite*)
+	// see the correct decorated type. This is the single conversion point —
+	// all Workgroup layout-free values are converted to decorated on load.
+	if gv.Space == ir.SpaceWorkGroup && e.backend.typeNeedsLayoutDecoration(gv.Type) {
+		layoutFreeTypeID := e.backend.emitTypeWithoutLayout(gv.Type)
+		loadedID := e.backend.builder.AddLoad(layoutFreeTypeID, ptrID)
+
+		e.backend.requireSpirvVersion14()
+		return e.backend.builder.AddCopyLogical(typeID, loadedID), nil
+	}
+
 	return e.backend.builder.AddLoad(typeID, ptrID), nil
 }
 
@@ -3981,6 +3994,19 @@ func (e *ExpressionEmitter) maybeCopyLogicalForStore(pointerExpr, valueExpr ir.E
 		targetTypeID = e.backend.emitTypeWithoutLayout(*valueTypeHandle)
 	}
 
+	// Resolve the current SPIR-V type of the value. If the value was already
+	// converted at load time (load-conversion pattern), it's already the target type.
+	// OpCopyLogical requires Result Type != Operand type — skip if same.
+	currentTypeID, _ := e.backend.emitType(*valueTypeHandle)
+	if valueIsWG {
+		// Value loaded from Workgroup — check if load-time conversion already applied.
+		// After our load-conversion fix, Workgroup loads return decorated types.
+		// If the target (decorated) matches what the value already is, skip.
+		if targetTypeID == currentTypeID {
+			return valueID
+		}
+	}
+
 	// Bump SPIR-V version to 1.4 (minimum for OpCopyLogical).
 	e.backend.requireSpirvVersion14()
 
@@ -4155,6 +4181,12 @@ func (e *ExpressionEmitter) emitAccess(exprHandle ir.ExpressionHandle, access ir
 		// See VUID-RuntimeSpirv-NonUniform-06274.
 		if isNonUniformBA {
 			e.backend.decorateNonUniformBindingArrayAccess(loadID)
+		}
+
+		// Convert layout-free → decorated after loading from Workgroup.
+		if storageClass == StorageClassWorkgroup && accessElementTypeID != elementTypeID {
+			e.backend.requireSpirvVersion14()
+			loadID = e.backend.builder.AddCopyLogical(elementTypeID, loadID)
 		}
 
 		return loadID, nil
@@ -4409,7 +4441,15 @@ func (e *ExpressionEmitter) emitAccessIndex(exprHandle ir.ExpressionHandle, acce
 		}
 
 		// Auto-load the value - emitExpression should return VALUES, not pointers
-		return e.backend.builder.AddLoad(accessElementTypeID, ptrID), nil
+		loadID := e.backend.builder.AddLoad(accessElementTypeID, ptrID)
+
+		// Convert layout-free → decorated after loading from Workgroup.
+		if storageClass == StorageClassWorkgroup && accessElementTypeID != elementTypeID {
+			e.backend.requireSpirvVersion14()
+			loadID = e.backend.builder.AddCopyLogical(elementTypeID, loadID)
+		}
+
+		return loadID, nil
 	}
 
 	// Check if the base was spilled by a previous Access expression
@@ -4848,7 +4888,20 @@ func (e *ExpressionEmitter) emitLoad(load ir.ExprLoad) (uint32, error) {
 	// The OpLoad result type must match the pointer's pointee type, which is layout-free.
 	storageClass := e.getExpressionStorageClass(load.Pointer)
 	resultType := e.dereferencePointerTypeForStorageClass(pointerType, storageClass)
-	return e.backend.builder.AddLoad(resultType, pointerID), nil
+	loadedID := e.backend.builder.AddLoad(resultType, pointerID)
+
+	// Single conversion point: immediately convert layout-free → decorated after
+	// loading from Workgroup. All downstream uses (OpFunctionCall, OpStore,
+	// OpCompositeExtract, etc.) see the correct decorated type.
+	if storageClass == StorageClassWorkgroup {
+		decoratedType := e.dereferencePointerTypeForStorageClass(pointerType, StorageClassFunction)
+		if decoratedType != resultType {
+			e.backend.requireSpirvVersion14()
+			return e.backend.builder.AddCopyLogical(decoratedType, loadedID), nil
+		}
+	}
+
+	return loadedID, nil
 }
 
 // dereferencePointerTypeForStorageClass extracts the base type, using layout-free types


### PR DESCRIPTION
## Summary

Fixes BUG-SPIRV-002 — regression from v0.17.1 Workgroup ArrayStride fix.

Values loaded from `Workgroup` variables had layout-free types that propagated into `OpFunctionCall` arguments, causing type mismatch with decorated function parameters. 4 Vello tilecompute shaders failed spirv-val v2026.1.

**Fix:** insert `OpCopyLogical` (layout-free → decorated) immediately after every `OpLoad` from Workgroup — single conversion point in `emitLoad`, `emitAccess`, `emitAccessIndex`. Guard `maybeCopyLogicalForStore` against double-conversion.

Closes gogpu/wgpu#134. Reported by @SideFx via gogpu/ui#67.

## Test plan

- [x] spirv-val v2026.1: 164/164 naga snapshot shaders pass
- [x] spirv-val v2026.1: 23/23 gg GPU shaders pass (14 gpu + 9 tilecompute)
- [x] Workgroup ArrayStride fix still works (no regression on BUG-SPIRV-001)
- [x] golangci-lint 0 issues
- [ ] @SideFx confirms text visible on Adreno Vulkan (post-cascade)