### PR TITLE
fix(dxil): PHI node ordering + coverage waves 3-4 (#75)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.17.13] - 2026-05-08
+
+### Fixed (DXIL)
+
+- **PHI node ordering** — mem2reg Phase B phi instructions now grouped at
+  top of basic blocks before non-phi instructions. Fixes `path_count.wgsl`
+  (Vello tilecompute) IDxcValidator "PHI nodes not grouped at top of basic
+  block" error. Root cause: merged StmtEmit runs emitted low-handle regular
+  expressions before high-handle phi expressions.
+
+### Added
+
+- Test coverage waves 3-4: hlsl 70.6%, wgsl/lower 65.3%, msl 64.2%,
+  spirv 76.5%, dxil/emit 37.4%. Overall ~60%.
+
 ## [0.17.12] - 2026-05-07
 
 ### Changed

--- a/dxil/dxil_test.go
+++ b/dxil/dxil_test.go
@@ -1296,3 +1296,92 @@ fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
 }
 `)
 }
+
+// TestPhiNodesGroupedAtTopOfBasicBlock verifies that phi instructions
+// produced by mem2reg Phase B are placed at the top of their basic
+// block, before any non-phi instructions. LLVM requires this grouping;
+// the IDxcValidator rejects DXIL with misplaced phi nodes.
+//
+// The if body contains both a promoted variable assignment (which mem2reg
+// Phase B turns into a phi at the merge point) AND a buffer store side
+// effect (which keeps the if-statement alive through DCE). At the merge
+// block, the phi must come before the regular expressions that follow.
+func TestPhiNodesGroupedAtTopOfBasicBlock(t *testing.T) {
+	compileWGSLToDXIL(t, `
+@group(0) @binding(0) var<storage, read_write> buf: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    var value: f32 = 1.0;
+
+    if (idx > 32u) {
+        value = 2.0;
+        // Side effect keeps the if alive through DCE.
+        buf[0u] = 99.0;
+    }
+
+    let result = value * 3.0;
+    buf[idx] = result;
+}
+`)
+}
+
+// TestPhiNodesMultipleVars verifies phi ordering with multiple variables
+// that diverge across the same if-else branch. Each variable produces a
+// separate phi instruction; all must appear at the top of the merge BB.
+func TestPhiNodesMultipleVars(t *testing.T) {
+	compileWGSLToDXIL(t, `
+@group(0) @binding(0) var<storage, read_write> buf: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    var a: f32 = 0.0;
+    var b: f32 = 0.0;
+
+    if (idx > 16u) {
+        a = 1.0;
+        b = 2.0;
+        buf[0u] = 99.0;
+    } else {
+        a = 3.0;
+        b = 4.0;
+        buf[1u] = 98.0;
+    }
+
+    let result = a + b;
+    buf[idx] = result;
+}
+`)
+}
+
+// TestPhiNodesNestedIf verifies phi ordering with nested if statements.
+// The outer if's merge phi must not be interleaved with the inner if's
+// merge block expressions.
+func TestPhiNodesNestedIf(t *testing.T) {
+	compileWGSLToDXIL(t, `
+@group(0) @binding(0) var<storage, read_write> buf: array<f32>;
+
+@compute @workgroup_size(64)
+fn main(@builtin(global_invocation_id) gid: vec3<u32>) {
+    let idx = gid.x;
+    var x: f32 = 0.0;
+
+    if (idx > 10u) {
+        if (idx > 20u) {
+            x = 1.0;
+            buf[0u] = 97.0;
+        } else {
+            x = 2.0;
+            buf[1u] = 96.0;
+        }
+    } else {
+        x = 3.0;
+        buf[2u] = 95.0;
+    }
+
+    buf[idx] = x * 5.0;
+}
+`)
+}

--- a/dxil/internal/emit/emit_test.go
+++ b/dxil/internal/emit/emit_test.go
@@ -7345,6 +7345,106 @@ func TestMergeConsecutiveEmitRangesNoAlloc(t *testing.T) {
 	}
 }
 
+// TestSplitPhiRanges verifies that splitPhiRanges correctly separates
+// phi-bearing StmtEmit ranges from non-phi ranges. Phi-bearing ranges
+// must be emitted first so phi instructions appear at the top of the
+// basic block per LLVM requirements.
+func TestSplitPhiRanges(t *testing.T) {
+	fn := &ir.Function{
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprBinary{}}, // [0] non-phi
+			{Kind: ir.ExprBinary{}}, // [1] non-phi
+			{Kind: ir.ExprBinary{}}, // [2] non-phi
+			{Kind: ir.ExprPhi{Incoming: []ir.PhiIncoming{{PredKey: ir.PhiPredIfAccept, Value: 0}, {PredKey: ir.PhiPredIfReject, Value: 1}}}}, // [3] phi
+			{Kind: ir.ExprPhi{Incoming: []ir.PhiIncoming{{PredKey: ir.PhiPredIfAccept, Value: 1}, {PredKey: ir.PhiPredIfReject, Value: 2}}}}, // [4] phi
+		},
+	}
+
+	tests := []struct {
+		name         string
+		ranges       []ir.Range
+		wantPhiCount int
+		wantNonCount int
+	}{
+		{
+			name:         "no phi ranges",
+			ranges:       []ir.Range{{Start: 0, End: 3}},
+			wantPhiCount: 0,
+			wantNonCount: 1,
+		},
+		{
+			name:         "only phi ranges",
+			ranges:       []ir.Range{{Start: 3, End: 4}, {Start: 4, End: 5}},
+			wantPhiCount: 2,
+			wantNonCount: 0,
+		},
+		{
+			name:         "mixed phi and non-phi",
+			ranges:       []ir.Range{{Start: 3, End: 4}, {Start: 4, End: 5}, {Start: 0, End: 3}},
+			wantPhiCount: 2,
+			wantNonCount: 1,
+		},
+		{
+			name:         "multi-handle range not treated as phi",
+			ranges:       []ir.Range{{Start: 3, End: 5}},
+			wantPhiCount: 0,
+			wantNonCount: 1,
+		},
+	}
+
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			phiR, nonR := splitPhiRanges(fn, tc.ranges)
+			if len(phiR) != tc.wantPhiCount {
+				t.Errorf("phi ranges: got %d, want %d", len(phiR), tc.wantPhiCount)
+			}
+			if len(nonR) != tc.wantNonCount {
+				t.Errorf("non-phi ranges: got %d, want %d", len(nonR), tc.wantNonCount)
+			}
+		})
+	}
+}
+
+// TestIsPhiExpression verifies the phi expression detection helper.
+func TestIsPhiExpression(t *testing.T) {
+	fn := &ir.Function{
+		Expressions: []ir.Expression{
+			{Kind: ir.ExprBinary{}},
+			{Kind: ir.ExprPhi{Incoming: []ir.PhiIncoming{{PredKey: ir.PhiPredIfAccept, Value: 0}}}},
+		},
+	}
+
+	if isPhiExpression(fn, 0) {
+		t.Error("handle 0 (ExprBinary) should not be phi")
+	}
+	if !isPhiExpression(fn, 1) {
+		t.Error("handle 1 (ExprPhi) should be phi")
+	}
+	if isPhiExpression(fn, 99) {
+		t.Error("out-of-range handle should not be phi")
+	}
+}
+
+// TestIsFollowedByEmit verifies the consecutive StmtEmit detection.
+func TestIsFollowedByEmit(t *testing.T) {
+	block := ir.Block{
+		{Kind: ir.StmtEmit{Range: ir.Range{Start: 0, End: 1}}},
+		{Kind: ir.StmtEmit{Range: ir.Range{Start: 1, End: 2}}},
+		{Kind: ir.StmtStore{Pointer: 0, Value: 1}},
+		{Kind: ir.StmtEmit{Range: ir.Range{Start: 2, End: 3}}},
+	}
+
+	if !isFollowedByEmit(block, 0) {
+		t.Error("block[0] should be followed by emit")
+	}
+	if isFollowedByEmit(block, 1) {
+		t.Error("block[1] should not be followed by emit (store follows)")
+	}
+	if isFollowedByEmit(block, 3) {
+		t.Error("block[3] should not be followed by emit (last element)")
+	}
+}
+
 // TestDecomposeWorkgroupStructNames verifies that decomposeWorkgroupStruct
 // produces per-member globals with correct MSVC-mangled names matching DXC's
 // groupshared struct decomposition convention.

--- a/dxil/internal/emit/statements.go
+++ b/dxil/internal/emit/statements.go
@@ -784,15 +784,8 @@ func (e *Emitter) emitBlock(fn *ir.Function, block ir.Block) error {
 			continue
 		}
 
-		// Check if the next statement is also StmtEmit.
-		if i+1 >= len(block) {
-			if err := e.emitStatement(fn, &block[i]); err != nil {
-				return err
-			}
-			i++
-			continue
-		}
-		if _, nextIsEmit := block[i+1].Kind.(ir.StmtEmit); !nextIsEmit {
+		// Single StmtEmit with no following StmtEmit -- emit directly.
+		if !isFollowedByEmit(block, i) {
 			if err := e.emitStatement(fn, &block[i]); err != nil {
 				return err
 			}
@@ -800,24 +793,98 @@ func (e *Emitter) emitBlock(fn *ir.Function, block ir.Block) error {
 			continue
 		}
 
-		// Found consecutive StmtEmit statements -- collect them all.
-		ranges := []ir.Range{firstEmit.Range}
-		j := i + 1
-		for j < len(block) {
-			nextEmit, nextOk := block[j].Kind.(ir.StmtEmit)
-			if !nextOk {
-				break
-			}
-			ranges = append(ranges, nextEmit.Range)
-			j++
-		}
-
-		if err := e.emitMergedStmtEmit(fn, ranges); err != nil {
+		// Found consecutive StmtEmit statements -- collect and
+		// emit as a group, with phi ranges emitted first.
+		j, err := e.emitConsecutiveEmitRun(fn, block, i, firstEmit)
+		if err != nil {
 			return err
 		}
 		i = j
 	}
 	return nil
+}
+
+// isFollowedByEmit reports whether block[i] is followed by at least
+// one more StmtEmit at block[i+1]. Used by emitBlock to decide
+// between single-emit and consecutive-emit-run paths.
+func isFollowedByEmit(block ir.Block, i int) bool {
+	if i+1 >= len(block) {
+		return false
+	}
+	_, ok := block[i+1].Kind.(ir.StmtEmit)
+	return ok
+}
+
+// emitConsecutiveEmitRun collects all consecutive StmtEmit statements
+// starting at block[i] and emits them. Phi-bearing emit ranges are
+// emitted before non-phi ranges so that LLVM phi instructions appear
+// at the top of the basic block.
+//
+// LLVM requires all phi instructions to be grouped at the top of a
+// basic block, before any non-phi instructions. mem2reg Phase B inserts
+// phi-bearing StmtEmit ranges (single-handle ranges containing ExprPhi)
+// immediately after StmtIf/StmtSwitch in the IR statement list. When
+// these are followed by regular StmtEmit ranges for the merge block's
+// own expressions, merging them all into one combined emission would
+// process handles in ascending order -- and since phi handles are
+// appended later by mem2reg (higher handle numbers), regular
+// expressions would be emitted first, violating the phi-at-top rule.
+//
+// Returns the index of the first statement after the run.
+func (e *Emitter) emitConsecutiveEmitRun(fn *ir.Function, block ir.Block, start int, firstEmit ir.StmtEmit) (int, error) {
+	ranges := []ir.Range{firstEmit.Range}
+	j := start + 1
+	for j < len(block) {
+		nextEmit, nextOk := block[j].Kind.(ir.StmtEmit)
+		if !nextOk {
+			break
+		}
+		ranges = append(ranges, nextEmit.Range)
+		j++
+	}
+
+	phiRanges, nonPhiRanges := splitPhiRanges(fn, ranges)
+	for _, pr := range phiRanges {
+		if err := e.emitStmtEmit(fn, ir.StmtEmit{Range: pr}); err != nil {
+			return 0, err
+		}
+	}
+	if len(nonPhiRanges) == 1 {
+		if err := e.emitStmtEmit(fn, ir.StmtEmit{Range: nonPhiRanges[0]}); err != nil {
+			return 0, err
+		}
+	} else if len(nonPhiRanges) > 1 {
+		if err := e.emitMergedStmtEmit(fn, nonPhiRanges); err != nil {
+			return 0, err
+		}
+	}
+	return j, nil
+}
+
+// splitPhiRanges separates a list of StmtEmit ranges into phi-bearing
+// ranges and non-phi ranges. A range is phi-bearing when it covers
+// exactly one expression handle whose kind is ir.ExprPhi. Phi-bearing
+// ranges must be emitted before non-phi ranges so that LLVM phi
+// instructions appear at the top of the basic block.
+func splitPhiRanges(fn *ir.Function, ranges []ir.Range) (phiRanges, nonPhiRanges []ir.Range) {
+	for _, r := range ranges {
+		if r.End-r.Start == 1 && isPhiExpression(fn, r.Start) {
+			phiRanges = append(phiRanges, r)
+		} else {
+			nonPhiRanges = append(nonPhiRanges, r)
+		}
+	}
+	return phiRanges, nonPhiRanges
+}
+
+// isPhiExpression reports whether the expression at handle h is an
+// ir.ExprPhi node (produced by the DXIL mem2reg Phase B walker).
+func isPhiExpression(fn *ir.Function, h ir.ExpressionHandle) bool {
+	if int(h) >= len(fn.Expressions) {
+		return false
+	}
+	_, ok := fn.Expressions[h].Kind.(ir.ExprPhi)
+	return ok
 }
 
 // mergeConsecutiveEmitRanges coalesces directly adjacent StmtEmit


### PR DESCRIPTION
## Summary

- **PHI ordering fix** — path_count.wgsl (Vello tilecompute) now passes IDxcValidator
- **Coverage waves 3-4** — hlsl 70.6%, wgsl/lower 65.3%, msl 64.2%, spirv 76.5%

### Root cause
mem2reg Phase B phi expressions have high handles, emitted after regular expressions in merged StmtEmit runs. `splitPhiRanges` separates and emits phis first.

## Test plan
- [x] path_count.wgsl — VALID (S_OK)
- [x] TestDxilValSummary — 161/170
- [x] TestDxilValGGProduction — 61/61
- [x] TestRustReference — 100%
- [x] golangci-lint — 0 issues
- [ ] CI green