### PR TITLE
feat(dxil): 94 golden diff=0, 48.1% parity — output promotion, sig ordering, raw buffer i32

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,15 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   storage texture format classification, used by DXIL backend for correct
   component type metadata.
 
+- **Single-store local promotion** — new emitter optimization that detects
+  vector/scalar locals stored exactly once in straight-line code and resolves
+  loads directly to the stored value, eliminating alloca/store/load chains
+  for vertex/fragment output staging. Matches DXC's direct `storeOutput`
+  pattern.
+
+- **Strength reduction** — `urem x, 2^N` emitted as `and x, (2^N-1)` at
+  emit time, matching DXC's LLVM InstCombine optimization.
+
 ### Fixed (DXIL)
 
 - **UNorm/SNorm component types** — storage textures with `rgba8unorm` now
@@ -38,6 +47,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   vertex/primitive output functions now get correct `nounwind readonly`
   attributes instead of plain `nounwind`.
 
+- **HLSL namer suffix on resource names** — resource metadata names now get
+  trailing `_` when ending with a digit or matching an HLSL keyword,
+  matching the DXC roundtrip path (WGSL→HLSL→DXC→DXIL).
+
+- **Sampler heap handles after input loads** — `emitSamplerHeapHandles()`
+  moved after `emitInputLoads()` to match DXC emit ordering for fragment
+  shaders with both samplers and input varyings.
+
+- **Raw buffer float loads use i32 overload** — `bufferLoad` for
+  ByteAddressBuffer now always uses i32 overload with bitcast to float,
+  matching DXC behavior. Fixes `%dx.types.ResRet.f32` → `.i32` type
+  declaration difference.
+
+- **Fragment input signature ordering** — LOC semantics sorted before
+  SV_Position in fragment shader input signatures, matching DXC convention.
+  Applied across ISG1, metadata, loadInput, and ViewID analysis.
+
+- **Input used mask sorted order** — `computeInputElementUsedMasks` now
+  iterates in sorted signature order, fixing incorrect extended properties
+  metadata for fragment shaders with multiple struct inputs.
+
 ### Changed
 
 - **DXC golden normalizer** — function declarations and attribute definitions
@@ -46,8 +76,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Metrics
 
-- DXC golden diff=0: 72 → **82** (+10)
-- Line parity: 45.7% → **46.4%**
+- DXC golden diff=0: 72 → **94** (+22)
+- Line parity: 45.7% → **48.1%**
 - IDxcValidator: 161/170 (94.7%, unchanged)
 - gg production: 58/59 (fine.wgsl pre-existing failure)
 - Text backends: 100% (unchanged)

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@
 - **MSL Backend** — Metal Shading Language output for macOS/iOS (**91/91 exact Rust naga parity**), vertex pulling transform, external textures, override pipeline constants
 - **GLSL Backend** — OpenGL Shading Language for OpenGL 3.3+, ES 3.0+ (**68/68 exact Rust naga parity**), dead code elimination, ProcessOverrides, image bounds checking
 - **HLSL Backend** — High-Level Shading Language for DirectX 11/12 (**72/72 exact Rust naga parity**)
-- **DXIL Backend** (experimental) — Direct DXIL generation from naga IR (**161/170 IDxcValidator validation, 94.7%**; **82/208 DXC golden parity, diff=0**; **gg production: 58/59 entry points VALID**; visual: renders circles + text on D3D12). LLVM 3.7 bitcode with dx.op intrinsics, DXBC container. Vertex, fragment, compute, and mesh shaders (SM 6.0-6.5). CBV/SRV/UAV (read-only storage as SRV, read-write as UAV), atomics (i32/i64/f32 + image), barriers, ray query (35 intrinsics), wave/subgroup ops (13 intrinsics), texture sampling (8 variants), matrix scalarization, pack/unpack, helper functions. Optimization passes: DCE (mark-and-sweep), SROA (struct decomposition), mem2reg (SSA promotion), function inlining (early-return wrapping). `Options.BindingMap` for WGSL→DXIL `(space, register)` remap (wgpu root signature compatibility). Eliminates FXC/DXC dependency. `dxil.Compile()` API. ~48K LOC, 315 unit tests. World's first Pure Go DXIL generator.
+- **DXIL Backend** (experimental) — Direct DXIL generation from naga IR (**161/170 IDxcValidator validation, 94.7%**; **94/208 DXC golden parity, diff=0**; **gg production: 58/59 entry points VALID**; visual: renders circles + text on D3D12). LLVM 3.7 bitcode with dx.op intrinsics, DXBC container. Vertex, fragment, compute, and mesh shaders (SM 6.0-6.5). CBV/SRV/UAV (read-only storage as SRV, read-write as UAV), atomics (i32/i64/f32 + image), barriers, ray query (35 intrinsics), wave/subgroup ops (13 intrinsics), texture sampling (8 variants), matrix scalarization, pack/unpack, helper functions. Optimization passes: DCE (mark-and-sweep), SROA (struct decomposition), mem2reg (SSA promotion), single-store local promotion, function inlining (early-return wrapping), strength reduction. `Options.BindingMap` for WGSL→DXIL `(space, register)` remap (wgpu root signature compatibility). Eliminates FXC/DXC dependency. `dxil.Compile()` API. ~50K LOC, 330+ unit tests. World's first Pure Go DXIL generator.
 - **Type Conversions** — Scalar constructors `f32(x)`, `u32(y)`, `i32(z)` with correct SPIR-V opcodes
 - **Bitcast** — `bitcast<T>(expr)` for reinterpreting bit patterns between types
 - **Warnings** — Unused variable detection with `_` prefix exception
@@ -248,7 +248,7 @@ naga/                              ~192K LOC total
 │   ├── storage.go     # Buffer/atomic operations
 │   ├── functions.go   # Entry points with semantics
 │   └── keywords.go    # HLSL reserved words
-├── dxil/              # DXIL backend (~48K LOC, 161/170 IDxcValidator)
+├── dxil/              # DXIL backend (~50K LOC, 161/170 IDxcValidator)
 │   ├── dxil.go        # Public API: Compile(), DefaultOptions()
 │   └── internal/      # All implementation internal
 │       ├── bitcode/   # LLVM 3.7 bit-level writer

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -32,9 +32,9 @@
   - MSL: 91/91 Rust naga parity (Metal)
   - GLSL: 68/68 Rust naga parity (OpenGL)
   - HLSL: 72/72 Rust naga parity (DirectX 11/12)
-  - DXIL: **161/170 IDxcValidator (94.7%)**, 82/208 DXC golden parity (DirectX 12, SM 6.0-6.5) — world's first Pure Go DXIL generator
+  - DXIL: **161/170 IDxcValidator (94.7%)**, 94/208 DXC golden parity (DirectX 12, SM 6.0-6.5) — world's first Pure Go DXIL generator
   - IR: 144/144 Rust naga parity
-- **DXIL backend** (~48K LOC, 315 unit tests) — VS/PS/CS/MS, CBV/SRV/UAV (read-only storage → SRV, read-write → UAV), atomics (i32/i64/f32 + image), barriers, ray query (35 intrinsics), wave ops (13 intrinsics), mesh shaders (SM 6.5), texture sampling (8 variants), matrix scalarization, pack/unpack, helper functions. Optimization passes: DCE, SROA, mem2reg, function inlining. `Options.BindingMap` for wgpu root signature compatibility. Eliminates FXC/DXC dependency. Verified 2400+ frames at 60 FPS on D3D12. Renders circles + text in gg production integration. Rust naga has NOT implemented this (open issue since 2020)
+- **DXIL backend** (~50K LOC, 330+ unit tests) — VS/PS/CS/MS, CBV/SRV/UAV (read-only storage → SRV, read-write → UAV), atomics (i32/i64/f32 + image), barriers, ray query (35 intrinsics), wave ops (13 intrinsics), mesh shaders (SM 6.5), texture sampling (8 variants), matrix scalarization, pack/unpack, helper functions. Optimization passes: DCE, SROA, mem2reg, single-store local promotion, function inlining, strength reduction. `Options.BindingMap` for wgpu root signature compatibility. Eliminates FXC/DXC dependency. Verified 2400+ frames at 60 FPS on D3D12. Renders circles + text in gg production integration. Rust naga has NOT implemented this (open issue since 2020)
 - **100+ WGSL built-in functions** — math, geometric, bit manipulation, packing, derivatives
 - **Compute shaders** — atomics (int32/int64/float32), barriers, workgroups, runtime-sized arrays
 - **Ray tracing** — ray query types, acceleration structures, 7 ray query builtins
@@ -73,7 +73,7 @@
 | **DXIL Phase 2a: Compute foundation** | P2 | 5 | ✅ Done. Thread IDs, numthreads, UAV bufferLoad/bufferStore. |
 | **DXIL Phase 2b: Atomics + barriers** | P2 | 3 | ✅ Done. atomicBinOp (8 ops), atomicCmpXchg, dx.op.barrier, workgroup atomicrmw/cmpxchg. |
 | **DXIL Phase 2c: Mesh shaders** | P2 | 5 | ✅ Done. SM 6.5 intrinsics (168-172), PSG1 signatures, mesh metadata. |
-| **DXIL DXC validation** | ✅ Done | — | **161/170 IDxcValidator (94.7%)**. 82/208 DXC golden parity. gg 58/59. All features: ray query, image atomics, wave ops. |
+| **DXIL DXC validation** | ✅ Done | — | **161/170 IDxcValidator (94.7%)**. 94/208 DXC golden parity. gg 58/59. All features: ray query, image atomics, wave ops. |
 | **DXIL Phase 3: SM 6.x features** | ✅ Done | — | Ray query (SM 6.5), wave intrinsics (SM 6.0), mesh shaders (SM 6.5), image atomics. |
 | **DXIL real validation — `IDxcValidator` wrapper** | ✅ Done | — | `cmd/dxilval` CLI + `internal/dxcvalidator` Pure Go wrapper around Microsoft `dxil.dll` (zero CGO). Three-layer defensive stack: (0) emitter assertion against null entry-point function refs, (1) `PreCheckContainer` fixed-offset DXBC structural check, (2) `bitcheck.Check` minimal LLVM 3.7 bitstream walker verifying `!dx.entryPoints[i][0]` is non-null. Prevents the `dxil.dll+0xe9da` AV class on any input (our own naga output, DXC output, third-party tool output, hand-crafted garbage). Closes BUG-DXIL-VALIDATOR-REAL. |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -112,7 +112,7 @@ naga/                              ~189K LOC total
 │   ├── functions.go               # Entry points with semantics
 │   └── keywords.go                # HLSL reserved words
 │
-├── dxil/                          # DXIL backend (~48K LOC, 161/170 IDxcValidator, experimental)
+├── dxil/                          # DXIL backend (~50K LOC, 161/170 IDxcValidator, experimental)
 │   ├── dxil.go                    # Public API: Compile, DefaultOptions, Options, ShaderModel
 │   ├── sig_usage.go               # Input signature Used mask analysis
 │   ├── validate.go                # IDxcValidator integration

--- a/dxil/dxil.go
+++ b/dxil/dxil.go
@@ -441,7 +441,7 @@ func buildSignatures(irMod *ir.Module, ep *ir.EntryPoint, isFragment bool) ([]co
 	// This mirrors DXC's MarkUsedSignatureElements pass which sets
 	// AlwaysReadsMask based on actual loadInput instructions in the bitcode.
 	usedMasks := computeInputUsedMasks(irMod, &ep.Function)
-	flatArgMapping := buildFlatArgMapping(irMod, ep.Function.Arguments)
+	flatArgMapping := buildFlatArgMapping(irMod, ep.Function.Arguments, isVSInput)
 
 	inputs := make([]container.SignatureElement, 0, len(bindings))
 	for i, b := range bindings {
@@ -552,7 +552,7 @@ func collectFlatBindings(
 	irMod *ir.Module,
 	args []ir.FunctionArgument,
 	_ []ir.StructMember,
-	_ ir.ShaderStage,
+	stage ir.ShaderStage,
 	_ bool,
 ) ([]ir.Binding, []ir.TypeHandle) {
 	var bindings []ir.Binding
@@ -578,18 +578,34 @@ func collectFlatBindings(
 			types = append(types, m.Type)
 		}
 	}
+	// Sort across all arguments so locations come before builtins.
+	// Within-struct ordering is handled by SortedMemberIndices above,
+	// but when multiple struct-typed arguments contribute members (e.g.,
+	// fs_main(in: VertexOutput, note: NoteInstance)), the cross-argument
+	// ordering must also be locations-first to match DXC's fragment input
+	// register assignment. VS inputs use InputAssembler packing which
+	// preserves declaration order.
+	backend.SortFlatBindings(bindings, types, stage == ir.StageVertex)
 	return bindings, types
 }
 
 // buildFlatArgMapping constructs a parallel mapping from the flat binding list
 // (as produced by collectFlatBindings) back to (argIdx, memberIdx) keys for the
-// input usage analysis. The iteration order MUST match collectFlatBindings exactly.
-func buildFlatArgMapping(irMod *ir.Module, args []ir.FunctionArgument) []inputUsageKey {
-	var keys []inputUsageKey
+// input usage analysis. The iteration order MUST match collectFlatBindings exactly,
+// including the cross-argument locations-first sort for non-VS inputs.
+func buildFlatArgMapping(irMod *ir.Module, args []ir.FunctionArgument, isVSInput bool) []inputUsageKey {
+	type keyedBinding struct {
+		key     inputUsageKey
+		binding ir.Binding
+	}
+	var items []keyedBinding
 	for argIdx := range args {
 		arg := &args[argIdx]
 		if arg.Binding != nil {
-			keys = append(keys, inputUsageKey{argIdx: argIdx, memberIdx: -1})
+			items = append(items, keyedBinding{
+				key:     inputUsageKey{argIdx: argIdx, memberIdx: -1},
+				binding: *arg.Binding,
+			})
 			continue
 		}
 		argType := irMod.Types[arg.Type]
@@ -603,8 +619,24 @@ func buildFlatArgMapping(irMod *ir.Module, args []ir.FunctionArgument) []inputUs
 			if m.Binding == nil {
 				continue
 			}
-			keys = append(keys, inputUsageKey{argIdx: argIdx, memberIdx: idx})
+			items = append(items, keyedBinding{
+				key:     inputUsageKey{argIdx: argIdx, memberIdx: idx},
+				binding: *m.Binding,
+			})
 		}
+	}
+	// Apply the same cross-argument sort as collectFlatBindings.
+	// VS inputs use InputAssembler packing which preserves declaration order.
+	if !isVSInput {
+		sort.SliceStable(items, func(i, j int) bool {
+			ki := backend.NewMemberInterfaceKey(&items[i].binding)
+			kj := backend.NewMemberInterfaceKey(&items[j].binding)
+			return backend.MemberInterfaceLess(ki, kj)
+		})
+	}
+	keys := make([]inputUsageKey, len(items))
+	for i, item := range items {
+		keys[i] = item.key
 	}
 	return keys
 }

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -5706,3 +5706,92 @@ func TestEmitRawBufferIntStoreNoBitcast(t *testing.T) {
 		t.Errorf("expected 0 bitcast instructions for integer UAV store, got %d", bitcastCount)
 	}
 }
+
+// TestResourceNameSuffix verifies that the DXIL emitter applies the
+// HLSL namer trailing-underscore convention to resource names in
+// dx.resources metadata. DXC processes HLSL variable names through
+// its namer (Rust naga proc::Namer) which appends "_" when the name
+// ends with a digit or is an HLSL keyword. Our DXIL backend must
+// match this convention so dxc -dumpbin shows identical resource
+// names in the Resource Bindings comment table.
+func TestResourceNameSuffix(t *testing.T) {
+	tests := []struct {
+		irName   string
+		wantName string
+	}{
+		// Ends with digit -> trailing underscore
+		{"t1", "t1_"},
+		{"atomic_i32", "atomic_i32_"},
+		{"input3", "input3_"},
+		// HLSL keyword -> trailing underscore
+		{"in", "in_"},
+		{"out", "out_"},
+		{"indices", "indices_"},
+		// Normal name -> no change
+		{"data", "data"},
+		{"params", "params"},
+		{"camera", "camera"},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.irName, func(t *testing.T) {
+			u32Handle := ir.TypeHandle(0)
+			arrayU32Handle := ir.TypeHandle(1)
+
+			mod := &ir.Module{
+				Types: []ir.Type{
+					{Inner: ir.ScalarType{Kind: ir.ScalarUint, Width: 4}},
+					{Inner: ir.ArrayType{
+						Base:   u32Handle,
+						Size:   ir.ArraySize{},
+						Stride: 4,
+					}},
+				},
+				GlobalVariables: []ir.GlobalVariable{
+					{
+						Name:   tt.irName,
+						Space:  ir.SpaceStorage,
+						Access: ir.StorageReadWrite,
+						Binding: &ir.ResourceBinding{
+							Group:   0,
+							Binding: 0,
+						},
+						Type: arrayU32Handle,
+					},
+				},
+				EntryPoints: []ir.EntryPoint{
+					{
+						Name:      "main",
+						Stage:     ir.StageCompute,
+						Function:  ir.Function{Name: "main"},
+						Workgroup: [3]uint32{1, 1, 1},
+					},
+				},
+			}
+
+			result, err := Emit(mod, EmitOptions{
+				ShaderModelMajor: 6,
+				ShaderModelMinor: 0,
+				ReachableGlobals: map[ir.GlobalVariableHandle]bool{0: true},
+			})
+			if err != nil {
+				t.Fatalf("Emit failed: %v", err)
+			}
+
+			// Find the resource name in metadata strings. The name
+			// appears as an MDString operand in the dx.resources
+			// metadata tuple. Scan all metadata for string nodes
+			// containing the expected name.
+			found := false
+			for _, md := range result.Metadata {
+				if md.Kind == module.MDString && md.StringValue == tt.wantName {
+					found = true
+					break
+				}
+			}
+			if !found {
+				t.Errorf("metadata string %q not found; IR name was %q", tt.wantName, tt.irName)
+			}
+		})
+	}
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -5795,3 +5795,124 @@ func TestResourceNameSuffix(t *testing.T) {
 		})
 	}
 }
+
+// TestSamplerHeapHandleAfterInputLoads verifies that in fragment shaders with
+// sampler heap bindings, dx.op.loadInput calls for interpolated varyings appear
+// BEFORE dx.op.bufferLoad calls for the sampler heap index lookup. DXC's lazy
+// evaluation produces this ordering because loadInput for vertex inputs is
+// resolved before the sampler index indirection at the sample call site. We
+// match by emitting sampler heap handles after input loads in emitEntryPoint.
+func TestSamplerHeapHandleAfterInputLoads(t *testing.T) {
+	vec4f32Handle := ir.TypeHandle(1)
+	vec2f32Handle := ir.TypeHandle(2)
+	tex2dHandle := ir.TypeHandle(3)
+	samplerTyHandle := ir.TypeHandle(4)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},                                         // [0] f32
+			{Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},         // [1] vec4<f32>
+			{Inner: ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},         // [2] vec2<f32>
+			{Inner: ir.ImageType{Dim: ir.Dim2D, Class: ir.ImageClassSampled, SampledKind: ir.ScalarFloat}}, // [3] texture_2d<f32>
+			{Inner: ir.SamplerType{Comparison: false}},                                                     // [4] sampler
+		},
+		GlobalVariables: []ir.GlobalVariable{
+			{Name: "tex", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 0}, Type: tex2dHandle},
+			{Name: "samp", Space: ir.SpaceHandle, Binding: &ir.ResourceBinding{Group: 0, Binding: 1}, Type: samplerTyHandle},
+		},
+	}
+
+	// Build a fragment shader: @fragment fn main(@location(0) uv: vec2<f32>) -> @location(0) vec4<f32>
+	// that does textureSample(tex, samp, uv).
+	uvBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+
+	sampleExprHandle := ir.ExpressionHandle(3)
+
+	fn := ir.Function{
+		Name: "main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "uv", Type: vec2f32Handle, Binding: &uvBinding},
+		},
+		Result: &ir.FunctionResult{
+			Type:    vec4f32Handle,
+			Binding: &resultBinding,
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},                       // [0] uv
+			{Kind: ir.ExprGlobalVariable{Variable: 0}},                      // [1] tex
+			{Kind: ir.ExprGlobalVariable{Variable: 1}},                      // [2] samp
+			{Kind: ir.ExprImageSample{Image: 1, Sampler: 2, Coordinate: 0}}, // [3] textureSample
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec2f32Handle},   // uv
+			{Handle: &tex2dHandle},     // tex
+			{Handle: &samplerTyHandle}, // samp
+			{Handle: &vec4f32Handle},   // sample result
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 4}}},
+			{Kind: ir.StmtReturn{Value: &sampleExprHandle}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	result, err := Emit(mod, EmitOptions{
+		ShaderModelMajor: 6,
+		ShaderModelMinor: 0,
+		ReachableGlobals: map[ir.GlobalVariableHandle]bool{0: true, 1: true},
+	})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Find the entry function body.
+	var entryFn *module.Function
+	for _, fn := range result.Functions {
+		if !fn.IsDeclaration && fn.Name == "main" {
+			entryFn = fn
+			break
+		}
+	}
+	if entryFn == nil {
+		t.Fatal("entry function 'main' not found")
+	}
+	if len(entryFn.BasicBlocks) == 0 {
+		t.Fatal("entry function has no basic blocks")
+	}
+
+	// Walk the instruction sequence and record the position of:
+	// - first dx.op.loadInput call (input varyings)
+	// - first dx.op.bufferLoad call (sampler heap index lookup)
+	firstLoadInput := -1
+	firstBufferLoad := -1
+	bb := entryFn.BasicBlocks[0]
+	for i, instr := range bb.Instructions {
+		if instr.Kind != module.InstrCall || instr.CalledFunc == nil {
+			continue
+		}
+		name := instr.CalledFunc.Name
+		if firstLoadInput < 0 && (name == "dx.op.loadInput.f32" || name == "dx.op.loadInput.i32") {
+			firstLoadInput = i
+		}
+		if firstBufferLoad < 0 && name == "dx.op.bufferLoad.i32" {
+			firstBufferLoad = i
+		}
+	}
+
+	if firstLoadInput < 0 {
+		t.Fatal("no dx.op.loadInput call found in entry function")
+	}
+	if firstBufferLoad < 0 {
+		t.Fatal("no dx.op.bufferLoad call found in entry function (sampler heap)")
+	}
+
+	if firstLoadInput >= firstBufferLoad {
+		t.Errorf("dx.op.loadInput (pos %d) should appear BEFORE dx.op.bufferLoad (pos %d); "+
+			"DXC emits loadInput for interpolated varyings before sampler heap index lookups",
+			firstLoadInput, firstBufferLoad)
+	}
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -3002,33 +3002,22 @@ func TestEmitMultipleLocals(t *testing.T) {
 		t.Fatal("main function not found")
 	}
 
-	// Two local variables should produce exactly 2 alloca instructions.
+	// Single-store scalar locals are promoted directly to SSA values,
+	// bypassing alloca/store/load. This matches DXC's mem2reg behavior
+	// for locals stored once in straight-line code.
 	allocaCount := countInstrKind(mod, module.InstrAlloca)
-	if allocaCount != 2 {
-		t.Errorf("expected 2 alloca instructions for 2 local vars, got %d", allocaCount)
+	if allocaCount != 0 {
+		t.Errorf("expected 0 alloca instructions (single-store promotion), got %d", allocaCount)
 	}
 
-	// 2 stores (a = 1.0, b = 2.0).
 	storeCount := countInstrKind(mod, module.InstrStore)
-	if storeCount != 2 {
-		t.Errorf("expected 2 store instructions, got %d", storeCount)
+	if storeCount != 0 {
+		t.Errorf("expected 0 store instructions (single-store promotion), got %d", storeCount)
 	}
 
-	// 2 loads (load a, load b).
 	loadCount := countInstrKind(mod, module.InstrLoad)
-	if loadCount != 2 {
-		t.Errorf("expected 2 load instructions, got %d", loadCount)
-	}
-
-	// Verify alloca result types are pointer types to f32.
-	for _, bb := range mainFn.BasicBlocks {
-		for _, instr := range bb.Instructions {
-			if instr.Kind == module.InstrAlloca {
-				if instr.ResultType == nil || instr.ResultType.Kind != module.TypePointer {
-					t.Errorf("alloca should produce pointer type, got %v", instr.ResultType)
-				}
-			}
-		}
+	if loadCount != 0 {
+		t.Errorf("expected 0 load instructions (single-store promotion), got %d", loadCount)
 	}
 
 	bc := module.Serialize(mod)
@@ -6108,4 +6097,269 @@ func TestSamplerHeapHandleAfterInputLoads(t *testing.T) {
 			"DXC emits loadInput for interpolated varyings before sampler heap index lookups",
 			firstLoadInput, firstBufferLoad)
 	}
+}
+
+// buildStructReturnVertex creates a vertex shader that returns a struct
+// through a local variable:
+//
+//	struct VertexOutput {
+//	    @location(0) color: vec3<f32>,
+//	    @builtin(position) position: vec4<f32>,
+//	}
+//	@vertex fn vs_main(@location(0) in_color: vec3<f32>) -> VertexOutput {
+//	    var out: VertexOutput;
+//	    out.color = in_color;
+//	    out.position = vec4<f32>(1.0, 2.0, 0.0, 1.0);
+//	    return out;
+//	}
+func buildStructReturnVertex() *ir.Module {
+	vec3Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+	structHandle := ir.TypeHandle(2)
+	f32Handle := ir.TypeHandle(3)
+
+	locBinding0 := ir.Binding(ir.LocationBinding{Location: 0})
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "VertexOutput", Inner: ir.StructType{
+				Members: []ir.StructMember{
+					{Name: "color", Type: vec3Handle, Offset: 0, Binding: &locBinding0},
+					{Name: "position", Type: vec4Handle, Offset: 16, Binding: &posBinding},
+				},
+				Span: 32,
+			}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+		},
+	}
+
+	// Expression handles
+	lvH := ir.ExpressionHandle(1)
+	colorFieldH := ir.ExpressionHandle(2)
+	posFieldH := ir.ExpressionHandle(3)
+	literal1 := ir.ExpressionHandle(4)
+	literal2 := ir.ExpressionHandle(5)
+	literal0 := ir.ExpressionHandle(6)
+	composeH := ir.ExpressionHandle(7)
+	loadH := ir.ExpressionHandle(8)
+
+	fn := ir.Function{
+		Name: "vs_main",
+		Arguments: []ir.FunctionArgument{
+			{Name: "in_color", Type: vec3Handle, Binding: &locBinding0},
+		},
+		Result: &ir.FunctionResult{
+			Type:    structHandle,
+			Binding: nil,
+		},
+		LocalVars: []ir.LocalVariable{
+			{Name: "out", Type: structHandle, Init: nil},
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprFunctionArgument{Index: 0}},
+			{Kind: ir.ExprLocalVariable{Variable: 0}},
+			{Kind: ir.ExprAccessIndex{Base: lvH, Index: 0}},
+			{Kind: ir.ExprAccessIndex{Base: lvH, Index: 1}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(2.0)}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(0.0)}},
+			{Kind: ir.ExprCompose{Type: vec4Handle, Components: []ir.ExpressionHandle{literal1, literal2, literal0, literal1}}},
+			{Kind: ir.ExprLoad{Pointer: lvH}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec3Handle},
+			{Handle: &structHandle},
+			{Handle: &vec3Handle},
+			{Handle: &vec4Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &f32Handle},
+			{Handle: &vec4Handle},
+			{Handle: &structHandle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 4}}},
+			{Kind: ir.StmtStore{Pointer: colorFieldH, Value: ir.ExpressionHandle(0)}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 8}}},
+			{Kind: ir.StmtStore{Pointer: posFieldH, Value: composeH}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 8, End: 9}}},
+			{Kind: ir.StmtReturn{Value: &loadH}},
+		},
+	}
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{Name: "vs_main", Stage: ir.StageVertex, Function: fn},
+	}
+
+	return mod
+}
+
+// TestOutputStructPromotion verifies that struct-typed local variables
+// used exclusively as output staging (var out: S; out.x = a; return out)
+// are identified as promotable by the analysis function.
+// DXC's SROA+mem2reg achieves the same elimination.
+func TestOutputStructPromotion(t *testing.T) {
+	irMod := buildStructReturnVertex()
+
+	mod := module.NewModule(module.VertexShader)
+	e := &Emitter{
+		ir:                   irMod,
+		mod:                  mod,
+		outputPromotedLocals: make(map[uint32]bool),
+		outputPromotedStores: make(map[outputStoreKey]ir.ExpressionHandle),
+	}
+
+	fn := &irMod.EntryPoints[0].Function
+	e.currentFn = fn
+
+	// Run the analysis.
+	e.analyzeOutputPromotableLocals(fn)
+
+	if !e.outputPromotedLocals[0] {
+		t.Fatal("expected local var 0 ('out') to be identified as output-promotable")
+	}
+}
+
+// TestOutputStructPromotionNotInLoop verifies that struct locals stored
+// inside control flow are NOT identified as output-promotable.
+func TestOutputStructPromotionNotInLoop(t *testing.T) {
+	irMod := buildStructReturnVertex()
+	fn := &irMod.EntryPoints[0].Function
+
+	// Wrap the stores inside an if block to make them non-promotable.
+	origBody := fn.Body
+	fn.Body = []ir.Statement{
+		{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 4}}},
+		{Kind: ir.StmtIf{
+			Condition: ir.ExpressionHandle(0), // doesn't matter
+			Accept:    origBody[1:4],          // stores + emits inside if
+			Reject:    nil,
+		}},
+		origBody[4], // emit for load
+		origBody[5], // return
+	}
+
+	mod := module.NewModule(module.VertexShader)
+	e := &Emitter{
+		ir:                   irMod,
+		mod:                  mod,
+		outputPromotedLocals: make(map[uint32]bool),
+		outputPromotedStores: make(map[outputStoreKey]ir.ExpressionHandle),
+	}
+	e.currentFn = fn
+
+	e.analyzeOutputPromotableLocals(fn)
+
+	if e.outputPromotedLocals[0] {
+		t.Fatal("expected local var 0 NOT to be promotable when stores are inside an if block")
+	}
+}
+
+// TestSingleStoreVectorLocalPromotion verifies that vector-typed locals
+// stored once in straight-line code are identified by analyzeSingleStoreLocals.
+// This covers the pattern created by SROA: struct decomposition produces
+// per-member vector locals with exactly one store and one load.
+func TestSingleStoreVectorLocalPromotion(t *testing.T) {
+	vec3Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Inner: ir.VectorType{Size: 3, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	resultBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	retH := ir.ExpressionHandle(6)
+
+	fn := ir.Function{
+		Name: "main",
+		Result: &ir.FunctionResult{
+			Type:    vec4Handle,
+			Binding: &resultBinding,
+		},
+		LocalVars: []ir.LocalVariable{
+			{Name: "color", Type: vec3Handle},    // stored once, loaded once
+			{Name: "position", Type: vec4Handle}, // stored once, loaded once
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprLocalVariable{Variable: 0}},                                         // [0] &color
+			{Kind: ir.ExprCompose{Type: vec3Handle}},                                          // [1] vec3(...)
+			{Kind: ir.ExprLocalVariable{Variable: 1}},                                         // [2] &position
+			{Kind: ir.ExprCompose{Type: vec4Handle}},                                          // [3] vec4(...)
+			{Kind: ir.ExprLoad{Pointer: ir.ExpressionHandle(0)}},                              // [4] load color
+			{Kind: ir.ExprLoad{Pointer: ir.ExpressionHandle(2)}},                              // [5] load position
+			{Kind: ir.ExprCompose{Type: vec4Handle, Components: []ir.ExpressionHandle{4, 5}}}, // [6]
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &vec3Handle}, {Handle: &vec3Handle},
+			{Handle: &vec4Handle}, {Handle: &vec4Handle},
+			{Handle: &vec3Handle}, {Handle: &vec4Handle},
+			{Handle: &vec4Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtStore{Pointer: ir.ExpressionHandle(0), Value: ir.ExpressionHandle(1)}},
+			{Kind: ir.StmtStore{Pointer: ir.ExpressionHandle(2), Value: ir.ExpressionHandle(3)}},
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 4, End: 7}}},
+			{Kind: ir.StmtReturn{Value: &retH}},
+		},
+	}
+
+	irMod.EntryPoints = []ir.EntryPoint{
+		{Name: "main", Stage: ir.StageFragment, Function: fn},
+	}
+
+	result := analyzeSingleStoreLocals(&fn, irMod)
+	if _, ok := result[0]; !ok {
+		t.Error("expected local var 0 (vec3 color) to be single-store promotable")
+	}
+	if _, ok := result[1]; !ok {
+		t.Error("expected local var 1 (vec4 position) to be single-store promotable")
+	}
+}
+
+// TestSingleStoreLocalNotInLoop verifies that locals stored inside control
+// flow are NOT identified as single-store promotable.
+func TestSingleStoreLocalNotInLoop(t *testing.T) {
+	f32Handle := ir.TypeHandle(0)
+	vec4Handle := ir.TypeHandle(1)
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+		},
+	}
+
+	fn := ir.Function{
+		Name: "main",
+		LocalVars: []ir.LocalVariable{
+			{Name: "x", Type: f32Handle},
+		},
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprLocalVariable{Variable: 0}},
+			{Kind: ir.Literal{Value: ir.LiteralF32(1.0)}},
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &f32Handle}, {Handle: &f32Handle},
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtIf{
+				Condition: ir.ExpressionHandle(1),
+				Accept: []ir.Statement{
+					{Kind: ir.StmtStore{Pointer: ir.ExpressionHandle(0), Value: ir.ExpressionHandle(1)}},
+				},
+			}},
+		},
+	}
+
+	result := analyzeSingleStoreLocals(&fn, irMod)
+	if _, ok := result[0]; ok {
+		t.Error("expected local var 0 NOT to be promotable when stored inside an if block")
+	}
+	_ = vec4Handle
 }

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -5707,6 +5707,199 @@ func TestEmitRawBufferIntStoreNoBitcast(t *testing.T) {
 	}
 }
 
+// buildComputeWithFloatVec2Load creates a compute shader module that loads
+// vec2<f32> from a storage buffer (ByteAddressBuffer).
+//
+//	@group(0) @binding(0) var<storage, read> data: array<vec2<f32>>;
+//	@group(0) @binding(1) var<storage, read_write> out: array<vec2<f32>>;
+//
+//	@compute @workgroup_size(1)
+//	fn main() {
+//	    out[0] = data[0];
+//	}
+func buildComputeWithFloatVec2Load() *ir.Module {
+	f32Handle := ir.TypeHandle(0)
+	vec2f32Handle := ir.TypeHandle(1)
+	arrayVec2Handle := ir.TypeHandle(2)
+	u32Handle := ir.TypeHandle(3)
+
+	mod := &ir.Module{
+		Types: []ir.Type{
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}},
+			{Name: "", Inner: ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Name: "", Inner: ir.ArrayType{Base: vec2f32Handle, Stride: 8}},
+			{Name: "", Inner: ir.ScalarType{Kind: ir.ScalarUint, Width: 4}},
+		},
+		GlobalVariables: []ir.GlobalVariable{
+			{
+				Name:   "data",
+				Space:  ir.SpaceStorage,
+				Access: ir.StorageRead,
+				Binding: &ir.ResourceBinding{
+					Group: 0, Binding: 0,
+				},
+				Type: arrayVec2Handle,
+			},
+			{
+				Name:   "out",
+				Space:  ir.SpaceStorage,
+				Access: ir.StorageReadWrite,
+				Binding: &ir.ResourceBinding{
+					Group: 0, Binding: 1,
+				},
+				Type: arrayVec2Handle,
+			},
+		},
+	}
+
+	// Load data[0], store to out[0].
+	fn := ir.Function{
+		Name: "main",
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprGlobalVariable{Variable: 0}},  // [0] &data
+			{Kind: ir.Literal{Value: ir.LiteralU32(0)}}, // [1] 0u
+			{Kind: ir.ExprAccess{Base: 0, Index: 1}},    // [2] &data[0]
+			{Kind: ir.ExprLoad{Pointer: 2}},             // [3] data[0]
+			{Kind: ir.ExprGlobalVariable{Variable: 1}},  // [4] &out
+			{Kind: ir.ExprAccess{Base: 4, Index: 1}},    // [5] &out[0]
+		},
+		ExpressionTypes: []ir.TypeResolution{
+			{Handle: &arrayVec2Handle},                            // &data
+			{Value: ir.ScalarType{Kind: ir.ScalarUint, Width: 4}}, // 0u
+			{Handle: &vec2f32Handle},                              // &data[0]
+			{Handle: &vec2f32Handle},                              // data[0]
+			{Handle: &arrayVec2Handle},                            // &out
+			{Handle: &vec2f32Handle},                              // &out[0]
+		},
+		Body: []ir.Statement{
+			{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 6}}},
+			{Kind: ir.StmtStore{Pointer: 5, Value: 3}},
+		},
+	}
+	_ = f32Handle
+	_ = u32Handle
+
+	mod.EntryPoints = []ir.EntryPoint{
+		{
+			Name:      "main",
+			Stage:     ir.StageCompute,
+			Function:  fn,
+			Workgroup: [3]uint32{1, 1, 1},
+		},
+	}
+
+	return mod
+}
+
+// TestEmitRawBufferFloatLoadUsesI32Overload verifies that float loads from
+// raw buffers (ByteAddressBuffer/RWByteAddressBuffer) use the i32 overload
+// with bitcast, matching DXC's convention. DXC always loads via
+// bufferLoad.i32 for raw buffers because HLSL's ByteAddressBuffer.Load
+// returns uint and asfloat() wraps it.
+//
+// Checks:
+//  1. dx.op.bufferLoad.i32 is declared (not .f32)
+//  2. Bitcast (i32->float) instructions are present in the function body
+//  3. ExtractValue instructions use i32 result type (not float)
+func TestEmitRawBufferFloatLoadUsesI32Overload(t *testing.T) {
+	irMod := buildComputeWithFloatVec2Load()
+
+	result, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	// Check declared functions: must have bufferLoad.i32, not bufferLoad.f32.
+	hasI32Load := false
+	hasF32Load := false
+	for _, fn := range result.Functions {
+		switch fn.Name {
+		case "dx.op.bufferLoad.i32":
+			hasI32Load = true
+		case "dx.op.bufferLoad.f32":
+			hasF32Load = true
+		}
+	}
+	if !hasI32Load {
+		t.Error("dx.op.bufferLoad.i32 not declared; raw buffer float loads must use i32 overload")
+	}
+	if hasF32Load {
+		t.Error("dx.op.bufferLoad.f32 declared; raw buffer float loads should NOT use f32 overload")
+	}
+
+	// Check that bitcast instructions (i32 -> float) exist in the main function.
+	mainFn := findMainFunction(result)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	bitcastCount := 0
+	bufferLoadI32Count := 0
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCast && len(instr.Operands) >= 2 &&
+				CastOpKind(instr.Operands[1]) == CastBitcast {
+				bitcastCount++
+			}
+			if instr.Kind == module.InstrCall && instr.CalledFunc != nil &&
+				instr.CalledFunc.Name == "dx.op.bufferLoad.i32" {
+				bufferLoadI32Count++
+			}
+		}
+	}
+
+	// vec2<f32> load: 2 extractvalue(i32) + 2 bitcast(i32->float) + store uses
+	// 2 bitcast(float->i32). Total bitcasts = 4 (2 load + 2 store).
+	if bitcastCount < 2 {
+		t.Errorf("expected at least 2 bitcast instructions (i32->float for vec2 load), got %d", bitcastCount)
+	}
+	if bufferLoadI32Count < 1 {
+		t.Errorf("expected at least 1 bufferLoad.i32 call, got %d", bufferLoadI32Count)
+	}
+
+	// Verify serialization.
+	bc := module.Serialize(result)
+	if len(bc) == 0 {
+		t.Fatal("serialization produced empty bitcode")
+	}
+
+	t.Logf("raw buffer float load: %d bitcasts, %d bufferLoad.i32 calls, %d bytes bitcode",
+		bitcastCount, bufferLoadI32Count, len(bc))
+}
+
+// TestEmitRawBufferIntLoadNoBitcast verifies that integer loads from raw
+// buffers do NOT produce unnecessary bitcast instructions — i32 values are
+// extracted directly from bufferLoad.i32 without any cast.
+func TestEmitRawBufferIntLoadNoBitcast(t *testing.T) {
+	irMod := buildComputeWithUAV() // loads u32, should use i32 directly
+
+	result, err := Emit(irMod, EmitOptions{ShaderModelMajor: 6, ShaderModelMinor: 0})
+	if err != nil {
+		t.Fatalf("Emit failed: %v", err)
+	}
+
+	mainFn := findMainFunction(result)
+	if mainFn == nil {
+		t.Fatal("main function not found")
+	}
+
+	// Count bitcast instructions in the main function. Integer loads from raw
+	// buffers should not need any bitcast (i32 load returns i32 directly).
+	bitcastCount := 0
+	for _, bb := range mainFn.BasicBlocks {
+		for _, instr := range bb.Instructions {
+			if instr.Kind == module.InstrCast && len(instr.Operands) >= 2 &&
+				CastOpKind(instr.Operands[1]) == CastBitcast {
+				bitcastCount++
+			}
+		}
+	}
+
+	if bitcastCount > 0 {
+		t.Errorf("expected 0 bitcast instructions for integer UAV load, got %d", bitcastCount)
+	}
+}
+
 // TestResourceNameSuffix verifies that the DXIL emitter applies the
 // HLSL namer trailing-underscore convention to resource names in
 // dx.resources metadata. DXC processes HLSL variable names through

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -6363,3 +6363,84 @@ func TestSingleStoreLocalNotInLoop(t *testing.T) {
 	}
 	_ = vec4Handle
 }
+
+// TestURemStrengthReduction verifies that unsigned modulo by a power
+// of 2 is strength-reduced to a bitwise AND. This matches DXC's LLVM
+// InstCombine pass: urem x, 2^N -> and x, (2^N - 1).
+func TestURemStrengthReduction(t *testing.T) {
+	e := &Emitter{
+		constMap:    make(map[int]*module.Constant),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+	}
+	e.mod = &module.Module{}
+
+	// Test power-of-2 constants.
+	tests := []struct {
+		value     int64
+		expectAnd bool
+		mask      int64
+	}{
+		{2, true, 1},
+		{4, true, 3},
+		{8, true, 7},
+		{16, true, 15},
+		{256, true, 255},
+		{1024, true, 1023},
+		{1, false, 0},  // 1 is NOT >= 2
+		{3, false, 0},  // 3 is not a power of 2
+		{5, false, 0},  // 5 is not a power of 2
+		{6, false, 0},  // 6 is not a power of 2
+		{7, false, 0},  // 7 is not a power of 2
+		{0, false, 0},  // 0 is not a power of 2
+		{-2, false, 0}, // negative values are not power of 2
+	}
+
+	for _, tt := range tests {
+		// Create a constant for the value.
+		constID := e.getIntConstID(tt.value)
+		maskID, ok := e.tryURemToBitwiseAnd(constID)
+		if ok != tt.expectAnd {
+			t.Errorf("tryURemToBitwiseAnd(%d): got ok=%v, want %v", tt.value, ok, tt.expectAnd)
+			continue
+		}
+		if ok {
+			maskConst, hasConst := e.constMap[maskID]
+			if !hasConst {
+				t.Errorf("tryURemToBitwiseAnd(%d): mask ID not in constMap", tt.value)
+				continue
+			}
+			if maskConst.IntValue != tt.mask {
+				t.Errorf("tryURemToBitwiseAnd(%d): mask = %d, want %d", tt.value, maskConst.IntValue, tt.mask)
+			}
+		}
+	}
+}
+
+// TestURemStrengthReductionNonInt verifies that float and undef
+// constants are not treated as power-of-2 for strength reduction.
+func TestURemStrengthReductionNonInt(t *testing.T) {
+	e := &Emitter{
+		constMap:    make(map[int]*module.Constant),
+		intConsts:   make(map[int64]int),
+		floatConsts: make(map[uint64]int),
+	}
+	e.mod = &module.Module{}
+
+	// Float constant should not trigger.
+	floatID := e.getFloatConstID(2.0)
+	if _, ok := e.tryURemToBitwiseAnd(floatID); ok {
+		t.Error("tryURemToBitwiseAnd should not trigger for float constant")
+	}
+
+	// Undef should not trigger.
+	undefID := e.getUndefConstID()
+	if _, ok := e.tryURemToBitwiseAnd(undefID); ok {
+		t.Error("tryURemToBitwiseAnd should not trigger for undef")
+	}
+
+	// Non-existent ID should not trigger.
+	if _, ok := e.tryURemToBitwiseAnd(99999); ok {
+		t.Error("tryURemToBitwiseAnd should not trigger for unknown value ID")
+	}
+}

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -3,6 +3,7 @@ package emit
 import (
 	"fmt"
 	"math"
+	"sort"
 
 	"github.com/gogpu/naga/dxil/internal/module"
 	"github.com/gogpu/naga/dxil/internal/viewid"
@@ -3036,46 +3037,88 @@ func (e *Emitter) emitGraphicsViewIDState(ep *ir.EntryPoint) {
 // (from sig_usage.go analysis) to per-input-signature-element masks, clamped
 // to the element's actual channel count. Returns nil-length slice when no
 // usage data is available.
+//
+// The iteration order MUST match the signature element order produced by
+// collectGraphicsSignatures / collectFlatArgBindings -- which sorts
+// locations before builtins for non-VS inputs. An earlier version
+// iterated arguments in declaration order, causing the usage mask for
+// a builtin (@builtin(position)) in arg0 to land on the LOC slot when
+// a location from arg1 was sorted first. This produced incorrect null
+// extended-properties metadata for used inputs and non-null for unused.
 func (e *Emitter) computeInputElementUsedMasks(ep *ir.EntryPoint, inElems []viewid.SigElement) []int64 {
 	masks := make([]int64, len(inElems))
 	if e.opts.InputUsedMasks == nil {
 		return masks
 	}
-	elemIdx := 0
-	for argIdx := range ep.Function.Arguments {
-		arg := &ep.Function.Arguments[argIdx]
-		argType := e.ir.Types[arg.Type]
-		if st, ok := argType.Inner.(ir.StructType); ok { //nolint:nestif // struct-member vs direct-binding dispatch
-			for mi := range st.Members {
-				if st.Members[mi].Binding == nil {
-					continue
-				}
-				if elemIdx >= len(masks) {
-					break
-				}
-				key := InputUsageKey{ArgIdx: argIdx, MemberIdx: mi}
-				mask := e.opts.InputUsedMasks[key]
-				channels := inElems[elemIdx].NumChannels
-				if channels > 0 && channels <= 4 {
-					mask &= uint8((1 << channels) - 1)
-				}
-				masks[elemIdx] = int64(mask)
-				elemIdx++
-			}
-		} else if arg.Binding != nil {
-			if elemIdx < len(masks) {
-				key := InputUsageKey{ArgIdx: argIdx, MemberIdx: -1}
-				mask := e.opts.InputUsedMasks[key]
-				channels := inElems[elemIdx].NumChannels
-				if channels > 0 && channels <= 4 {
-					mask &= uint8((1 << channels) - 1)
-				}
-				masks[elemIdx] = int64(mask)
-				elemIdx++
-			}
+	isVSInput := ep.Stage == ir.StageVertex
+	// Build sorted flat key list using the same convention as
+	// collectFlatArgBindings -- this guarantees element index i
+	// corresponds to inElems[i].
+	sortedKeys := buildSortedInputUsageKeys(e.ir, ep.Function.Arguments, isVSInput)
+	for i, key := range sortedKeys {
+		if i >= len(masks) {
+			break
 		}
+		mask := e.opts.InputUsedMasks[key]
+		channels := inElems[i].NumChannels
+		if channels > 0 && channels <= 4 {
+			mask &= uint8((1 << channels) - 1)
+		}
+		masks[i] = int64(mask)
 	}
 	return masks
+}
+
+// buildSortedInputUsageKeys produces an InputUsageKey per flat binding in
+// the same sorted order as collectFlatArgBindings. This mapping lets
+// computeInputElementUsedMasks look up the correct per-argument usage
+// mask for each signature element position.
+func buildSortedInputUsageKeys(irMod *ir.Module, args []ir.FunctionArgument, isVSInput bool) []InputUsageKey {
+	type keyedBinding struct {
+		key     InputUsageKey
+		binding ir.Binding
+	}
+	var items []keyedBinding
+	for argIdx := range args {
+		arg := &args[argIdx]
+		if arg.Binding != nil {
+			items = append(items, keyedBinding{
+				key:     InputUsageKey{ArgIdx: argIdx, MemberIdx: -1},
+				binding: *arg.Binding,
+			})
+			continue
+		}
+		argType := irMod.Types[arg.Type]
+		st, ok := argType.Inner.(ir.StructType)
+		if !ok {
+			continue
+		}
+		order := backend.SortedMemberIndices(st.Members)
+		for _, idx := range order {
+			m := st.Members[idx]
+			if m.Binding == nil {
+				continue
+			}
+			items = append(items, keyedBinding{
+				key:     InputUsageKey{ArgIdx: argIdx, MemberIdx: idx},
+				binding: *m.Binding,
+			})
+		}
+	}
+	// Apply the same cross-argument sort as collectFlatArgBindings.
+	// VS inputs use InputAssembler packing which preserves declaration order.
+	if !isVSInput && len(items) > 1 {
+		sort.SliceStable(items, func(i, j int) bool {
+			ki := backend.NewMemberInterfaceKey(&items[i].binding)
+			kj := backend.NewMemberInterfaceKey(&items[j].binding)
+			return backend.MemberInterfaceLess(ki, kj)
+		})
+	}
+	keys := make([]InputUsageKey, len(items))
+	for i, item := range items {
+		keys[i] = item.key
+	}
+	return keys
 }
 
 func sigInfosToViewIDElems(infos []dxilSigInfo) []viewid.SigElement {

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -1028,6 +1028,13 @@ func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
 		return fmt.Errorf("input loads: %w", err)
 	}
 
+	// Sampler-heap handles: emit bufferLoad+createHandle for each sampler
+	// binding AFTER loadInput calls. DXC's lazy evaluation places loadInput
+	// for vertex/fragment interpolants before the sampler index lookup from
+	// the heap index buffer. Calling this here (rather than inside
+	// emitResourceHandles) produces the same instruction ordering.
+	e.emitSamplerHeapHandles()
+
 	if err := e.emitFunctionBody(fn); err != nil {
 		return fmt.Errorf("function body: %w", err)
 	}

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -10,6 +10,14 @@ import (
 	"github.com/gogpu/naga/ir"
 )
 
+// outputStoreKey identifies a specific struct member within an
+// output-promoted local variable. Used as a map key to track the
+// value expression stored to each member.
+type outputStoreKey struct {
+	varIdx    uint32 // local variable index
+	memberIdx int    // struct member index (WGSL declaration order)
+}
+
 // Emitter translates naga IR into a DXIL module.
 type Emitter struct {
 	ir   *ir.Module
@@ -60,6 +68,37 @@ type Emitter struct {
 	// alloca+store path entirely — access code (getLocalConstVecLane)
 	// synthesizes per-lane selects or constant lookups.
 	localConstVecArrays map[uint32][][]float32
+
+	// outputPromotedLocals identifies struct-typed local variables that
+	// serve exclusively as output staging: each member is assigned once
+	// via field-level stores, and the struct is returned as the entry
+	// point's output. For such locals the alloca/GEP/store/load chain
+	// is unnecessary -- DXC's SROA + mem2reg eliminates it entirely,
+	// emitting direct dx.op.storeOutput calls instead. When a local is
+	// in this set, preAllocateLocalVars skips the alloca, store handlers
+	// record the value expression handle instead of emitting GEP+store,
+	// and emitStructReturnFromLoad evaluates the recorded expressions
+	// directly into storeOutput calls.
+	outputPromotedLocals map[uint32]bool
+
+	// outputPromotedStores records the value expression handle stored to
+	// each member of an output-promoted struct local. Keyed by
+	// (varIdx, memberIdx). The memberIdx is the WGSL struct member index,
+	// not the flat scalar index. At return time, emitStructReturnFromLoad
+	// evaluates each member's expression and emits per-component
+	// storeOutput calls.
+	outputPromotedStores map[outputStoreKey]ir.ExpressionHandle
+
+	// singleStoreLocals tracks vector/scalar locals that are stored to
+	// exactly once in straight-line code (top-level body, no control flow).
+	// For such locals the alloca/store/load chain is unnecessary -- we
+	// record the stored value expression handle and resolve loads directly
+	// to it. This extends the initOnlyLocals optimization to the common
+	// SROA decomposition pattern: after struct SROA, per-member vector
+	// locals are stored once and loaded once in the return Compose.
+	// DXC's mem2reg promotes both scalar AND vector locals; our mem2reg
+	// only handles scalars, so this fills the gap for vectors.
+	singleStoreLocals map[uint32]ir.ExpressionHandle
 
 	// initOnlyLocals tracks non-scalar locals (vector, array, struct)
 	// that have a non-nil Init expression and are never stored to in the
@@ -983,6 +1022,9 @@ func (e *Emitter) emitEntryPoint(ep *ir.EntryPoint) error {
 	e.localVarArrayTypes = make(map[uint32]*module.Type)
 	e.localConstVecArrays = make(map[uint32][][]float32)
 	e.initOnlyLocals = make(map[uint32]ir.ExpressionHandle)
+	e.singleStoreLocals = make(map[uint32]ir.ExpressionHandle)
+	e.outputPromotedLocals = make(map[uint32]bool)
+	e.outputPromotedStores = make(map[outputStoreKey]ir.ExpressionHandle)
 	e.globalVarAllocas = make(map[ir.GlobalVariableHandle]int)
 	e.globalVarAllocaTypes = make(map[ir.GlobalVariableHandle]*module.Type)
 	e.workgroupFieldPtrs = make(map[int]workgroupFieldOrigin)

--- a/dxil/internal/emit/emitter.go
+++ b/dxil/internal/emit/emitter.go
@@ -290,6 +290,13 @@ type Emitter struct {
 	// order. nil when no ViewID analysis has been performed (non-graphics
 	// stages).
 	inputUsedMasks []int64
+
+	// inputRowMap maps (argIdx, memberIdx) to ISG1 register row for input
+	// signature elements. Precomputed by emitInputLoads using the same
+	// sorted+packed order as collectFlatArgBindings + PackSignatureElements.
+	// Used by emitStructInputLoads to assign correct loadInput sigId values
+	// when cross-argument sorting places locations before builtins.
+	inputRowMap map[inputRowKey]int
 }
 
 // meshContext holds state for mesh shader intrinsic emission.
@@ -2680,7 +2687,7 @@ func (e *Emitter) collectGraphicsSignatures(ep *ir.EntryPoint, isFragment bool) 
 
 	// Inputs: flatten args + struct members into a single binding list.
 	{
-		bindings, types := collectFlatArgBindings(e.ir, fn.Arguments)
+		bindings, types := collectFlatArgBindings(e.ir, fn.Arguments, isVSInput)
 		infos := make([]backend.SigElementInfo, len(bindings))
 		for i, b := range bindings {
 			infos[i] = backend.SigElementInfoForBinding(e.ir, b, types[i], stage, false, interpFnIn)
@@ -2721,7 +2728,7 @@ func (e *Emitter) collectGraphicsSignatures(ep *ir.EntryPoint, isFragment bool) 
 // collectFlatArgBindings flattens a function's arg list (and any struct-typed
 // arg's members) into a sorted (binding, type) pair list using the shared
 // interface-order convention. Mirrors dxil/dxil.go collectFlatBindings.
-func collectFlatArgBindings(irMod *ir.Module, args []ir.FunctionArgument) ([]ir.Binding, []ir.TypeHandle) {
+func collectFlatArgBindings(irMod *ir.Module, args []ir.FunctionArgument, isVSInput bool) ([]ir.Binding, []ir.TypeHandle) {
 	var bindings []ir.Binding
 	var types []ir.TypeHandle
 	for _, arg := range args {
@@ -2745,6 +2752,12 @@ func collectFlatArgBindings(irMod *ir.Module, args []ir.FunctionArgument) ([]ir.
 			types = append(types, m.Type)
 		}
 	}
+	// Sort across all arguments so locations come before builtins.
+	// Within-struct ordering is handled by SortedMemberIndices above,
+	// but cross-argument ordering must also be locations-first to match
+	// DXC's fragment input register assignment. VS inputs use
+	// InputAssembler packing which preserves declaration order.
+	backend.SortFlatBindings(bindings, types, isVSInput)
 	return bindings, types
 }
 

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -90,6 +90,11 @@ func (e *Emitter) emitExpression(fn *ir.Function, handle ir.ExpressionHandle) (i
 		valueID, err = e.emitPhi(fn, ek)
 
 	case ir.ExprLocalVariable:
+		// Single-store locals bypass alloca -- their loads resolve to the
+		// stored value directly. Return a sentinel to prevent alloca creation.
+		if _, isSingle := e.singleStoreLocals[ek.Variable]; isSingle {
+			return 0, nil
+		}
 		valueID, err = e.emitLocalVariable(fn, ek)
 
 	case ir.ExprGlobalVariable:
@@ -3834,6 +3839,30 @@ func (e *Emitter) tryLoadInitOnly(fn *ir.Function, load ir.ExprLoad) (int, bool,
 	return id, true, nil
 }
 
+// tryLoadSingleStore resolves a load from a single-store vector/scalar local
+// directly to the stored value expression, bypassing alloca+store+load.
+// This mirrors DXC's mem2reg for the common SROA decomposition pattern.
+func (e *Emitter) tryLoadSingleStore(fn *ir.Function, load ir.ExprLoad) (int, bool, error) {
+	lv, ok := fn.Expressions[load.Pointer].Kind.(ir.ExprLocalVariable)
+	if !ok {
+		return 0, false, nil
+	}
+	valueHandle, isSingleStore := e.singleStoreLocals[lv.Variable]
+	if !isSingleStore {
+		return 0, false, nil
+	}
+	id, err := e.emitExpression(fn, valueHandle)
+	if err != nil {
+		return 0, false, err
+	}
+	// Propagate component tracking from the stored value expression so
+	// downstream getComponentID calls resolve correctly for the Load handle.
+	if comps, hasComps := e.exprComponents[valueHandle]; hasComps {
+		e.pendingComponents = comps
+	}
+	return id, true, nil
+}
+
 // Constant idx collapses at the validator's constant-folding step;
 // dynamic idx emits N-1 selects and N-1 icmps per lane. Per-lane
 // results are tracked via pendingComponents so downstream compose /
@@ -3919,6 +3948,16 @@ func (e *Emitter) emitLoad(fn *ir.Function, load ir.ExprLoad) (int, error) {
 	// value. This eliminates the alloca+load and matches DXC's SROA output
 	// for `var x = const_expr; return x` patterns.
 	if id, handled, emitErr := e.tryLoadInitOnly(fn, load); emitErr != nil {
+		return 0, emitErr
+	} else if handled {
+		return id, nil
+	}
+
+	// Single-store local optimization: if loading from a vector/scalar local
+	// that was stored to exactly once, resolve directly to the stored value
+	// expression. This eliminates alloca+store+load for per-member vector
+	// locals created by struct SROA, matching DXC's mem2reg output.
+	if id, handled, emitErr := e.tryLoadSingleStore(fn, load); emitErr != nil {
 		return 0, emitErr
 	} else if handled {
 		return id, nil

--- a/dxil/internal/emit/expressions.go
+++ b/dxil/internal/emit/expressions.go
@@ -1482,6 +1482,10 @@ func selectDivOp(isFloat, isSigned bool) BinOpKind {
 // emitModulo emits a modulo/remainder operation. DXIL does not support FRem
 // natively (DXC rejects it with "Invalid record"), so float modulo is lowered
 // to: a - b * floor(a / b). This matches Mesa nir_to_dxil.c lower_fmod.
+//
+// For unsigned integer modulo by a constant power of 2, DXC's LLVM
+// InstCombine applies strength reduction: urem x, 2^N -> and x, (2^N - 1).
+// We match this to produce identical output.
 func (e *Emitter) emitModulo(resultTy *module.Type, lhs, rhs int, isFloat, isSigned bool) (int, error) {
 	if isFloat {
 		return e.emitFRemLowered(resultTy, lhs, rhs), nil
@@ -1489,7 +1493,34 @@ func (e *Emitter) emitModulo(resultTy *module.Type, lhs, rhs int, isFloat, isSig
 	if isSigned {
 		return e.addBinOpInstr(resultTy, BinOpSRem, lhs, rhs), nil
 	}
+	// Strength reduction: urem x, 2^N -> and x, (2^N - 1).
+	if maskID, ok := e.tryURemToBitwiseAnd(rhs); ok {
+		return e.addBinOpInstr(resultTy, BinOpAnd, lhs, maskID), nil
+	}
 	return e.addBinOpInstr(resultTy, BinOpURem, lhs, rhs), nil
+}
+
+// tryURemToBitwiseAnd checks whether valueID refers to an integer constant
+// that is a power of 2 (>= 2). If so, returns the value ID for the bitmask
+// (value - 1) for use in strength reduction: urem x, 2^N -> and x, (2^N - 1).
+// This matches DXC's LLVM InstCombine pass.
+func (e *Emitter) tryURemToBitwiseAnd(valueID int) (int, bool) {
+	c, ok := e.constMap[valueID]
+	if !ok || c.IsUndef || c.IsAggregate {
+		return 0, false
+	}
+	if c.ConstType == nil || c.ConstType.Kind != module.TypeInteger {
+		return 0, false
+	}
+	v := c.IntValue
+	if v < 2 {
+		return 0, false
+	}
+	// Check power of 2: v & (v-1) == 0.
+	if v&(v-1) != 0 {
+		return 0, false
+	}
+	return e.getIntConstID(v - 1), true
 }
 
 // emitComparison emits a comparison instruction with the correct predicate

--- a/dxil/internal/emit/input_used_mask_test.go
+++ b/dxil/internal/emit/input_used_mask_test.go
@@ -170,6 +170,142 @@ func TestInputUsedMaskNull(t *testing.T) {
 	}
 }
 
+// TestInputUsedMaskSortedOrder verifies that computeInputElementUsedMasks
+// assigns masks in sorted signature order (locations before builtins) rather
+// than declaration order. Regression test for the msl-varyings/fs_main bug
+// where @builtin(position) from arg0 got LOC's slot and @location(1) from
+// arg1 got SV_Position's slot.
+func TestInputUsedMaskSortedOrder(t *testing.T) {
+	// Fragment shader with:
+	//   arg0: VertexOutput { @builtin(position) position: vec4f }
+	//   arg1: NoteInstance { @location(1) position: vec2f }
+	// Sorted order: LOC1 (sig element 0), SV_Position (sig element 1)
+	vec4Type := ir.TypeHandle(0)
+	vec2Type := ir.TypeHandle(1)
+	vertexOutputType := ir.TypeHandle(2) // struct { @builtin(position) vec4f }
+	noteInstanceType := ir.TypeHandle(3) // struct { @location(1) vec2f }
+
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+	loc1Binding := ir.Binding(ir.LocationBinding{Location: 1})
+
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Inner: ir.VectorType{Size: 2, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Inner: ir.StructType{Members: []ir.StructMember{
+				{Name: "position", Type: vec4Type, Binding: &posBinding},
+			}}},
+			{Inner: ir.StructType{Members: []ir.StructMember{
+				{Name: "position", Type: vec2Type, Binding: &loc1Binding},
+			}}},
+		},
+	}
+
+	targetBinding := ir.Binding(ir.LocationBinding{Location: 0})
+	ep := &ir.EntryPoint{
+		Name:  "fs_main",
+		Stage: ir.StageFragment,
+		Function: ir.Function{
+			Name: "fs_main",
+			Arguments: []ir.FunctionArgument{
+				{Type: vertexOutputType}, // arg0: has @builtin(position)
+				{Type: noteInstanceType}, // arg1: has @location(1)
+			},
+			Result: &ir.FunctionResult{
+				Type:    vec4Type,
+				Binding: &targetBinding,
+			},
+		},
+	}
+
+	// SV_Position is used (mask=15), LOC1 is not used (mask=0)
+	usedMasks := map[InputUsageKey]uint8{
+		{ArgIdx: 0, MemberIdx: 0}: 0x0F, // SV_Position used
+		// arg1/member0 (LOC1) absent = not used
+	}
+
+	e := &Emitter{
+		ir:   irMod,
+		opts: EmitOptions{InputUsedMasks: usedMasks},
+	}
+
+	// inElems in sorted order: LOC1 first (2 channels), SV_Position second (4 channels)
+	inElems := []viewid.SigElement{
+		{ScalarStart: 0, NumChannels: 2, VectorRow: 0}, // LOC1
+		{ScalarStart: 2, NumChannels: 4, VectorRow: 1}, // SV_Position
+	}
+
+	masks := e.computeInputElementUsedMasks(ep, inElems)
+
+	// LOC1 (element 0) is not used -> mask should be 0
+	if masks[0] != 0 {
+		t.Errorf("LOC1 (element 0): expected mask 0 (unused), got %d", masks[0])
+	}
+	// SV_Position (element 1) is used -> mask should be 15
+	if masks[1] != 15 {
+		t.Errorf("SV_Position (element 1): expected mask 15 (all 4 channels used), got %d", masks[1])
+	}
+}
+
+// TestInputUsedMaskVSInputPreservesOrder verifies that VS inputs use
+// declaration order (not sorted) for the usage mask mapping.
+func TestInputUsedMaskVSInputPreservesOrder(t *testing.T) {
+	vec4Type := ir.TypeHandle(0)
+	u32Type := ir.TypeHandle(1)
+	irMod := &ir.Module{
+		Types: []ir.Type{
+			{Inner: ir.VectorType{Size: 4, Scalar: ir.ScalarType{Kind: ir.ScalarFloat, Width: 4}}},
+			{Inner: ir.ScalarType{Kind: ir.ScalarUint, Width: 4}},
+		},
+	}
+
+	vidBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinVertexIndex})
+	loc0Binding := ir.Binding(ir.LocationBinding{Location: 0})
+	posBinding := ir.Binding(ir.BuiltinBinding{Builtin: ir.BuiltinPosition})
+
+	ep := &ir.EntryPoint{
+		Name:  "vs_main",
+		Stage: ir.StageVertex,
+		Function: ir.Function{
+			Name: "vs_main",
+			Arguments: []ir.FunctionArgument{
+				{Type: u32Type, Binding: &vidBinding},   // arg0: SV_VertexID
+				{Type: vec4Type, Binding: &loc0Binding}, // arg1: LOC0
+			},
+			Result: &ir.FunctionResult{
+				Type:    vec4Type,
+				Binding: &posBinding,
+			},
+		},
+	}
+
+	usedMasks := map[InputUsageKey]uint8{
+		{ArgIdx: 0, MemberIdx: -1}: 0x01, // SV_VertexID used
+		{ArgIdx: 1, MemberIdx: -1}: 0x0F, // LOC0 used
+	}
+
+	e := &Emitter{
+		ir:   irMod,
+		opts: EmitOptions{InputUsedMasks: usedMasks},
+	}
+
+	// VS inputs in declaration order: SV_VertexID (1 channel), LOC0 (4 channels)
+	inElems := []viewid.SigElement{
+		{ScalarStart: 0, NumChannels: 1, VectorRow: 0}, // SV_VertexID
+		{ScalarStart: 1, NumChannels: 4, VectorRow: 1}, // LOC0
+	}
+
+	masks := e.computeInputElementUsedMasks(ep, inElems)
+
+	// Declaration order preserved for VS: element 0 = SV_VertexID
+	if masks[0] != 1 {
+		t.Errorf("SV_VertexID (element 0): expected mask 1, got %d", masks[0])
+	}
+	if masks[1] != 15 {
+		t.Errorf("LOC0 (element 1): expected mask 15, got %d", masks[1])
+	}
+}
+
 // TestViewIDMaxPackedLocationIncludesStartCol verifies that the ViewID state
 // scalar count uses DXC's DetermineMaxPackedLocation formula:
 // max(StartRow*4 + StartCol + NumChannels) over all non-system-managed elements.

--- a/dxil/internal/emit/io.go
+++ b/dxil/internal/emit/io.go
@@ -2,6 +2,7 @@ package emit
 
 import (
 	"fmt"
+	"sort"
 
 	"github.com/gogpu/naga/dxil/internal/module"
 	"github.com/gogpu/naga/internal/backend"
@@ -21,6 +22,12 @@ import (
 // Reference: Mesa nir_to_dxil.c emit_load_input_via_intrinsic(),
 // emit_load_global_invocation_id(), emit_load_local_invocation_id()
 func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
+	// Precompute ISG1 row assignments that match the sorted order produced
+	// by collectFlatArgBindings + PackSignatureElements. This ensures the
+	// loadInput sigId values match the ISG1 register layout exactly.
+	rowMap := e.buildInputRowMap(fn, stage)
+	e.inputRowMap = rowMap
+
 	// Phase 1: classify each argument. Identify which args need loadInput,
 	// which need special intrinsics, and assign ISG1 row indices (sigId).
 	type loadInputArg struct {
@@ -29,7 +36,6 @@ func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
 		inputRow int
 	}
 	var loadArgs []loadInputArg
-	inputRow := 0
 
 	for argIdx := range fn.Arguments {
 		arg := &fn.Arguments[argIdx]
@@ -37,11 +43,10 @@ func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
 			// Struct-typed arguments: handled separately with their own reverse logic.
 			argType := e.ir.Types[arg.Type]
 			if st, isSt := argType.Inner.(ir.StructType); isSt {
-				n, err := e.emitStructInputLoads(fn, argIdx, &st, stage, inputRow)
-				if err != nil {
+				startRow := rowMap[inputRowKey{argIdx: argIdx, memberIdx: -1}]
+				if err := e.emitStructInputLoads(fn, argIdx, &st, stage, startRow); err != nil {
 					return err
 				}
-				inputRow += n
 			}
 			continue
 		}
@@ -75,8 +80,8 @@ func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
 			continue
 		}
 
-		loadArgs = append(loadArgs, loadInputArg{argIdx: argIdx, arg: arg, inputRow: inputRow})
-		inputRow++
+		row := rowMap[inputRowKey{argIdx: argIdx, memberIdx: -1}]
+		loadArgs = append(loadArgs, loadInputArg{argIdx: argIdx, arg: arg, inputRow: row})
 	}
 
 	// Phase 2: emit loadInput calls in reverse ISG1 row order to match DXC.
@@ -85,6 +90,10 @@ func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
 	// signature element is retained (for pipeline compatibility) but the
 	// bitcode body omits the call. loadInput is readnone so elision is
 	// observably correct.
+	// Sort by inputRow so reverse iteration matches reverse ISG1 order.
+	sort.SliceStable(loadArgs, func(i, j int) bool {
+		return loadArgs[i].inputRow < loadArgs[j].inputRow
+	})
 	for i := len(loadArgs) - 1; i >= 0; i-- {
 		la := &loadArgs[i]
 		if !isArgRead(fn, la.argIdx) {
@@ -95,6 +104,158 @@ func (e *Emitter) emitInputLoads(fn *ir.Function, stage ir.ShaderStage) error {
 		}
 	}
 	return nil
+}
+
+// inputRowKey identifies a specific binding element in the flat input list.
+// argIdx is the function argument index; memberIdx is the struct member index
+// (or -1 for non-struct arguments or as a struct-level start row marker).
+type inputRowKey struct {
+	argIdx    int
+	memberIdx int
+}
+
+// buildInputRowMap precomputes the ISG1 row assignment for every input binding
+// element, matching the sorted order from collectFlatArgBindings + PackSignatureElements.
+// Returns a map from (argIdx, memberIdx) to ISG1 row index.
+//
+// For struct arguments, the map contains an entry with memberIdx=-1 whose
+// value is the starting row for that struct's first loadInput-producing member
+// in the sorted order. emitStructInputLoads uses its own SortedMemberIndices
+// walk, so the starting row is sufficient.
+func (e *Emitter) buildInputRowMap(fn *ir.Function, stage ir.ShaderStage) map[inputRowKey]int {
+	isFragment := stage == ir.StageFragment
+	isVSInput := stage == ir.StageVertex
+	isComputeLike := stage == ir.StageCompute || stage == ir.StageMesh || stage == ir.StageTask
+
+	interpFn := func(loc ir.LocationBinding) backend.SigPackInterp {
+		return backend.SigPackInterp(interpolationModeForBinding(loc.Interpolation, isFragment, false))
+	}
+
+	entries := e.collectFlatInputEntries(fn, isVSInput)
+
+	// Build SigElementInfo for packing (mirrors collectGraphicsSignatures).
+	infos := make([]backend.SigElementInfo, len(entries))
+	for i, ent := range entries {
+		infos[i] = backend.SigElementInfoForBinding(e.ir, ent.binding, ent.typeH, stage, false, interpFn)
+		if isVSInput && infos[i].Kind == backend.SigPackLocation {
+			infos[i].Kind = backend.SigPackBuiltinSystemValue
+		}
+	}
+	packed := backend.PackSignatureElements(infos, true)
+
+	// Map each entry to its packed register row.
+	result := make(map[inputRowKey]int, len(entries))
+	for i, ent := range entries {
+		pe := packed[i]
+		if pe.Rows == 0 {
+			continue
+		}
+		if isSkippedInputBinding(ent.binding, stage, isComputeLike) {
+			continue
+		}
+		result[inputRowKey{argIdx: ent.argIdx, memberIdx: ent.memberIdx}] = int(pe.Register)
+	}
+
+	// Add struct-level start row sentinels.
+	addStructStartRows(e.ir, fn, result, stage, isComputeLike)
+	return result
+}
+
+// inputFlatEntry represents one binding element in the flattened input list.
+type inputFlatEntry struct {
+	argIdx    int
+	memberIdx int // -1 for direct-binding args
+	binding   ir.Binding
+	typeH     ir.TypeHandle
+}
+
+// collectFlatInputEntries builds the sorted flat binding list for all
+// function arguments (same order as collectFlatArgBindings).
+func (e *Emitter) collectFlatInputEntries(fn *ir.Function, isVSInput bool) []inputFlatEntry {
+	var entries []inputFlatEntry
+	for argIdx := range fn.Arguments {
+		arg := &fn.Arguments[argIdx]
+		if arg.Binding != nil {
+			entries = append(entries, inputFlatEntry{argIdx: argIdx, memberIdx: -1, binding: *arg.Binding, typeH: arg.Type})
+			continue
+		}
+		argType := e.ir.Types[arg.Type]
+		st, ok := argType.Inner.(ir.StructType)
+		if !ok {
+			continue
+		}
+		order := backend.SortedMemberIndices(st.Members)
+		for _, idx := range order {
+			m := st.Members[idx]
+			if m.Binding == nil {
+				continue
+			}
+			entries = append(entries, inputFlatEntry{argIdx: argIdx, memberIdx: idx, binding: *m.Binding, typeH: m.Type})
+		}
+	}
+	if !isVSInput {
+		sort.SliceStable(entries, func(i, j int) bool {
+			ki := backend.NewMemberInterfaceKey(&entries[i].binding)
+			kj := backend.NewMemberInterfaceKey(&entries[j].binding)
+			return backend.MemberInterfaceLess(ki, kj)
+		})
+	}
+	return entries
+}
+
+// addStructStartRows adds memberIdx=-1 sentinel entries to the row map
+// for each struct-typed argument, using the minimum row of any member.
+func addStructStartRows(irMod *ir.Module, fn *ir.Function, result map[inputRowKey]int, stage ir.ShaderStage, isComputeLike bool) {
+	for argIdx := range fn.Arguments {
+		arg := &fn.Arguments[argIdx]
+		if arg.Binding != nil {
+			continue
+		}
+		argType := irMod.Types[arg.Type]
+		st, ok := argType.Inner.(ir.StructType)
+		if !ok {
+			continue
+		}
+		minRow := -1
+		order := backend.SortedMemberIndices(st.Members)
+		for _, idx := range order {
+			m := st.Members[idx]
+			if m.Binding == nil {
+				continue
+			}
+			if isSkippedInputBinding(*m.Binding, stage, isComputeLike) {
+				continue
+			}
+			if r, ok := result[inputRowKey{argIdx: argIdx, memberIdx: idx}]; ok {
+				if minRow < 0 || r < minRow {
+					minRow = r
+				}
+			}
+		}
+		if minRow >= 0 {
+			result[inputRowKey{argIdx: argIdx, memberIdx: -1}] = minRow
+		}
+	}
+}
+
+// isSkippedInputBinding returns true for bindings that don't produce
+// loadInput calls and don't consume ISG1 rows. Used by buildInputRowMap
+// to filter out ViewID, Coverage, and compute builtins.
+func isSkippedInputBinding(binding ir.Binding, stage ir.ShaderStage, isComputeLike bool) bool {
+	bb, ok := binding.(ir.BuiltinBinding)
+	if !ok {
+		return false
+	}
+	if bb.Builtin == ir.BuiltinViewIndex {
+		return true
+	}
+	if bb.Builtin == ir.BuiltinSampleMask && stage == ir.StageFragment {
+		return true
+	}
+	if isComputeLike {
+		return true
+	}
+	return false
 }
 
 // emitCoverageLoad emits dx.op.coverage.i32(i32 91) and binds the result
@@ -138,8 +299,7 @@ func (e *Emitter) emitSingleInputLoad(fn *ir.Function, argIdx int, arg *ir.Funct
 	scalar, ok := scalarOfType(argType.Inner)
 	if !ok {
 		if st, isSt := argType.Inner.(ir.StructType); isSt {
-			_, err := e.emitStructInputLoads(fn, argIdx, &st, stage, inputRow)
-			return err
+			return e.emitStructInputLoads(fn, argIdx, &st, stage, inputRow)
 		}
 		return fmt.Errorf("unsupported input type for argument %d", argIdx)
 	}
@@ -444,7 +604,7 @@ func (e *Emitter) getDxOpComputeBuiltinFunc(name string, hasComponent bool) *mod
 // this struct's members, so downstream expression evaluation resolves them directly.
 //
 //nolint:gocognit,gocyclo,cyclop,funlen // dispatch over builtin/scalar/vector struct-member shapes
-func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.StructType, stage ir.ShaderStage, inputRow int) (int, error) {
+func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.StructType, stage ir.ShaderStage, inputRow int) error {
 	// Find the expression handle for this FunctionArgument.
 	argExprHandle := e.findArgExprHandle(fn, argIdx)
 
@@ -482,13 +642,24 @@ func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.Struc
 		if bb, ok := (*member.Binding).(ir.BuiltinBinding); ok && isComputeLike {
 			valueID, err := e.emitComputeBuiltinMemberLoad(bb.Builtin)
 			if err != nil {
-				return 0, fmt.Errorf("struct member %q: %w", member.Name, err)
+				return fmt.Errorf("struct member %q: %w", member.Name, err)
 			}
 			memberValues[memberIdx] = &memberInfo{firstID: valueID, comps: []int{valueID}}
 			continue
 		}
 
-		loadMembers = append(loadMembers, loadMember{memberIdx: memberIdx, inputID: inputRow + rowCount})
+		// Look up the ISG1 row from the precomputed map if available.
+		// The map accounts for cross-argument sorting (locations before
+		// builtins), so each member gets its correct packed register.
+		// Fallback to sequential assignment for compute shaders and
+		// cases where the map was not populated (emitSingleInputLoad path).
+		memberRow := inputRow + rowCount
+		if e.inputRowMap != nil {
+			if r, ok := e.inputRowMap[inputRowKey{argIdx: argIdx, memberIdx: memberIdx}]; ok {
+				memberRow = r
+			}
+		}
+		loadMembers = append(loadMembers, loadMember{memberIdx: memberIdx, inputID: memberRow})
 		rowCount++
 	}
 
@@ -509,7 +680,7 @@ func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.Struc
 		memberType := e.ir.Types[member.Type]
 		scalar, ok := scalarOfType(memberType.Inner)
 		if !ok {
-			return 0, fmt.Errorf("unsupported struct member type for input %q", member.Name)
+			return fmt.Errorf("unsupported struct member type for input %q", member.Name)
 		}
 
 		numComps := componentCount(memberType.Inner)
@@ -578,7 +749,7 @@ func (e *Emitter) emitStructInputLoads(fn *ir.Function, argIdx int, st *ir.Struc
 			e.exprComponents[handle] = info.comps
 		}
 	}
-	return rowCount, nil
+	return nil
 }
 
 // emitOutputStore emits a dx.op.storeOutput call for a single output.

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -5,6 +5,7 @@ import (
 	"sort"
 
 	"github.com/gogpu/naga/dxil/internal/module"
+	"github.com/gogpu/naga/hlsl"
 	"github.com/gogpu/naga/ir"
 )
 
@@ -183,9 +184,20 @@ func (e *Emitter) analyzeResources() {
 			}
 		}
 
+		// Apply the HLSL namer suffix convention: names that end
+		// with a digit or match an HLSL keyword get a trailing
+		// underscore. DXC reads the resource name from dx.resources
+		// metadata and displays it in the "Resource Bindings"
+		// comment table emitted by dxc -dumpbin. Matching this
+		// convention keeps the resource table identical to DXC.
+		resName := gv.Name
+		if hlsl.NeedsTrailingUnderscore(resName) {
+			resName += "_"
+		}
+
 		info := resourceInfo{
 			varHandle:      ir.GlobalVariableHandle(uint32(i)),
-			name:           gv.Name,
+			name:           resName,
 			class:          class,
 			rangeID:        rangeID,
 			group:          grp,

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -4247,22 +4247,15 @@ func (e *Emitter) emitUAVLoad(fn *ir.Function, chain *uavPointerChain) (int, err
 		return 0, err
 	}
 
-	// BUG-DXIL-026 (Group A): mixed-scalar struct/array element types must be
-	// decomposed into per-field bufferLoads with per-field overload. Otherwise a
-	// single bufferLoad.f32 returns 4 floats and the float component for an
-	// integer field is then stored into an i32* alloca, tripping the validator
-	// rule "Explicit load/store type does not match pointee type of pointer
-	// operand" (0x80aa0009). DXC's pattern is identical (separate bufferLoad
-	// per field with .i32 + bitcast), but we keep per-field overload which
-	// validates equally and avoids extra bitcast traffic.
+	// Mixed-scalar struct/array element types must be decomposed into per-field
+	// bufferLoads. Otherwise a single bufferLoad.i32 returns 4 i32s and the
+	// integer field would need different handling than float fields. DXC uses
+	// separate bufferLoad per field with i32 overload + bitcast for float fields.
 	if hasMixedScalarTypes(e.ir, chain.elemType) {
 		return e.emitUAVLoadDecomposed(chain, handleID, indexID)
 	}
 
 	ol := overloadForScalar(chain.scalar)
-	resRetTy := e.getDxResRetType(ol)
-	scalarTy := e.overloadReturnType(ol)
-	undefVal := e.getUndefConstID()
 
 	// Count all scalar components. For struct/array element types, use deep
 	// component counting to load all fields.
@@ -4281,12 +4274,34 @@ func (e *Emitter) emitUAVLoad(fn *ir.Function, chain *uavPointerChain) (int, err
 	// covers i16/i32/i64/f16/f32/f64. The atomic-int64 / int64 storage
 	// buffer test corpus depends on this routing.
 	is64Bit := chain.scalar.Width == 8
+
+	// For raw buffer loads (all naga storage buffers are ByteAddressBuffer /
+	// RWByteAddressBuffer, kind 11), DXC always uses the i32 overload.
+	// HLSL ByteAddressBuffer.Load() returns uint; asfloat() wraps the result.
+	// This mirrors the store side which already uses i32+bitcast. After
+	// extractvalue we bitcast i32 to float to recover the original type.
+	needsBitcast := !is64Bit && chain.scalar.Kind == ir.ScalarFloat
+	if needsBitcast {
+		ol = overloadI32
+	}
+
+	resRetTy := e.getDxResRetType(ol)
+	scalarTy := e.overloadReturnType(ol)
+	undefVal := e.getUndefConstID()
+
+	// The original scalar type for bitcasting extracted i32 values back to float.
+	var targetScalarTy *module.Type
+	if needsBitcast {
+		targetScalarTy = e.mod.GetFloatType(32)
+	}
+
 	if numComps <= 4 && !is64Bit {
 		// Single bufferLoad call (≤4 components fit one ResRet).
 		bufLoadFn := e.getDxOpBufferLoadFunc(ol)
 		opcodeVal := e.getIntConstID(int64(OpBufferLoad))
 		retID := e.addCallInstr(bufLoadFn, resRetTy, []int{opcodeVal, handleID, indexID, undefVal})
 		comps := make([]int, numComps)
+		// Extract all components first (DXC groups extractvalues together).
 		for i := 0; i < numComps; i++ {
 			extractID := e.allocValue()
 			instr := &module.Instruction{
@@ -4299,13 +4314,20 @@ func (e *Emitter) emitUAVLoad(fn *ir.Function, chain *uavPointerChain) (int, err
 			e.currentBB.AddInstruction(instr)
 			comps[i] = extractID
 		}
+		// Then bitcast i32 to float for raw buffer loads of float data.
+		// DXC groups bitcasts after all extractvalues from the same load.
+		if needsBitcast {
+			for i := 0; i < numComps; i++ {
+				comps[i] = e.addCastInstr(targetScalarTy, CastBitcast, comps[i])
+			}
+		}
 		if numComps > 1 {
 			e.pendingComponents = comps
 		}
 		return comps[0], nil
 	}
 
-	return e.emitUAVLoadRaw(chain, handleID, indexID, numComps, ol, resRetTy, scalarTy, undefVal)
+	return e.emitUAVLoadRaw(chain, handleID, indexID, numComps, ol, resRetTy, scalarTy, undefVal, needsBitcast)
 }
 
 // emitUAVLoadRaw emits chunked dx.op.rawBufferLoad calls for elements with
@@ -4314,6 +4336,10 @@ func (e *Emitter) emitUAVLoad(fn *ir.Function, chain *uavPointerChain) (int, err
 // buffers, so we switch to rawBufferLoad which covers all buffer kinds and
 // supports the full i16/i32/i64/f16/f32/f64 overload set.
 //
+// When needsBitcast is true, extracted i32 values are bitcast to float to
+// recover the original type (matching DXC's raw buffer load convention where
+// ByteAddressBuffer.Load returns uint and asfloat wraps it).
+//
 // Mesa nir_to_dxil.c:810 emit_raw_bufferload_call is the reference. coord0
 // carries the current byte offset (our chain index is already in scalar
 // units), coord1 is undef, mask = (1<<count)-1, alignment = scalarWidth.
@@ -4321,6 +4347,7 @@ func (e *Emitter) emitUAVLoadRaw(
 	chain *uavPointerChain,
 	handleID, indexID, numComps int,
 	ol overloadType, resRetTy, scalarTy *module.Type, undefVal int,
+	needsBitcast bool,
 ) (int, error) {
 	rawLoadFn := e.getDxOpRawBufferLoadFunc(ol)
 	rawOpcodeVal := e.getIntConstID(int64(OpRawBufferLoad))
@@ -4330,6 +4357,11 @@ func (e *Emitter) emitUAVLoadRaw(
 		scalarWidth = 4
 	}
 	alignmentID := e.getIntConstID(int64(scalarWidth))
+
+	var targetScalarTy *module.Type
+	if needsBitcast {
+		targetScalarTy = e.mod.GetFloatType(32)
+	}
 
 	comps := make([]int, 0, numComps)
 	remaining := numComps
@@ -4349,6 +4381,8 @@ func (e *Emitter) emitUAVLoadRaw(
 		maskID := e.getI8ConstID(mask)
 		retID := e.addCallInstr(rawLoadFn, resRetTy,
 			[]int{rawOpcodeVal, handleID, coord0, undefVal, maskID, alignmentID})
+		// Extract all components from this chunk first.
+		chunkStart := len(comps)
 		for i := 0; i < count; i++ {
 			extractID := e.allocValue()
 			instr := &module.Instruction{
@@ -4360,6 +4394,13 @@ func (e *Emitter) emitUAVLoadRaw(
 			}
 			e.currentBB.AddInstruction(instr)
 			comps = append(comps, extractID)
+		}
+		// Then bitcast extracted i32 values to float (DXC groups bitcasts
+		// after all extractvalues from the same load).
+		if needsBitcast {
+			for i := chunkStart; i < len(comps); i++ {
+				comps[i] = e.addCastInstr(targetScalarTy, CastBitcast, comps[i])
+			}
 		}
 		remaining -= count
 		byteOffset += uint32(count) * scalarWidth
@@ -4499,15 +4540,14 @@ func scalarsShareDXILType(a, b ir.ScalarType) bool {
 }
 
 // emitUAVLoadDecomposed emits one dx.op.bufferLoad per scalar field of a
-// mixed-type aggregate element, each with the field's own overload. Per-field
-// component IDs are tracked in pendingComponents so downstream
-// extract/AccessIndex paths see the correctly-typed value.
+// mixed-type aggregate element. Per-field component IDs are tracked in
+// pendingComponents so downstream extract/AccessIndex paths see the
+// correctly-typed value.
 //
 // Each per-field load is a single-component bufferLoad with byte offset
-// computed from the element base via integer add. We prefer .iN/.fN overloads
-// matching the field type so the extracted value matches the DXIL store/use
-// type without bitcast — equivalent in validity to DXC's "always .i32 +
-// bitcast" pattern but more direct for the typical mixed-int+float case.
+// computed from the element base via integer add. For raw buffer loads,
+// DXC always uses the i32 overload (ByteAddressBuffer.Load returns uint)
+// and then bitcasts to float when needed. We match that convention here.
 //
 // Reference: Mesa nir_to_dxil.c emit_load_ssbo (~3427) emits per-intrinsic
 // loads after NIR scalarization passes; we do the equivalent decomposition
@@ -4522,11 +4562,17 @@ func (e *Emitter) emitUAVLoadDecomposed(chain *uavPointerChain, handleID, indexI
 	// Each field's byteOffset adds directly without scalar-unit conversion.
 	undefVal := e.getUndefConstID()
 	i32Ty := e.mod.GetIntType(32)
+	f32Ty := e.mod.GetFloatType(32)
 	opcodeVal := e.getIntConstID(int64(OpBufferLoad))
 
 	comps := make([]int, len(fields))
 	for i, f := range fields {
 		ol := overloadForScalar(f.scalar)
+		// For raw buffer loads of float fields, use i32 overload + bitcast.
+		fieldNeedsBitcast := f.scalar.Kind == ir.ScalarFloat && f.scalar.Width != 8
+		if fieldNeedsBitcast {
+			ol = overloadI32
+		}
 		resRetTy := e.getDxResRetType(ol)
 		scalarTy := e.overloadReturnType(ol)
 		bufLoadFn := e.getDxOpBufferLoadFunc(ol)
@@ -4549,6 +4595,10 @@ func (e *Emitter) emitUAVLoadDecomposed(chain *uavPointerChain, handleID, indexI
 			ValueID:    extractID,
 		}
 		e.currentBB.AddInstruction(instr)
+		// Bitcast i32 to float for raw buffer loads of float fields.
+		if fieldNeedsBitcast {
+			extractID = e.addCastInstr(f32Ty, CastBitcast, extractID)
+		}
 		comps[i] = extractID
 		_ = f.offsetWords // reserved for stride-based path
 	}

--- a/dxil/internal/emit/resources.go
+++ b/dxil/internal/emit/resources.go
@@ -309,12 +309,11 @@ func (e *Emitter) emitResourceHandles() {
 		}
 	}
 
-	// Sampler-heap mode: after the regular createHandle calls (which have
-	// produced handles for the per-group index buffer SRVs), emit one
-	// bufferLoad+createHandle pair per WGSL sampler binding. This stays
-	// inside the entry block so the resulting handles dominate every
-	// downstream sample site.
-	e.emitSamplerHeapHandles()
+	// Sampler-heap handles are emitted separately via emitSamplerHeapHandles()
+	// AFTER emitInputLoads() in the entry-point emission sequence. DXC emits
+	// loadInput calls before the sampler heap bufferLoad+createHandle sequence
+	// (lazy evaluation places input reads before sampler index lookups). Matching
+	// this order avoids instruction-scheduling diffs in the golden comparison.
 }
 
 // buildHandleEmitOrder returns indices into e.resources in DXC's createHandle

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -44,10 +44,30 @@ func (e *Emitter) emitFunctionBody(fn *ir.Function) error {
 // to the Init value without alloca. This matches DXC's SROA + constant
 // propagation for the pattern `var x = const_expr; return x`.
 func (e *Emitter) preAllocateLocalVars(fn *ir.Function) error {
+	// Identify struct locals that serve exclusively as output staging.
+	// Must run before alloca creation so promoted locals can be skipped.
+	e.analyzeOutputPromotableLocals(fn)
+
+	// Identify vector/scalar locals stored to exactly once in straight-line
+	// code. These bypass alloca -- loads resolve to the stored value directly.
+	singleStores := analyzeSingleStoreLocals(fn, e.ir)
+
 	live := liveLocalVars(fn)
 	stored := localsStoredTo(fn)
 	for i := range fn.LocalVars {
 		if !live[uint32(i)] {
+			continue
+		}
+		// Output-promoted locals bypass the alloca entirely.
+		// Their field stores record expression handles, and the return
+		// emits storeOutput directly from those values.
+		if e.outputPromotedLocals[uint32(i)] {
+			continue
+		}
+		// Single-store vector/scalar local: skip alloca, record the stored
+		// value so loads resolve directly to it.
+		if valueH, ok := singleStores[uint32(i)]; ok {
+			e.singleStoreLocals[uint32(i)] = valueH
 			continue
 		}
 		// Init-only optimization: if the local has a non-nil Init and is
@@ -105,6 +125,375 @@ func localsStoredToBlock(fn *ir.Function, block ir.Block, lvHandles map[ir.Expre
 			localsStoredToBlock(fn, sk.Block, lvHandles, stored)
 		}
 	}
+}
+
+// analyzeSingleStoreLocals identifies vector/scalar local variables that
+// are stored to exactly once in straight-line code (top-level function body).
+// For such locals, the alloca/store/load chain can be bypassed: loads
+// resolve directly to the stored value expression.
+//
+// This fills the gap left by mem2reg (which only handles scalar locals)
+// for the common SROA decomposition pattern: after struct SROA, per-member
+// vector locals are stored once and loaded once in the return's Compose.
+// DXC's LLVM mem2reg handles both scalar and vector promotions; ours
+// does not, so this targeted analysis handles the vector case.
+//
+// A local is eligible when ALL of:
+//  1. It is scalar or vector typed (not struct/array/matrix)
+//  2. It has exactly one whole-variable Store in the top-level body
+//  3. It has no Init expression (Init locals are handled by initOnlyLocals)
+//  4. No stores to it exist inside control flow (if/loop/switch)
+//  5. No AccessIndex/Access chains reference it (only direct Load/Store)
+func analyzeSingleStoreLocals(fn *ir.Function, mod *ir.Module) map[uint32]ir.ExpressionHandle {
+	lvHandles := buildLocalVarHandleMap(fn)
+	hasChainRef := findChainReferencedLocals(fn, lvHandles)
+	storeCount, storeValue := countTopLevelStores(fn, lvHandles)
+	nestedStored := findNestedStoredLocals(fn, lvHandles)
+
+	result := make(map[uint32]ir.ExpressionHandle)
+	for varIdx, count := range storeCount {
+		if !isSingleStoreEligible(fn, mod, varIdx, count, nestedStored, hasChainRef) {
+			continue
+		}
+		result[varIdx] = storeValue[varIdx]
+	}
+	return result
+}
+
+// buildLocalVarHandleMap maps ExprLocalVariable expression handles to
+// their local variable indices.
+func buildLocalVarHandleMap(fn *ir.Function) map[ir.ExpressionHandle]uint32 {
+	lvHandles := make(map[ir.ExpressionHandle]uint32)
+	for h, expr := range fn.Expressions {
+		if lv, ok := expr.Kind.(ir.ExprLocalVariable); ok {
+			lvHandles[ir.ExpressionHandle(h)] = lv.Variable
+		}
+	}
+	return lvHandles
+}
+
+// findChainReferencedLocals identifies locals referenced via AccessIndex
+// or Access chains, which need pointer semantics and cannot be promoted.
+func findChainReferencedLocals(fn *ir.Function, lvHandles map[ir.ExpressionHandle]uint32) map[uint32]bool {
+	hasChainRef := make(map[uint32]bool)
+	for _, expr := range fn.Expressions {
+		switch k := expr.Kind.(type) {
+		case ir.ExprAccessIndex:
+			if v, ok := lvHandles[k.Base]; ok {
+				hasChainRef[v] = true
+			}
+		case ir.ExprAccess:
+			if v, ok := lvHandles[k.Base]; ok {
+				hasChainRef[v] = true
+			}
+		}
+	}
+	return hasChainRef
+}
+
+// countTopLevelStores counts whole-variable stores per local in the
+// top-level function body only (not inside control flow).
+func countTopLevelStores(fn *ir.Function, lvHandles map[ir.ExpressionHandle]uint32) (map[uint32]int, map[uint32]ir.ExpressionHandle) {
+	storeCount := make(map[uint32]int)
+	storeValue := make(map[uint32]ir.ExpressionHandle)
+	for _, stmt := range fn.Body {
+		if sk, ok := stmt.Kind.(ir.StmtStore); ok {
+			if v, ok := lvHandles[sk.Pointer]; ok {
+				storeCount[v]++
+				storeValue[v] = sk.Value
+			}
+		}
+	}
+	return storeCount, storeValue
+}
+
+// findNestedStoredLocals identifies locals that have stores inside
+// control flow blocks (if/loop/switch), which cannot be promoted.
+func findNestedStoredLocals(fn *ir.Function, lvHandles map[ir.ExpressionHandle]uint32) map[uint32]bool {
+	nestedStored := make(map[uint32]bool)
+	for _, stmt := range fn.Body {
+		switch sk := stmt.Kind.(type) {
+		case ir.StmtIf:
+			markNestedStores(sk.Accept, lvHandles, nestedStored)
+			markNestedStores(sk.Reject, lvHandles, nestedStored)
+		case ir.StmtLoop:
+			markNestedStores(sk.Body, lvHandles, nestedStored)
+			markNestedStores(sk.Continuing, lvHandles, nestedStored)
+		case ir.StmtSwitch:
+			for ci := range sk.Cases {
+				markNestedStores(sk.Cases[ci].Body, lvHandles, nestedStored)
+			}
+		case ir.StmtBlock:
+			markNestedStores(sk.Block, lvHandles, nestedStored)
+		}
+	}
+	return nestedStored
+}
+
+// isSingleStoreEligible checks if a local variable with the given store
+// count is eligible for single-store promotion.
+func isSingleStoreEligible(fn *ir.Function, mod *ir.Module, varIdx uint32, count int,
+	nestedStored, hasChainRef map[uint32]bool) bool {
+	if count != 1 || nestedStored[varIdx] || hasChainRef[varIdx] {
+		return false
+	}
+	if int(varIdx) >= len(fn.LocalVars) {
+		return false
+	}
+	lv := &fn.LocalVars[varIdx]
+	if lv.Init != nil {
+		return false // handled by initOnlyLocals
+	}
+	if int(lv.Type) >= len(mod.Types) {
+		return false
+	}
+	inner := mod.Types[lv.Type].Inner
+	switch inner.(type) {
+	case ir.ScalarType, ir.VectorType:
+		return true
+	}
+	return false
+}
+
+// markNestedStores marks local variables that have stores inside a block.
+func markNestedStores(block ir.Block, lvHandles map[ir.ExpressionHandle]uint32, stored map[uint32]bool) {
+	for _, stmt := range block {
+		switch sk := stmt.Kind.(type) {
+		case ir.StmtStore:
+			if v, ok := lvHandles[sk.Pointer]; ok {
+				stored[v] = true
+			}
+		case ir.StmtIf:
+			markNestedStores(sk.Accept, lvHandles, stored)
+			markNestedStores(sk.Reject, lvHandles, stored)
+		case ir.StmtLoop:
+			markNestedStores(sk.Body, lvHandles, stored)
+			markNestedStores(sk.Continuing, lvHandles, stored)
+		case ir.StmtSwitch:
+			for ci := range sk.Cases {
+				markNestedStores(sk.Cases[ci].Body, lvHandles, stored)
+			}
+		case ir.StmtBlock:
+			markNestedStores(sk.Block, lvHandles, stored)
+		}
+	}
+}
+
+// analyzeOutputPromotableLocals identifies struct-typed local variables
+// that can bypass the alloca/GEP/store/load chain and emit storeOutput
+// directly. A local is promotable when ALL of the following hold:
+//
+//  1. The function has a struct result type (entry point returns a struct)
+//  2. The local variable has the same type as the result
+//  3. The return statement loads from exactly this local variable
+//  4. All stores to the local are field-level (AccessIndex) in straight-line
+//     code (not inside if/loop/switch) -- each member stored exactly once
+//  5. The local is not read mid-body (only loaded in the return)
+//
+// DXC's LLVM SROA + mem2reg eliminates the alloca entirely for this pattern,
+// producing direct storeOutput calls. We replicate that at the emitter level.
+func (e *Emitter) analyzeOutputPromotableLocals(fn *ir.Function) {
+	// Must be an entry point with a struct return type.
+	if fn.Result == nil || e.emittingHelperFunction {
+		return
+	}
+	resultType := e.ir.Types[fn.Result.Type]
+	st, isSt := resultType.Inner.(ir.StructType)
+	if !isSt {
+		return
+	}
+
+	// Find the return statement and its load source in the top-level body.
+	retVarIdx, retFound := findReturnLoadVar(fn)
+	if !retFound {
+		return
+	}
+
+	// Verify the local variable is a struct of the same type as the result.
+	if int(retVarIdx) >= len(fn.LocalVars) {
+		return
+	}
+	localVar := &fn.LocalVars[retVarIdx]
+	if localVar.Type != fn.Result.Type {
+		return
+	}
+
+	// Find the ExprLocalVariable handle for this variable.
+	var lvHandle ir.ExpressionHandle
+	foundLV := false
+	for h, expr := range fn.Expressions {
+		if lv, ok := expr.Kind.(ir.ExprLocalVariable); ok && lv.Variable == retVarIdx {
+			lvHandle = ir.ExpressionHandle(h)
+			foundLV = true
+			break
+		}
+	}
+	if !foundLV {
+		return
+	}
+
+	// Verify all stores to this local are field-level AccessIndex stores
+	// in straight-line code (top-level body only, not inside control flow).
+	// Also verify no other reads happen (no Load of this local except in return).
+	if !isOutputOnlyLocal(fn, lvHandle, retVarIdx, &st) {
+		return
+	}
+
+	e.outputPromotedLocals[retVarIdx] = true
+}
+
+// findReturnLoadVar finds the local variable index loaded in the return
+// statement of a function. Returns (varIdx, true) if the function body
+// ends with StmtReturn whose value is an ExprLoad of an ExprLocalVariable.
+func findReturnLoadVar(fn *ir.Function) (uint32, bool) {
+	for i := len(fn.Body) - 1; i >= 0; i-- {
+		ret, ok := fn.Body[i].Kind.(ir.StmtReturn)
+		if !ok {
+			continue
+		}
+		if ret.Value == nil {
+			return 0, false
+		}
+		retExpr := fn.Expressions[*ret.Value]
+		load, ok := retExpr.Kind.(ir.ExprLoad)
+		if !ok {
+			return 0, false
+		}
+		lv, ok := fn.Expressions[load.Pointer].Kind.(ir.ExprLocalVariable)
+		if !ok {
+			return 0, false
+		}
+		return lv.Variable, true
+	}
+	return 0, false
+}
+
+// isOutputOnlyLocal checks that a struct local variable is only used for
+// field-level stores in straight-line code (the top-level function body)
+// and is never read except via the return-time Load. Returns false if any
+// usage pattern would make output promotion unsafe:
+//   - Store inside control flow (if/loop/switch)
+//   - Whole-variable store (Store to the LocalVariable directly)
+//   - Dynamic access (Access instead of AccessIndex)
+//   - Load mid-body (any Load except the final return)
+//   - Passed as a function call argument
+func isOutputOnlyLocal(fn *ir.Function, _ ir.ExpressionHandle, varIdx uint32, st *ir.StructType) bool {
+	aiHandles := collectFieldAccessHandles(fn, varIdx)
+	memberStored := make(map[int]bool)
+
+	for _, stmt := range fn.Body {
+		switch sk := stmt.Kind.(type) {
+		case ir.StmtStore:
+			if ok := classifyOutputStore(fn, sk, varIdx, aiHandles, memberStored); !ok {
+				return false
+			}
+		case ir.StmtReturn, ir.StmtEmit:
+			continue
+		case ir.StmtIf:
+			if blockStoresTo(fn, sk.Accept, varIdx) || blockStoresTo(fn, sk.Reject, varIdx) {
+				return false
+			}
+		case ir.StmtLoop:
+			if blockStoresTo(fn, sk.Body, varIdx) || blockStoresTo(fn, sk.Continuing, varIdx) {
+				return false
+			}
+		case ir.StmtSwitch:
+			for ci := range sk.Cases {
+				if blockStoresTo(fn, sk.Cases[ci].Body, varIdx) {
+					return false
+				}
+			}
+		case ir.StmtBlock:
+			if blockStoresTo(fn, sk.Block, varIdx) {
+				return false
+			}
+		}
+	}
+
+	// Verify all members with bindings were stored to.
+	for idx, member := range st.Members {
+		if member.Binding != nil && !memberStored[idx] {
+			return false
+		}
+	}
+	return true
+}
+
+// collectFieldAccessHandles finds all ExprAccessIndex handles rooted at
+// a local variable, returning a map from expression handle to member index.
+func collectFieldAccessHandles(fn *ir.Function, varIdx uint32) map[ir.ExpressionHandle]int {
+	aiHandles := make(map[ir.ExpressionHandle]int)
+	for h, expr := range fn.Expressions {
+		if ai, ok := expr.Kind.(ir.ExprAccessIndex); ok {
+			if inner, ok2 := fn.Expressions[ai.Base].Kind.(ir.ExprLocalVariable); ok2 {
+				if inner.Variable == varIdx {
+					aiHandles[ir.ExpressionHandle(h)] = int(ai.Index)
+				}
+			}
+		}
+	}
+	return aiHandles
+}
+
+// classifyOutputStore checks a single store statement against the output-only
+// local variable rules. Returns false if the store disqualifies the local.
+func classifyOutputStore(fn *ir.Function, sk ir.StmtStore, varIdx uint32,
+	aiHandles map[ir.ExpressionHandle]int, memberStored map[int]bool) bool {
+	// Whole-variable store -> not promotable.
+	if lv, ok := fn.Expressions[sk.Pointer].Kind.(ir.ExprLocalVariable); ok {
+		if lv.Variable == varIdx {
+			return false
+		}
+	}
+	// Field-level store via AccessIndex.
+	if memberIdx, ok := aiHandles[sk.Pointer]; ok {
+		if memberStored[memberIdx] {
+			return false // stored more than once
+		}
+		memberStored[memberIdx] = true
+		return true
+	}
+	// Two-level AccessIndex -> component-level store, bail.
+	if ai, ok := fn.Expressions[sk.Pointer].Kind.(ir.ExprAccessIndex); ok {
+		if _, ok2 := aiHandles[ai.Base]; ok2 {
+			return false
+		}
+	}
+	return true
+}
+
+// blockStoresTo checks if any statement in a block stores to the given
+// local variable (directly or via AccessIndex/Access chains).
+func blockStoresTo(fn *ir.Function, block ir.Block, varIdx uint32) bool {
+	for _, stmt := range block {
+		if stmtStoresTo(fn, stmt, varIdx) {
+			return true
+		}
+	}
+	return false
+}
+
+// stmtStoresTo checks a single statement and its children for stores
+// to the given local variable.
+func stmtStoresTo(fn *ir.Function, stmt ir.Statement, varIdx uint32) bool {
+	switch sk := stmt.Kind.(type) {
+	case ir.StmtStore:
+		v, ok := resolveLocalVarEmit(fn, sk.Pointer)
+		return ok && v == varIdx
+	case ir.StmtIf:
+		return blockStoresTo(fn, sk.Accept, varIdx) || blockStoresTo(fn, sk.Reject, varIdx)
+	case ir.StmtLoop:
+		return blockStoresTo(fn, sk.Body, varIdx) || blockStoresTo(fn, sk.Continuing, varIdx)
+	case ir.StmtSwitch:
+		for ci := range sk.Cases {
+			if blockStoresTo(fn, sk.Cases[ci].Body, varIdx) {
+				return true
+			}
+		}
+	case ir.StmtBlock:
+		return blockStoresTo(fn, sk.Block, varIdx)
+	}
+	return false
 }
 
 // resolveLocalVarEmit follows AccessIndex/Access chains to find the root
@@ -686,6 +1075,14 @@ func (e *Emitter) emitStructReturn(fn *ir.Function, ret ir.StmtReturn, st *ir.St
 // For a struct {vec4<f32>, vec4<f32>}, the DXIL type is {f32, f32, f32, f32, f32, f32, f32, f32}.
 // So member 0 (vec4) uses flattened indices 0..3, member 1 uses indices 4..7.
 func (e *Emitter) emitStructReturnFromLoad(fn *ir.Function, load ir.ExprLoad, st *ir.StructType) error {
+	// Output-promoted path: skip alloca/GEP/load entirely and emit
+	// storeOutput directly from the recorded value expressions.
+	if lv, ok := fn.Expressions[load.Pointer].Kind.(ir.ExprLocalVariable); ok {
+		if e.outputPromotedLocals[lv.Variable] {
+			return e.emitPromotedStructReturn(fn, lv.Variable, st)
+		}
+	}
+
 	// Ensure the pointer expression (local variable) is emitted.
 	ptr, err := e.emitExpression(fn, load.Pointer)
 	if err != nil {
@@ -739,6 +1136,61 @@ func (e *Emitter) emitStructReturnFromLoad(fn *ir.Function, load ir.ExprLoad, st
 		}
 	}
 
+	return nil
+}
+
+// emitPromotedStructReturn emits storeOutput calls for an output-promoted
+// struct local variable. Instead of GEP+load from an alloca, this evaluates
+// each member's stored value expression (recorded during statement emission)
+// and emits storeOutput directly. Produces the same output as DXC's
+// SROA+mem2reg pipeline for the "var out: S; out.x = a; return out;" pattern.
+//
+// Members are walked in graphics output order (locations first, builtins last)
+// to match the signature element ID assignment in buildSignatures and
+// collectGraphicsSignatures.
+func (e *Emitter) emitPromotedStructReturn(fn *ir.Function, varIdx uint32, st *ir.StructType) error {
+	order := backend.SortedMemberIndices(st.Members)
+	sigID := 0
+	for _, idx := range order {
+		member := st.Members[idx]
+		if member.Binding == nil {
+			continue
+		}
+
+		// Look up the recorded value expression for this member.
+		key := outputStoreKey{varIdx: varIdx, memberIdx: idx}
+		valueHandle, ok := e.outputPromotedStores[key]
+		if !ok {
+			return fmt.Errorf("output-promoted struct: no stored value for member %d", idx)
+		}
+
+		// Evaluate the value expression.
+		if _, err := e.emitExpression(fn, valueHandle); err != nil {
+			return fmt.Errorf("output-promoted struct member %d value: %w", idx, err)
+		}
+
+		memberType := e.ir.Types[member.Type]
+		scalar, ok := scalarOfType(memberType.Inner)
+		numComps := componentCount(memberType.Inner)
+		if !ok {
+			if arr, isArr := memberType.Inner.(ir.ArrayType); isArr {
+				elemInner := e.ir.Types[arr.Base].Inner
+				scalar, ok = scalarOfType(elemInner)
+				numComps = totalScalarCount(e.ir, memberType.Inner)
+				_ = arr
+			}
+		}
+		if !ok {
+			return fmt.Errorf("output-promoted struct member %d: unsupported type", idx)
+		}
+
+		ol := overloadForScalar(scalar)
+		for comp := 0; comp < numComps; comp++ {
+			compID := e.getComponentID(valueHandle, comp)
+			e.emitOutputStore(sigID, comp, compID, ol)
+		}
+		sigID++
+	}
 	return nil
 }
 
@@ -833,6 +1285,30 @@ func (e *Emitter) emitScalarLoad(scalarTy *module.Type, ptrID int) int {
 	return loadID
 }
 
+// tryOutputPromotedStore checks if a store targets a field of an
+// output-promoted struct local. If so, records the value expression
+// handle for later storeOutput emission and returns true (handled).
+// Handles both aggregate fields (vec4, vec3) and scalar fields (f32, u32).
+// Pattern: Store(AccessIndex(LocalVariable(V), memberIdx), value)
+func (e *Emitter) tryOutputPromotedStore(fn *ir.Function, store ir.StmtStore) bool {
+	ai, ok := fn.Expressions[store.Pointer].Kind.(ir.ExprAccessIndex)
+	if !ok {
+		return false
+	}
+	lv, ok := fn.Expressions[ai.Base].Kind.(ir.ExprLocalVariable)
+	if !ok {
+		return false
+	}
+	if !e.outputPromotedLocals[lv.Variable] {
+		return false
+	}
+	e.outputPromotedStores[outputStoreKey{
+		varIdx:    lv.Variable,
+		memberIdx: int(ai.Index),
+	}] = store.Value
+	return true
+}
+
 // emitStmtStore handles store statements.
 //
 // In naga IR, stores write a value through a pointer expression.
@@ -856,6 +1332,20 @@ func (e *Emitter) emitStmtStore(fn *ir.Function, store ir.StmtStore) error {
 	// UAV stores use dx.op.bufferStore instead of LLVM store instructions.
 	if chain, ok := e.resolveUAVPointerChain(fn, store.Pointer); ok {
 		return e.emitUAVStore(fn, chain, store.Value)
+	}
+
+	// Output-promoted struct field store: record the value expression
+	// for later direct storeOutput emission, skip alloca/GEP/store.
+	if handled := e.tryOutputPromotedStore(fn, store); handled {
+		return nil
+	}
+
+	// Single-store local: the value is already recorded in singleStoreLocals
+	// by the analysis. Skip the store -- the load will resolve directly.
+	if lv, ok := fn.Expressions[store.Pointer].Kind.(ir.ExprLocalVariable); ok {
+		if _, isSingle := e.singleStoreLocals[lv.Variable]; isSingle {
+			return nil
+		}
 	}
 
 	// Check for whole-local-variable stores: vector/struct/array via dedicated
@@ -1210,6 +1700,16 @@ func (e *Emitter) tryStructMemberAggregateStore(fn *ir.Function, store ir.StmtSt
 	st, isSt := e.ir.Types[localVar.Type].Inner.(ir.StructType)
 	if !isSt || int(ai.Index) >= len(st.Members) {
 		return false, nil
+	}
+
+	// Output-promoted local: record the store for later storeOutput emission
+	// at return time, skip the alloca/GEP/store chain entirely.
+	if e.outputPromotedLocals[lv.Variable] {
+		e.outputPromotedStores[outputStoreKey{
+			varIdx:    lv.Variable,
+			memberIdx: int(ai.Index),
+		}] = store.Value
+		return true, nil
 	}
 
 	member := st.Members[ai.Index]

--- a/dxil/internal/viewid/analysis.go
+++ b/dxil/internal/viewid/analysis.go
@@ -1,6 +1,9 @@
 package viewid
 
 import (
+	"sort"
+
+	"github.com/gogpu/naga/internal/backend"
 	"github.com/gogpu/naga/ir"
 )
 
@@ -124,12 +127,20 @@ func (s *analysisState) markEverythingDependsOnEverything() {
 
 // initArgumentTaint populates exprTaint for every ExprFunctionArgument
 // with per-scalar taint from the input signature elements.
+//
+// The sig-element index (sigIdx) must advance in the same order as
+// collectGraphicsSignatures / collectFlatArgBindings, which sort
+// bindings across arguments (locations first, builtins second) for
+// non-vertex-input stages. For VS inputs the declaration order is
+// preserved (InputAssembler packing).
 func (s *analysisState) initArgumentTaint() {
 	fn := &s.ep.Function
-	// Walk arguments the same way collectGraphicsSignatures does, so the
-	// sig-element index we track matches the emitter's and PSV0's
-	// ordering.
-	sigIdx := 0
+	isVSInput := s.ep.Stage == ir.StageVertex
+
+	// Build a mapping from (argIdx, memberIdx) -> sigIdx using the same
+	// sorted flat binding list as collectFlatArgBindings.
+	sigIdxMap := buildViewIDSigMap(s.irMod, fn.Arguments, isVSInput)
+
 	for argIdx := range fn.Arguments {
 		arg := &fn.Arguments[argIdx]
 
@@ -142,8 +153,11 @@ func (s *analysisState) initArgumentTaint() {
 		argType := s.irMod.Types[arg.Type]
 		if arg.Binding != nil {
 			// Direct binding on argument.
-			taint := s.taintForSig(sigIdx)
-			sigIdx++
+			si, hasSig := sigIdxMap[viewIDArgKey{argIdx: argIdx, memberIdx: -1}]
+			if !hasSig {
+				continue
+			}
+			taint := s.taintForSig(si)
 			// Replicate scalar taint across argument's component count.
 			s.exprTaint[argHandle] = expandTaintToType(s.irMod, argType.Inner, taint)
 			continue
@@ -170,8 +184,14 @@ func (s *analysisState) initArgumentTaint() {
 				memberTaints[memIdx] = emptyTaint(n)
 				continue
 			}
-			taint := s.taintForSig(sigIdx)
-			sigIdx++
+			si, hasSig := sigIdxMap[viewIDArgKey{argIdx: argIdx, memberIdx: memIdx}]
+			if !hasSig {
+				memberTy := s.irMod.Types[member.Type]
+				n := totalScalarCount(s.irMod, memberTy.Inner)
+				memberTaints[memIdx] = emptyTaint(n)
+				continue
+			}
+			taint := s.taintForSig(si)
 			memberTy := s.irMod.Types[member.Type]
 			memberTaints[memIdx] = expandTaintToType(s.irMod, memberTy.Inner, taint)
 		}
@@ -196,6 +216,64 @@ func (s *analysisState) initArgumentTaint() {
 			s.exprTaint[ir.ExpressionHandle(exprIdx)] = memberTaints[ai.Index]
 		}
 	}
+}
+
+// viewIDArgKey identifies a specific binding element for the ViewID
+// signature index mapping. memberIdx is -1 for direct-binding arguments.
+type viewIDArgKey struct {
+	argIdx    int
+	memberIdx int
+}
+
+// buildViewIDSigMap builds a mapping from (argIdx, memberIdx) to the
+// signature element index, using the same sorted order as
+// collectFlatArgBindings. This ensures the ViewID analysis assigns
+// taint from the correct input signature element.
+func buildViewIDSigMap(irMod *ir.Module, args []ir.FunctionArgument, isVSInput bool) map[viewIDArgKey]int {
+	type entry struct {
+		key     viewIDArgKey
+		binding ir.Binding
+	}
+	var entries []entry
+	for argIdx := range args {
+		arg := &args[argIdx]
+		if arg.Binding != nil {
+			entries = append(entries, entry{
+				key:     viewIDArgKey{argIdx: argIdx, memberIdx: -1},
+				binding: *arg.Binding,
+			})
+			continue
+		}
+		argType := irMod.Types[arg.Type]
+		st, ok := argType.Inner.(ir.StructType)
+		if !ok {
+			continue
+		}
+		order := backend.SortedMemberIndices(st.Members)
+		for _, idx := range order {
+			m := st.Members[idx]
+			if m.Binding == nil {
+				continue
+			}
+			entries = append(entries, entry{
+				key:     viewIDArgKey{argIdx: argIdx, memberIdx: idx},
+				binding: *m.Binding,
+			})
+		}
+	}
+	// Apply the same cross-argument sort for non-VS inputs.
+	if !isVSInput {
+		sort.SliceStable(entries, func(i, j int) bool {
+			ki := backend.NewMemberInterfaceKey(&entries[i].binding)
+			kj := backend.NewMemberInterfaceKey(&entries[j].binding)
+			return backend.MemberInterfaceLess(ki, kj)
+		})
+	}
+	result := make(map[viewIDArgKey]int, len(entries))
+	for i, e := range entries {
+		result[e.key] = i
+	}
+	return result
 }
 
 // findArgHandle finds the ExpressionHandle for a FunctionArgument with

--- a/dxil/internal/viewid/dataflow_test.go
+++ b/dxil/internal/viewid/dataflow_test.go
@@ -31,11 +31,9 @@ func scalarBinding(n uint32) *ir.Binding {
 //	    return vec4<f32>(input.color, 1.0);
 //	}
 //
-// Expected dependency:
-//   - input scalars 0..3 (position): contribute to nothing
-//   - input scalar 4 (color.r): contributes to output scalar 0 (.r)
-//   - input scalar 5 (color.g): contributes to output scalar 1 (.g)
-//   - input scalar 6 (color.b): contributes to output scalar 2 (.b)
+// Expected dependency (after locations-first input sorting):
+//   - input scalars 0..2 (color): contribute to output scalars 0..2
+//   - input scalars 4..7 (position): contribute to nothing
 //   - output scalar 3 (alpha): constant 1.0, no input deps
 func TestTrianglePassThroughFS(t *testing.T) {
 	mod := makeBasicMod()
@@ -99,9 +97,12 @@ func TestTrianglePassThroughFS(t *testing.T) {
 		Function: fn,
 	}
 
+	// Inputs are ordered locations-first: color (LOC 0) before position
+	// (SV_Position), matching the fragment input sorted order produced by
+	// collectGraphicsSignatures.
 	inputs := []SigElement{
-		{ScalarStart: 0, NumChannels: 4, VectorRow: 0}, // position
-		{ScalarStart: 4, NumChannels: 3, VectorRow: 1}, // color
+		{ScalarStart: 0, NumChannels: 3, VectorRow: 0}, // color (LOC 0)
+		{ScalarStart: 4, NumChannels: 4, VectorRow: 1}, // position (SV_Position)
 	}
 	outputs := []SigElement{
 		{ScalarStart: 0, NumChannels: 4, VectorRow: 0}, // SV_Target
@@ -109,35 +110,42 @@ func TestTrianglePassThroughFS(t *testing.T) {
 
 	deps := Analyze(mod, &ep, inputs, outputs)
 
-	if deps.NumInputScalars != 7 {
-		t.Errorf("NumInputScalars = %d, want 7", deps.NumInputScalars)
+	// With locations-first ordering: color at scalars 0-2, position at 4-7.
+	// Total: 3 (color) + gap + 4 (position) → cumScalar layout depends on
+	// packer; in this test color occupies row 0 (3 channels), position row 1
+	// (4 channels), so total = max(row*4+startCol+numChannels) = 1*4+0+4 = 8.
+	if deps.NumInputScalars != 8 {
+		t.Errorf("NumInputScalars = %d, want 8", deps.NumInputScalars)
 	}
 	if deps.NumOutputScalars != 4 {
 		t.Errorf("NumOutputScalars = %d, want 4", deps.NumOutputScalars)
 	}
 
-	// ViewIdState table: one row per input scalar, 1 dword per row
-	// (NumOutUINTs(4) = 1).
-	if got, want := len(deps.InputScalarToOutputs), 7; got != want {
+	// ViewIdState table: one row per input scalar.
+	if got, want := len(deps.InputScalarToOutputs), 8; got != want {
 		t.Fatalf("InputScalarToOutputs len = %d, want %d", got, want)
 	}
-	// Position scalars 0..3: no contribution.
-	for i := 0; i < 4; i++ {
+	// Color scalar 0 → bit 0 (output 0).
+	if got := deps.InputScalarToOutputs[0]; got != 0x1 {
+		t.Errorf("InputScalarToOutputs[0] = 0x%x, want 0x1", got)
+	}
+	// Color scalar 1 → bit 1 (output 1).
+	if got := deps.InputScalarToOutputs[1]; got != 0x2 {
+		t.Errorf("InputScalarToOutputs[1] = 0x%x, want 0x2", got)
+	}
+	// Color scalar 2 → bit 2 (output 2).
+	if got := deps.InputScalarToOutputs[2]; got != 0x4 {
+		t.Errorf("InputScalarToOutputs[2] = 0x%x, want 0x4", got)
+	}
+	// Color scalar 3 (unused, padding to 4-component row): no deps.
+	if deps.InputScalarToOutputs[3] != 0 {
+		t.Errorf("InputScalarToOutputs[3] = 0x%x, want 0", deps.InputScalarToOutputs[3])
+	}
+	// Position scalars 4..7: no contribution (not used in output).
+	for i := 4; i < 8; i++ {
 		if deps.InputScalarToOutputs[i] != 0 {
 			t.Errorf("InputScalarToOutputs[%d] = 0x%x, want 0", i, deps.InputScalarToOutputs[i])
 		}
-	}
-	// Color scalar 4 → bit 0 (output 0).
-	if got := deps.InputScalarToOutputs[4]; got != 0x1 {
-		t.Errorf("InputScalarToOutputs[4] = 0x%x, want 0x1", got)
-	}
-	// Color scalar 5 → bit 1 (output 1).
-	if got := deps.InputScalarToOutputs[5]; got != 0x2 {
-		t.Errorf("InputScalarToOutputs[5] = 0x%x, want 0x2", got)
-	}
-	// Color scalar 6 → bit 2 (output 2).
-	if got := deps.InputScalarToOutputs[6]; got != 0x4 {
-		t.Errorf("InputScalarToOutputs[6] = 0x%x, want 0x4", got)
 	}
 
 	// PSV0 table: SigInputVectors = 2, SigOutputVectors = 1.
@@ -146,27 +154,25 @@ func TestTrianglePassThroughFS(t *testing.T) {
 	if got, want := len(deps.InputCompToOutputComps), 8; got != want {
 		t.Fatalf("InputCompToOutputComps len = %d, want %d", got, want)
 	}
-	// Input comps 0..3 (position vector 0): no deps.
-	for i := 0; i < 4; i++ {
+	// Input comps 0-2 (color vector 0): r->out0, g->out1, b->out2.
+	if got := deps.InputCompToOutputComps[0]; got != 0x1 {
+		t.Errorf("InputCompToOutputComps[0] = 0x%x, want 0x1", got)
+	}
+	if got := deps.InputCompToOutputComps[1]; got != 0x2 {
+		t.Errorf("InputCompToOutputComps[1] = 0x%x, want 0x2", got)
+	}
+	if got := deps.InputCompToOutputComps[2]; got != 0x4 {
+		t.Errorf("InputCompToOutputComps[2] = 0x%x, want 0x4", got)
+	}
+	// Input comp 3 (unused padding): no deps.
+	if deps.InputCompToOutputComps[3] != 0 {
+		t.Errorf("InputCompToOutputComps[3] = 0x%x, want 0", deps.InputCompToOutputComps[3])
+	}
+	// Input comps 4..7 (position vector 1): no deps.
+	for i := 4; i < 8; i++ {
 		if deps.InputCompToOutputComps[i] != 0 {
 			t.Errorf("InputCompToOutputComps[%d] = 0x%x, want 0", i, deps.InputCompToOutputComps[i])
 		}
-	}
-	// Input comp 4 (color.r) → output comp 0.
-	if got := deps.InputCompToOutputComps[4]; got != 0x1 {
-		t.Errorf("InputCompToOutputComps[4] = 0x%x, want 0x1", got)
-	}
-	// Input comp 5 (color.g) → output comp 1.
-	if got := deps.InputCompToOutputComps[5]; got != 0x2 {
-		t.Errorf("InputCompToOutputComps[5] = 0x%x, want 0x2", got)
-	}
-	// Input comp 6 (color.b) → output comp 2.
-	if got := deps.InputCompToOutputComps[6]; got != 0x4 {
-		t.Errorf("InputCompToOutputComps[6] = 0x%x, want 0x4", got)
-	}
-	// Input comp 7 (color.w, unused): no deps.
-	if deps.InputCompToOutputComps[7] != 0 {
-		t.Errorf("InputCompToOutputComps[7] = 0x%x, want 0", deps.InputCompToOutputComps[7])
 	}
 }
 

--- a/hlsl/namer.go
+++ b/hlsl/namer.go
@@ -262,3 +262,23 @@ func (n *namer) callWithPrefix(prefix, base string) string {
 func isASCIIAlphanumeric(c rune) bool {
 	return (c >= 'a' && c <= 'z') || (c >= 'A' && c <= 'Z') || (c >= '0' && c <= '9')
 }
+
+// NeedsTrailingUnderscore reports whether a variable name requires a
+// trailing underscore suffix in HLSL output. The HLSL namer (matching
+// Rust naga's proc::Namer) appends "_" when the sanitized name ends
+// with an ASCII digit or collides with an HLSL reserved keyword. The
+// DXIL backend uses this to produce metadata resource names that match
+// what DXC would generate from the HLSL roundtrip.
+func NeedsTrailingUnderscore(name string) bool {
+	if name == "" {
+		return false
+	}
+	if endsWithDigit(name) {
+		return true
+	}
+	if _, found := reservedKeywords[name]; found {
+		return true
+	}
+	_, found := caseInsensitiveKeywords[strings.ToLower(name)]
+	return found
+}

--- a/hlsl/namer_test.go
+++ b/hlsl/namer_test.go
@@ -290,3 +290,55 @@ func TestIsASCIIAlphanumeric(t *testing.T) {
 		}
 	}
 }
+
+// TestNeedsTrailingUnderscore verifies the exported helper used by the
+// DXIL backend to match DXC resource name conventions. DXC applies the
+// HLSL namer to all resource variable names before emitting DXIL
+// metadata, so our DXIL backend must replicate the same suffix logic.
+func TestNeedsTrailingUnderscore(t *testing.T) {
+	tests := []struct {
+		name string
+		want bool
+	}{
+		// Ends with digit -> true
+		{"t1", true},
+		{"t2", true},
+		{"atomic_i32", true},
+		{"atomic_u32", true},
+		{"input1", true},
+		{"input2", true},
+		{"input3", true},
+		{"image_2d_i32", true},
+		{"in_data_storage_g0_b3", true},
+
+		// HLSL keyword (case sensitive) -> true
+		{"in", true},
+		{"out", true},
+		{"float", true},
+		{"int", true},
+		{"struct", true},
+		{"texture", true},  // reserved keyword (case-sensitive)
+		{"indices", true},  // reserved keyword
+		{"vertices", true}, // reserved keyword
+
+		// Normal names -> false
+		{"params", false},
+		{"uniformOne", false},
+		{"camera", false},
+		{"globals", false},
+		{"output", false},
+		{"result", false},
+		{"nagaSamplerHeap", false},
+
+		// Empty -> false
+		{"", false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := NeedsTrailingUnderscore(tt.name); got != tt.want {
+				t.Errorf("NeedsTrailingUnderscore(%q) = %v, want %v", tt.name, got, tt.want)
+			}
+		})
+	}
+}

--- a/internal/backend/interface_order.go
+++ b/internal/backend/interface_order.go
@@ -135,3 +135,52 @@ func SortedMemberIndices(members []ir.StructMember) []int {
 	}
 	return out
 }
+
+// SortFlatBindings sorts parallel (bindings, types) slices in graphics
+// interface order: @location bindings first (ascending by location index),
+// then @builtin bindings (ascending by builtin enum value).
+//
+// This is needed when multiple struct-typed arguments each contribute
+// members to the flat input binding list. SortedMemberIndices handles
+// within-struct ordering, but cross-argument ordering requires a final
+// sort of the concatenated result. Without this, a builtin from an
+// earlier argument (e.g., @builtin(position) from VertexOutput) appears
+// before a location from a later argument (e.g., @location(1) from
+// NoteInstance), producing wrong register assignments for fragment input
+// signatures.
+//
+// isVSInput should be true for vertex shader inputs (InputAssembler
+// packing). DXC keeps VS inputs in declaration order — system values
+// first, then locations — not the locations-first order used for
+// fragment/geometry inputs. When isVSInput is true, this function is
+// a no-op.
+func SortFlatBindings(bindings []ir.Binding, types []ir.TypeHandle, isVSInput bool) {
+	if isVSInput {
+		return
+	}
+	if len(bindings) <= 1 {
+		return
+	}
+	type keyed struct {
+		idx     int
+		key     MemberInterfaceKey
+		binding ir.Binding
+		th      ir.TypeHandle
+	}
+	tmp := make([]keyed, len(bindings))
+	for i := range bindings {
+		tmp[i] = keyed{
+			idx:     i,
+			key:     NewMemberInterfaceKey(&bindings[i]),
+			binding: bindings[i],
+			th:      types[i],
+		}
+	}
+	sort.SliceStable(tmp, func(i, j int) bool {
+		return MemberInterfaceLess(tmp[i].key, tmp[j].key)
+	})
+	for i, k := range tmp {
+		bindings[i] = k.binding
+		types[i] = k.th
+	}
+}

--- a/internal/backend/sig_pack_test.go
+++ b/internal/backend/sig_pack_test.go
@@ -3,6 +3,8 @@ package backend
 import (
 	"reflect"
 	"testing"
+
+	"github.com/gogpu/naga/ir"
 )
 
 // TestPackSignatureElements_Empty verifies the nil/empty case.
@@ -218,5 +220,91 @@ func TestPackSignatureElements_OtherBindingPlaceholder(t *testing.T) {
 	}
 	if got[1].Rows != 0 {
 		t.Fatalf("placeholder Rows = %d, want 0 (no row consumed)", got[1].Rows)
+	}
+}
+
+// TestSortFlatBindings_LocationsBeforeBuiltins verifies that
+// SortFlatBindings reorders bindings so locations come before builtins.
+// This matches DXC's fragment input signature element ordering.
+func TestSortFlatBindings_LocationsBeforeBuiltins(t *testing.T) {
+	// Simulate the msl-varyings fragment shader case:
+	// arg 0 = VertexOutput with @builtin(position)
+	// arg 1 = NoteInstance with @location(1)
+	// Expected after sort: location(1) first, then builtin(position).
+	bindings := []ir.Binding{
+		ir.BuiltinBinding{Builtin: ir.BuiltinPosition},
+		ir.LocationBinding{Location: 1},
+	}
+	types := []ir.TypeHandle{10, 20} // arbitrary handles
+
+	SortFlatBindings(bindings, types, false)
+
+	// After sort: location should be first.
+	if _, ok := bindings[0].(ir.LocationBinding); !ok {
+		t.Errorf("after sort, bindings[0] should be LocationBinding, got %T", bindings[0])
+	}
+	if _, ok := bindings[1].(ir.BuiltinBinding); !ok {
+		t.Errorf("after sort, bindings[1] should be BuiltinBinding, got %T", bindings[1])
+	}
+	// Types should follow the same reordering.
+	if types[0] != 20 {
+		t.Errorf("types[0] = %d, want 20 (location's type)", types[0])
+	}
+	if types[1] != 10 {
+		t.Errorf("types[1] = %d, want 10 (builtin's type)", types[1])
+	}
+}
+
+// TestSortFlatBindings_VSInputPreservesOrder verifies that VS inputs
+// are NOT sorted (InputAssembler packing preserves declaration order).
+func TestSortFlatBindings_VSInputPreservesOrder(t *testing.T) {
+	bindings := []ir.Binding{
+		ir.BuiltinBinding{Builtin: ir.BuiltinVertexIndex},
+		ir.BuiltinBinding{Builtin: ir.BuiltinInstanceIndex},
+		ir.LocationBinding{Location: 10},
+	}
+	types := []ir.TypeHandle{1, 2, 3}
+
+	SortFlatBindings(bindings, types, true)
+
+	// Order should be unchanged for VS input.
+	if bb, ok := bindings[0].(ir.BuiltinBinding); !ok || bb.Builtin != ir.BuiltinVertexIndex {
+		t.Errorf("VS input bindings[0] should be BuiltinVertexIndex, got %v", bindings[0])
+	}
+	if bb, ok := bindings[1].(ir.BuiltinBinding); !ok || bb.Builtin != ir.BuiltinInstanceIndex {
+		t.Errorf("VS input bindings[1] should be BuiltinInstanceIndex, got %v", bindings[1])
+	}
+	if lb, ok := bindings[2].(ir.LocationBinding); !ok || lb.Location != 10 {
+		t.Errorf("VS input bindings[2] should be LOC 10, got %v", bindings[2])
+	}
+}
+
+// TestSortFlatBindings_MultipleLocations verifies that multiple
+// locations sort by location index (ascending).
+func TestSortFlatBindings_MultipleLocations(t *testing.T) {
+	bindings := []ir.Binding{
+		ir.LocationBinding{Location: 5},
+		ir.BuiltinBinding{Builtin: ir.BuiltinPosition},
+		ir.LocationBinding{Location: 2},
+		ir.LocationBinding{Location: 8},
+	}
+	types := []ir.TypeHandle{50, 10, 20, 80}
+
+	SortFlatBindings(bindings, types, false)
+
+	// Expected order: loc(2), loc(5), loc(8), builtin(position).
+	wantLocs := []uint32{2, 5, 8}
+	for i, wantLoc := range wantLocs {
+		lb, ok := bindings[i].(ir.LocationBinding)
+		if !ok {
+			t.Errorf("bindings[%d] should be LocationBinding, got %T", i, bindings[i])
+			continue
+		}
+		if lb.Location != wantLoc {
+			t.Errorf("bindings[%d].Location = %d, want %d", i, lb.Location, wantLoc)
+		}
+	}
+	if _, ok := bindings[3].(ir.BuiltinBinding); !ok {
+		t.Errorf("bindings[3] should be BuiltinBinding, got %T", bindings[3])
 	}
 }


### PR DESCRIPTION
## Summary

DXIL golden parity push: 7 enterprise-level fixes bringing parity from 82→94 diff=0.

- **Single-store local promotion** — eliminate alloca/store/load chains for VS/FS output staging (+6 diff=0)
- **Sampler heap after input loads** — DXC emit ordering for fragment shaders (+3 diff=0)
- **HLSL namer suffix** — trailing `_` on resource names ending with digits/keywords (+2 diff=0)
- **Input used mask sorted order** — fix extended properties metadata for multi-struct inputs (+1 diff=0)
- **Fragment input signature ordering** — LOC before SV_Position (+33 lines parity)
- **Strength reduction** — `urem x, 2^N` → `and x, (2^N-1)` (+2 lines parity)
- **Raw buffer i32 overload** — float loads via i32 + bitcast, matching DXC (+11 lines parity)

## Metrics

| Metric | v0.17.5 tag | This PR |
|--------|:---:|:---:|
| DXC golden diff=0 | 82 | **94** (+12) |
| Line parity | 45.7% | **48.1%** |
| IDxcValidator | 161/170 | 161/170 |
| gg production | 58/59 | 58/59 |
| Text backends | 100% | 100% |
| SPIR-V val | 172/172 | 172/172 |

## Test plan

- [x] `go build ./...`
- [x] `go test ./dxil/... -count=1` — all pass
- [x] `go test -run TestDxilValSummary` — 161/170
- [x] `go test -run TestDxilDxcGolden` — 94 diff=0
- [x] `go test -run TestRustReference` — 100%
- [x] `golangci-lint run --timeout=5m` — clean
- [ ] CI green (Linux, macOS, Windows)
