### PR TITLE
docs: fix AGENTS.md API examples + update llms.txt

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,51 +1,61 @@
 # AGENTS.md — naga
 
-> Pure Go shader compiler. WGSL → SPIR-V, MSL, GLSL, HLSL, DXIL.
+> Pure Go shader compiler (~323K LOC). WGSL → SPIR-V, MSL, GLSL, HLSL, DXIL. Zero CGO.
 
 ## What is naga
 
-naga is a shader compiler that translates WGSL (WebGPU Shading Language) to all major GPU shader formats. Inspired by Rust naga (gfx-rs). Supports vertex, fragment, and compute shaders.
+naga is a shader compiler that translates WGSL (WebGPU Shading Language) to all major GPU shader formats. Inspired by [Rust naga](https://github.com/gfx-rs/naga) — **100% golden-file parity** across all text backends (MSL 91/91, GLSL 68/68, HLSL 72/72, SPIR-V 87/87). 172/172 SPIR-V binary validation. Experimental DXIL backend (161/170 IDxcValidator, 94.7%).
 
-Part of the [GoGPU ecosystem](https://github.com/gogpu) — think Flutter or Qt, but Pure Go with zero CGO.
+Part of the [GoGPU ecosystem](https://github.com/gogpu) — Pure Go GPU computing. v1.0 target: December 2026.
 
 ## When to use naga
 
 - **You write shaders in WGSL** and need SPIR-V for Vulkan → naga compiles it
-- **You need MSL** for Metal → naga generates it
-- **You need GLSL** for OpenGL ES → naga generates it
-- **You need HLSL/DXIL** for DirectX → naga generates it
+- **You need MSL** for Metal (macOS/iOS) → naga generates it
+- **You need GLSL** for OpenGL 3.3+ / ES 3.0+ → naga generates it
+- **You need HLSL** for DirectX 11/12 → naga generates it
+- **You need DXIL** for DirectX 12 SM 6.x (no FXC/DXC dependency) → naga generates it
 
 **Usually you don't import naga directly** — wgpu uses it internally for shader compilation. Import naga only if you need standalone shader compilation.
 
 ## Output Backends
 
-| Backend | Format | GPU API |
-|---------|--------|---------|
-| SPIR-V | Binary | Vulkan |
-| MSL | Text | Metal (macOS/iOS) |
-| GLSL | Text | OpenGL ES |
-| HLSL | Text | DirectX (FXC/DXC) |
-| DXIL | Binary | DirectX 12 (direct, no FXC) |
+| Backend | Format | GPU API | Status |
+|---------|--------|---------|--------|
+| SPIR-V | Binary | Vulkan | Production (172/172 spirv-val) |
+| MSL | Text | Metal (macOS/iOS) | Production (91/91 Rust parity) |
+| GLSL | Text | OpenGL 3.3+, ES 3.0+ | Production (68/68 Rust parity) |
+| HLSL | Text | DirectX 11/12 | Production (72/72 Rust parity) |
+| DXIL | Binary | DirectX 12 (SM 6.0–6.5) | Experimental (94.7% IDxcValidator) |
 
 ## Quick Start
 
 ```go
 import (
+    "fmt"
     "github.com/gogpu/naga"
-    "github.com/gogpu/naga/wgsl"
     "github.com/gogpu/naga/spirv"
+    "github.com/gogpu/naga/msl"
+    "github.com/gogpu/naga/glsl"
 )
 
-// Parse WGSL
-module, _ := wgsl.Parse(wgslSource)
+source := `
+@vertex
+fn main(@builtin(vertex_index) idx: u32) -> @builtin(position) vec4<f32> {
+    return vec4<f32>(0.0, 0.0, 0.0, 1.0);
+}
+`
 
-// Validate
-validator := naga.NewValidator()
-info, _ := validator.Validate(module)
+// Simple: WGSL → SPIR-V (one call)
+spirvBytes, err := naga.Compile(source)
 
-// Generate SPIR-V
-writer := spirv.NewWriter()
-spirvBytes, _ := writer.Write(module, info)
+// Multi-backend: Parse → Lower → Generate
+ast, _ := naga.Parse(source)
+module, _ := naga.Lower(ast)
+
+spirvBytes, _ := naga.GenerateSPIRV(module, spirv.Options{})
+mslCode, _, _ := msl.Compile(module, msl.DefaultOptions())
+glslCode, _, _ := glsl.Compile(module, glsl.DefaultOptions())
 ```
 
 ## Build & Test
@@ -53,8 +63,20 @@ spirvBytes, _ := writer.Write(module, info)
 ```bash
 go build ./...
 go test ./...
+
+# Quality gate — Rust reference comparison
+go test -run TestRustReference -count=1 ./snapshot/
+
+# SPIR-V binary validation
+go test -run TestSpirvValBinarySummary -v -count=1 ./snapshot/
+
+# Lint
 golangci-lint run --timeout=5m
 ```
+
+## Snapshot Testing
+
+Golden file names in `snapshot/testdata/golden/` match Rust naga test shader names **exactly, 1:1** (mixed naming conventions from upstream — do not rename). See [CONTRIBUTING.md](CONTRIBUTING.md) for details.
 
 ## Community & Support
 
@@ -67,4 +89,5 @@ golangci-lint run --timeout=5m
 
 - GitHub: https://github.com/gogpu/naga
 - Docs: https://pkg.go.dev/github.com/gogpu/naga
+- Roadmap: https://github.com/gogpu/naga/blob/main/ROADMAP.md
 - Ecosystem: [gogpu AGENTS.md](https://github.com/gogpu/gogpu/blob/main/AGENTS.md)

--- a/llms.txt
+++ b/llms.txt
@@ -1,12 +1,16 @@
 # naga — GoGPU Ecosystem
 
-> Part of the GoGPU Pure Go GPU Computing Ecosystem.
+> Pure Go shader compiler (~323K LOC). WGSL → SPIR-V, MSL, GLSL, HLSL, DXIL. Zero CGO.
+> 100% Rust naga parity. 172/172 SPIR-V validation. v1.0 target: December 2026.
 
 ## Docs
 
 - [API Reference](https://pkg.go.dev/github.com/gogpu/naga)
 - [AGENTS.md](https://github.com/gogpu/naga/blob/main/AGENTS.md): AI agent instructions
 - [README](https://github.com/gogpu/naga/blob/main/README.md): Human-readable overview
+- [ROADMAP](https://github.com/gogpu/naga/blob/main/ROADMAP.md): v1.0 roadmap and vision
+- [ARCHITECTURE](https://github.com/gogpu/naga/blob/main/docs/ARCHITECTURE.md): Compiler architecture
+- [CONTRIBUTING](https://github.com/gogpu/naga/blob/main/CONTRIBUTING.md): How to contribute
 
 ## Ecosystem
 


### PR DESCRIPTION
## Summary

- **AGENTS.md**: Quick Start had entirely wrong API examples (non-existent functions). Fixed to match real public API. Added metrics, backend status table, v1.0 target.
- **llms.txt**: Added description line, ROADMAP/ARCHITECTURE/CONTRIBUTING links.

## Test plan

- Docs-only, no code changes