### PR TITLE
fix(wgsl): reject function call argument type mismatches (#66)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,81 +7,65 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- **Function call argument type validation** ([#66](https://github.com/gogpu/naga/issues/66)).
+  WGSL lowerer now validates argument count and types against function
+  parameters. Passing `vec2<u32>` where `u32` is expected now produces a
+  clear compile error instead of silently generating invalid shader code
+  that crashes at pipeline creation. Reported by @maxsupermanhd.
+  9 test cases covering shape mismatches, count mismatches, and abstract
+  type concretization.
+
+## [0.17.6] - 2026-04-23
+
+### Fixed (DXIL)
+
+- **Single-store local promotion** — eliminates alloca/store/load chains
+  for vertex/fragment output staging, matching DXC's direct `storeOutput`.
+- **Sampler heap after input loads** — DXC emit ordering for fragment shaders.
+- **HLSL namer suffix** — trailing `_` on resource names ending with
+  digits or matching HLSL keywords.
+- **Input used mask sorted order** — correct extended properties metadata
+  for fragment shaders with multiple struct inputs.
+- **Fragment input signature ordering** — LOC semantics before SV_Position.
+- **Raw buffer i32 overload** — float loads via i32 + bitcast, matching
+  DXC ByteAddressBuffer convention.
+- **Strength reduction** — `urem x, 2^N` → `and x, (2^N-1)` at emit time.
+
+### Metrics
+
+- DXC golden diff=0: 82 → **94** (+12)
+- Line parity: 46.5% → **48.1%**
+
 ## [0.17.5] - 2026-04-23
 
 ### Added
 
 - **`ir.TypeSize()` — shared type size calculation** matching Rust naga
-  `TypeInner::try_size(gctx)`. Returns byte size for all IR types following
-  WGSL/WebGPU alignment rules. Used by wgpu core for late buffer binding
-  size validation (VAL-006). 23 unit tests covering scalars, vectors,
-  matrices, arrays, structs, atomics, pointers, and opaque types.
+  `TypeInner::try_size(gctx)`. Used by wgpu core for late buffer binding
+  size validation (VAL-006). 23 unit tests.
 
 - **`ir.StorageFormat.IsUnorm()` / `IsSnorm()`** — predicate methods for
   storage texture format classification, used by DXIL backend for correct
   component type metadata.
 
-- **Single-store local promotion** — new emitter optimization that detects
-  vector/scalar locals stored exactly once in straight-line code and resolves
-  loads directly to the stored value, eliminating alloca/store/load chains
-  for vertex/fragment output staging. Matches DXC's direct `storeOutput`
-  pattern.
-
-- **Strength reduction** — `urem x, 2^N` emitted as `and x, (2^N-1)` at
-  emit time, matching DXC's LLVM InstCombine optimization.
-
 ### Fixed (DXIL)
 
-- **UNorm/SNorm component types** — storage textures with `rgba8unorm` now
-  emit `UNormF32` (14) instead of `F32` (9) in DXIL extended resource
-  properties metadata. Same for SNorm formats. Matches DXC behavior.
-
-- **CBV metadata size** — constant buffer metadata field[6] now uses actual
-  struct byte size instead of vec4-rounded size. For a push-constant struct
-  with a single `f32`, this emits 4 bytes (not 16). Matches DXC.
-
-- **Named metadata ordering** — `!dx.resources` now emits before
-  `!dx.viewIdState`, matching DXC output order.
-
-- **dx.op attribute classification** — sample, mesh output, and store
-  vertex/primitive output functions now get correct `nounwind readonly`
-  attributes instead of plain `nounwind`.
-
-- **HLSL namer suffix on resource names** — resource metadata names now get
-  trailing `_` when ending with a digit or matching an HLSL keyword,
-  matching the DXC roundtrip path (WGSL→HLSL→DXC→DXIL).
-
-- **Sampler heap handles after input loads** — `emitSamplerHeapHandles()`
-  moved after `emitInputLoads()` to match DXC emit ordering for fragment
-  shaders with both samplers and input varyings.
-
-- **Raw buffer float loads use i32 overload** — `bufferLoad` for
-  ByteAddressBuffer now always uses i32 overload with bitcast to float,
-  matching DXC behavior. Fixes `%dx.types.ResRet.f32` → `.i32` type
-  declaration difference.
-
-- **Fragment input signature ordering** — LOC semantics sorted before
-  SV_Position in fragment shader input signatures, matching DXC convention.
-  Applied across ISG1, metadata, loadInput, and ViewID analysis.
-
-- **Input used mask sorted order** — `computeInputElementUsedMasks` now
-  iterates in sorted signature order, fixing incorrect extended properties
-  metadata for fragment shaders with multiple struct inputs.
+- **UNorm/SNorm component types** — `rgba8unorm` → `UNormF32` (14) in metadata.
+- **CBV metadata size** — actual struct size, not vec4-rounded.
+- **Named metadata ordering** — `!dx.resources` before `!dx.viewIdState`.
+- **dx.op attribute classification** — correct `nounwind readonly` attributes.
 
 ### Changed
 
 - **DXC golden normalizer** — function declarations and attribute definitions
-  are now sorted alphabetically for comparison, eliminating false-positive
-  diffs from DXC's non-deterministic declaration ordering.
+  sorted alphabetically, eliminating false-positive ordering diffs.
 
 ### Metrics
 
-- DXC golden diff=0: 72 → **94** (+22)
-- Line parity: 45.7% → **48.1%**
-- IDxcValidator: 161/170 (94.7%, unchanged)
-- gg production: 58/59 (fine.wgsl pre-existing failure)
-- Text backends: 100% (unchanged)
-- SPIR-V validation: 172/172 (100%, unchanged)
+- DXC golden diff=0: 72 → **82** (+10)
+- Line parity: 45.7% → **46.5%**
 
 ### Notes
 

--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@
 - **Type Conversions** — Scalar constructors `f32(x)`, `u32(y)`, `i32(z)` with correct SPIR-V opcodes
 - **Bitcast** — `bitcast<T>(expr)` for reinterpreting bit patterns between types
 - **Warnings** — Unused variable detection with `_` prefix exception
-- **Validation** — Type checking and semantic validation
+- **Validation** — Type checking, semantic validation, function call argument type/count verification
 - **CLI Tool** — `nagac` command-line compiler
 
 ---

--- a/wgsl/lower.go
+++ b/wgsl/lower.go
@@ -6990,6 +6990,90 @@ func (l *Lowerer) getTypeScalar(typeHandle ir.TypeHandle) (ir.ScalarType, bool) 
 // This implements WGSL's automatic type conversion at declaration sites:
 //
 // let x: vec2<u32> = vec2(44, 45) → concretize 44,45 from AbstractInt to u32.
+// checkArgumentType verifies that a call argument's resolved type matches the
+// expected parameter type. Abstract types are allowed (concretization handles them).
+func (l *Lowerer) checkArgumentType(argHandle ir.ExpressionHandle, paramType ir.TypeHandle, funcName string, argIndex int) error {
+	if l.currentFunc == nil || int(argHandle) >= len(l.currentFunc.ExpressionTypes) {
+		return nil
+	}
+	argInner := ir.TypeResInner(l.module, l.currentFunc.ExpressionTypes[argHandle])
+	if argInner == nil {
+		return nil
+	}
+	// Skip abstract types — concretization will handle or report them.
+	if s, ok := argInner.(ir.ScalarType); ok && (s.Kind == ir.ScalarAbstractInt || s.Kind == ir.ScalarAbstractFloat) {
+		return nil
+	}
+	if int(paramType) >= len(l.module.Types) {
+		return nil
+	}
+	paramInner := l.module.Types[paramType].Inner
+	if !typeShapeMatches(argInner, paramInner) {
+		return fmt.Errorf("function '%s' argument %d: type mismatch (expected %s, got %s)", funcName, argIndex, typeName(paramInner), typeName(argInner))
+	}
+	return nil
+}
+
+// typeShapeMatches checks if two TypeInner values have compatible shapes.
+// Scalar↔Scalar, Vector↔Vector (same size), Matrix↔Matrix (same dims), etc.
+func typeShapeMatches(arg, param ir.TypeInner) bool {
+	switch p := param.(type) {
+	case ir.ScalarType:
+		a, ok := arg.(ir.ScalarType)
+		return ok && (a.Kind == p.Kind || a.Kind == ir.ScalarAbstractInt || a.Kind == ir.ScalarAbstractFloat)
+	case ir.VectorType:
+		a, ok := arg.(ir.VectorType)
+		return ok && a.Size == p.Size
+	case ir.MatrixType:
+		a, ok := arg.(ir.MatrixType)
+		return ok && a.Columns == p.Columns && a.Rows == p.Rows
+	case ir.ArrayType:
+		_, ok := arg.(ir.ArrayType)
+		return ok
+	case ir.StructType:
+		_, ok := arg.(ir.StructType)
+		return ok
+	case ir.PointerType:
+		_, ok := arg.(ir.PointerType)
+		return ok
+	case ir.AtomicType:
+		_, ok := arg.(ir.AtomicType)
+		return ok
+	default:
+		return true // opaque types — trust downstream validation
+	}
+}
+
+func typeName(inner ir.TypeInner) string {
+	switch t := inner.(type) {
+	case ir.ScalarType:
+		switch t.Kind {
+		case ir.ScalarFloat:
+			if t.Width == 2 {
+				return "f16"
+			}
+			return "f32"
+		case ir.ScalarSint:
+			return "i32"
+		case ir.ScalarUint:
+			return "u32"
+		case ir.ScalarBool:
+			return "bool"
+		}
+	case ir.VectorType:
+		return fmt.Sprintf("vec%d<%s>", t.Size, typeName(t.Scalar))
+	case ir.MatrixType:
+		return fmt.Sprintf("mat%dx%d<%s>", t.Columns, t.Rows, typeName(t.Scalar))
+	case ir.ArrayType:
+		return "array<...>"
+	case ir.StructType:
+		return "struct"
+	case ir.PointerType:
+		return "ptr<...>"
+	}
+	return "unknown"
+}
+
 func (l *Lowerer) concretizeExpressionToType(handle ir.ExpressionHandle, targetType ir.TypeHandle) {
 	targetScalar, ok := l.getTypeScalar(targetType)
 	if !ok {
@@ -7391,12 +7475,16 @@ func (l *Lowerer) lowerCall(call *CallExpr, target *[]ir.Statement) (ir.Expressi
 		args[i] = handle
 	}
 
-	// Concretize abstract literal arguments to match the function parameter types.
+	// Validate argument count and types, then concretize abstract literals.
 	if int(funcHandle) < len(l.module.Functions) {
 		fn := &l.module.Functions[funcHandle]
+		if len(args) != len(fn.Arguments) {
+			return 0, fmt.Errorf("function '%s' expects %d argument(s), got %d", funcName, len(fn.Arguments), len(args))
+		}
 		for i, argHandle := range args {
-			if i < len(fn.Arguments) {
-				l.concretizeExpressionToType(argHandle, fn.Arguments[i].Type)
+			l.concretizeExpressionToType(argHandle, fn.Arguments[i].Type)
+			if err := l.checkArgumentType(argHandle, fn.Arguments[i].Type, funcName, i); err != nil {
+				return 0, err
 			}
 		}
 	}

--- a/wgsl/lower_test.go
+++ b/wgsl/lower_test.go
@@ -1504,3 +1504,128 @@ fn main() {
 		t.Errorf("matrix Compose type name = %q, want empty (anonymous); scalar grouping should use anonymous type", composeTypeName)
 	}
 }
+
+func TestCallArgumentTypeMismatch(t *testing.T) {
+	tests := []struct {
+		name    string
+		src     string
+		wantErr string
+	}{
+		{
+			name: "vec2 passed as scalar (issue #66)",
+			src: `fn takes_scalar(n: u32) -> u32 { return n; }
+@compute @workgroup_size(1)
+fn main() {
+    let v = vec2<u32>(1u, 2u);
+    takes_scalar(v);
+}`,
+			wantErr: "type mismatch (expected u32, got vec2<u32>)",
+		},
+		{
+			name: "scalar passed as vec2",
+			src: `fn takes_vec(v: vec2<f32>) -> vec2<f32> { return v; }
+@compute @workgroup_size(1)
+fn main() {
+    takes_vec(1.0);
+}`,
+			wantErr: "type mismatch (expected vec2<f32>, got f32)",
+		},
+		{
+			name: "vec3 passed as vec4",
+			src: `fn takes_vec4(v: vec4<f32>) -> vec4<f32> { return v; }
+@compute @workgroup_size(1)
+fn main() {
+    let v = vec3<f32>(1.0, 2.0, 3.0);
+    takes_vec4(v);
+}`,
+			wantErr: "type mismatch (expected vec4<f32>, got vec3<f32>)",
+		},
+		{
+			name: "wrong argument count — too many",
+			src: `fn takes_one(a: u32) -> u32 { return a; }
+@compute @workgroup_size(1)
+fn main() {
+    takes_one(1u, 2u);
+}`,
+			wantErr: "expects 1 argument(s), got 2",
+		},
+		{
+			name: "wrong argument count — too few",
+			src: `fn takes_two(a: u32, b: u32) -> u32 { return a + b; }
+@compute @workgroup_size(1)
+fn main() {
+    takes_two(1u);
+}`,
+			wantErr: "expects 2 argument(s), got 1",
+		},
+		{
+			name: "correct call compiles",
+			src: `fn add(a: u32, b: u32) -> u32 { return a + b; }
+@compute @workgroup_size(1)
+fn main() {
+    let x = add(1u, 2u);
+}`,
+			wantErr: "",
+		},
+		{
+			name: "abstract int concretizes to u32",
+			src: `fn takes_u32(n: u32) -> u32 { return n; }
+@compute @workgroup_size(1)
+fn main() {
+    let x = takes_u32(42);
+}`,
+			wantErr: "",
+		},
+		{
+			name: "abstract float concretizes to f32",
+			src: `fn takes_f32(n: f32) -> f32 { return n; }
+@compute @workgroup_size(1)
+fn main() {
+    let x = takes_f32(3.14);
+}`,
+			wantErr: "",
+		},
+		{
+			name: "multiple args — second wrong",
+			src: `fn mixed(a: vec2<u32>, b: u32) -> u32 { return b; }
+@compute @workgroup_size(1)
+fn main() {
+    let a = vec2<u32>(1u, 2u);
+    let b = vec2<u32>(3u, 4u);
+    mixed(a, b);
+}`,
+			wantErr: "argument 1: type mismatch (expected u32, got vec2<u32>)",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			_, err := compileWGSL(t, tt.src)
+			if tt.wantErr == "" {
+				if err != nil {
+					t.Fatalf("expected success, got error: %v", err)
+				}
+				return
+			}
+			if err == nil {
+				t.Fatalf("expected error containing %q, but compilation succeeded", tt.wantErr)
+			}
+			if !contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want containing %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && searchSubstring(s, substr)
+}
+
+func searchSubstring(s, substr string) bool {
+	for i := 0; i <= len(s)-len(substr); i++ {
+		if s[i:i+len(substr)] == substr {
+			return true
+		}
+	}
+	return false
+}


### PR DESCRIPTION
## Summary

Fixes #66 — WGSL lowerer now validates function call argument count and types.

`vec2<u32>` passed where `u32` is expected now produces a clear compile error
instead of silently generating invalid shader code that crashes at pipeline creation.

Reported by @maxsupermanhd.

## Test plan

- [x] 9 unit tests: shape mismatches, count mismatches, abstract concretization
- [x] `go test ./wgsl/ ./ir/ -count=1` — pass
- [x] `go test -run TestRustReference` — 100%
- [ ] CI green